### PR TITLE
Add BoardGameGeek adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -5224,6 +5224,210 @@
   },
   {
     "site": "boardgamegeek",
+    "name": "collection",
+    "description": "List a public BoardGameGeek user collection",
+    "access": "read",
+    "domain": "boardgamegeek.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "username",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "BoardGameGeek username"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 50,
+        "required": false,
+        "help": "Max results (1-100)"
+      },
+      {
+        "name": "subtype",
+        "type": "str",
+        "default": "boardgame",
+        "required": false,
+        "help": "Collection subtype",
+        "choices": [
+          "boardgame",
+          "boardgameexpansion",
+          "boardgameaccessory",
+          "rpgitem",
+          "rpgissue",
+          "videogame"
+        ]
+      },
+      {
+        "name": "own",
+        "type": "boolean",
+        "default": true,
+        "required": false,
+        "help": "Only owned items"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "collectionId",
+      "name",
+      "yearPublished",
+      "subtype",
+      "own",
+      "wishlist",
+      "forTrade",
+      "wantToPlay",
+      "numPlays",
+      "userRating",
+      "averageRating",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "boardgamegeek/collection.js",
+    "sourceFile": "boardgamegeek/collection.js"
+  },
+  {
+    "site": "boardgamegeek",
+    "name": "guild",
+    "description": "Get BoardGameGeek guild details",
+    "access": "read",
+    "domain": "boardgamegeek.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "BGG guild id, e.g. 1229"
+      }
+    ],
+    "columns": [
+      "id",
+      "name",
+      "created",
+      "manager",
+      "category",
+      "websiteUrl",
+      "memberCount",
+      "description",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "boardgamegeek/guild.js",
+    "sourceFile": "boardgamegeek/guild.js"
+  },
+  {
+    "site": "boardgamegeek",
+    "name": "hot",
+    "description": "List currently hot BoardGameGeek items",
+    "access": "read",
+    "domain": "boardgamegeek.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "type",
+        "type": "str",
+        "default": "boardgame",
+        "required": false,
+        "help": "Hot list type",
+        "choices": [
+          "boardgame",
+          "rpg",
+          "videogame",
+          "boardgameperson",
+          "rpgperson",
+          "boardgamecompany",
+          "rpgcompany",
+          "videogamecompany"
+        ]
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max results (1-50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "name",
+      "yearPublished",
+      "thumbnailUrl",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "boardgamegeek/hot.js",
+    "sourceFile": "boardgamegeek/hot.js"
+  },
+  {
+    "site": "boardgamegeek",
+    "name": "plays",
+    "description": "List recent BoardGameGeek logged plays",
+    "access": "read",
+    "domain": "boardgamegeek.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "username",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "BoardGameGeek username"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max results (1-100)"
+      },
+      {
+        "name": "page",
+        "type": "int",
+        "default": 1,
+        "required": false,
+        "help": "Result page (1-1000)"
+      },
+      {
+        "name": "mindate",
+        "type": "str",
+        "required": false,
+        "help": "Only plays on/after YYYY-MM-DD"
+      },
+      {
+        "name": "maxdate",
+        "type": "str",
+        "required": false,
+        "help": "Only plays on/before YYYY-MM-DD"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "date",
+      "quantity",
+      "length",
+      "incomplete",
+      "nowInStats",
+      "location",
+      "itemId",
+      "itemName",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "boardgamegeek/plays.js",
+    "sourceFile": "boardgamegeek/plays.js"
+  },
+  {
+    "site": "boardgamegeek",
     "name": "search",
     "description": "Search BoardGameGeek games via XML API2",
     "access": "read",
@@ -5279,6 +5483,77 @@
     "type": "js",
     "modulePath": "boardgamegeek/search.js",
     "sourceFile": "boardgamegeek/search.js"
+  },
+  {
+    "site": "boardgamegeek",
+    "name": "thing",
+    "description": "Get BoardGameGeek item details and ratings",
+    "access": "read",
+    "domain": "boardgamegeek.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "BGG thing id, e.g. 13"
+      }
+    ],
+    "columns": [
+      "id",
+      "name",
+      "type",
+      "yearPublished",
+      "minPlayers",
+      "maxPlayers",
+      "playingTime",
+      "minAge",
+      "averageRating",
+      "bayesAverage",
+      "usersRated",
+      "categories",
+      "mechanics",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "boardgamegeek/thing.js",
+    "sourceFile": "boardgamegeek/thing.js"
+  },
+  {
+    "site": "boardgamegeek",
+    "name": "user",
+    "description": "Get a public BoardGameGeek user profile",
+    "access": "read",
+    "domain": "boardgamegeek.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "username",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "BoardGameGeek username"
+      }
+    ],
+    "columns": [
+      "id",
+      "username",
+      "firstName",
+      "lastName",
+      "stateOrProvince",
+      "country",
+      "yearRegistered",
+      "lastLogin",
+      "tradeRating",
+      "marketRating",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "boardgamegeek/user.js",
+    "sourceFile": "boardgamegeek/user.js"
   },
   {
     "site": "booking",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -5223,6 +5223,64 @@
     "sourceFile": "bluesky/user.js"
   },
   {
+    "site": "boardgamegeek",
+    "name": "search",
+    "description": "Search BoardGameGeek games via XML API2",
+    "access": "read",
+    "domain": "boardgamegeek.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Game search terms, e.g. \"catan\""
+      },
+      {
+        "name": "type",
+        "type": "str",
+        "default": "boardgame",
+        "required": false,
+        "help": "BGG thing type or all",
+        "choices": [
+          "boardgame",
+          "boardgameexpansion",
+          "boardgameaccessory",
+          "videogame",
+          "rpgitem",
+          "all"
+        ]
+      },
+      {
+        "name": "exact",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Only exact name matches"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max results (1-100)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "name",
+      "type",
+      "yearPublished",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "boardgamegeek/search.js",
+    "sourceFile": "boardgamegeek/search.js"
+  },
+  {
     "site": "booking",
     "name": "search",
     "description": "Search Booking.com hotels by destination and dates (server-rendered card scrape).",

--- a/clis/boardgamegeek/boardgamegeek.test.js
+++ b/clis/boardgamegeek/boardgamegeek.test.js
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AuthRequiredError, EmptyResultError, ArgumentError } from '@agentrhq/webcmd/errors';
+import { getRegistry } from '@agentrhq/webcmd/registry';
+import { __test__ } from './search.js';
+import './search.js';
+
+afterEach(() => {
+    delete process.env.BOARDGAMEGEEK_TOKEN;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('boardgamegeek search', () => {
+    const cmd = getRegistry().get('boardgamegeek/search');
+
+    it('maps XML API2 search results', async () => {
+        process.env.BOARDGAMEGEEK_TOKEN = 'secret-token';
+        vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response(`
+            <items total="2">
+              <item type="boardgame" id="13">
+                <name type="primary" value="CATAN"/>
+                <yearpublished value="1995"/>
+              </item>
+              <item type="boardgame" id="68448">
+                <name type="primary" value="7 Wonders"/>
+                <yearpublished value="2010"/>
+              </item>
+            </items>
+        `, { status: 200, headers: { 'content-type': 'text/xml' } }))));
+
+        const rows = await cmd.func({ query: 'catan', limit: 1 });
+        expect(String(fetch.mock.calls[0][0])).toContain('query=catan');
+        expect(String(fetch.mock.calls[0][0])).toContain('type=boardgame');
+        expect(fetch.mock.calls[0][1].headers.authorization).toBe('Bearer secret-token');
+        expect(rows).toEqual([{
+            rank: 1,
+            id: '13',
+            name: 'CATAN',
+            type: 'boardgame',
+            yearPublished: 1995,
+            url: 'https://boardgamegeek.com/boardgame/13',
+        }]);
+    });
+
+    it('omits type filter for all', async () => {
+        process.env.BOARDGAMEGEEK_TOKEN = 'secret-token';
+        vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response(`
+            <items><item type="boardgame" id="1"><name value="Demo"/></item></items>
+        `, { status: 200 }))));
+
+        await cmd.func({ query: 'demo', type: 'all' });
+        expect(String(fetch.mock.calls[0][0])).not.toContain('type=');
+    });
+
+    it('requires BOARDGAMEGEEK_TOKEN', async () => {
+        await expect(cmd.func({ query: 'catan' })).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('promotes 401 responses to AuthRequiredError', async () => {
+        process.env.BOARDGAMEGEEK_TOKEN = 'bad-token';
+        vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response('Unauthorized', { status: 401 }))));
+        await expect(cmd.func({ query: 'catan' })).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('rejects empty queries and invalid limits', async () => {
+        await expect(cmd.func({ query: '' })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(cmd.func({ query: 'catan', limit: 101 })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('promotes empty XML results to EmptyResultError', async () => {
+        process.env.BOARDGAMEGEEK_TOKEN = 'secret-token';
+        vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response('<items total="0"></items>', { status: 200 }))));
+        await expect(cmd.func({ query: 'nope' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+});
+
+describe('boardgamegeek XML parser', () => {
+    it('decodes XML entities in names', () => {
+        expect(__test__.parseSearch(`
+            <items>
+              <item type="boardgame" id="42"><name value="A &amp; B &quot;Game&quot;"/></item>
+            </items>
+        `)[0]).toMatchObject({ name: 'A & B "Game"' });
+    });
+});

--- a/clis/boardgamegeek/boardgamegeek.test.js
+++ b/clis/boardgamegeek/boardgamegeek.test.js
@@ -2,7 +2,19 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AuthRequiredError, EmptyResultError, ArgumentError } from '@agentrhq/webcmd/errors';
 import { getRegistry } from '@agentrhq/webcmd/registry';
 import { __test__ } from './search.js';
+import { __test__ as collectionTest } from './collection.js';
+import { __test__ as guildTest } from './guild.js';
+import { __test__ as hotTest } from './hot.js';
+import { __test__ as playsTest } from './plays.js';
+import { __test__ as thingTest } from './thing.js';
+import { __test__ as userTest } from './user.js';
+import './collection.js';
+import './guild.js';
+import './hot.js';
+import './plays.js';
 import './search.js';
+import './thing.js';
+import './user.js';
 
 afterEach(() => {
     delete process.env.BOARDGAMEGEEK_TOKEN;
@@ -81,5 +93,166 @@ describe('boardgamegeek XML parser', () => {
               <item type="boardgame" id="42"><name value="A &amp; B &quot;Game&quot;"/></item>
             </items>
         `)[0]).toMatchObject({ name: 'A & B "Game"' });
+    });
+});
+
+describe('boardgamegeek thing', () => {
+    const cmd = getRegistry().get('boardgamegeek/thing');
+
+    it('maps thing details and stats', async () => {
+        process.env.BOARDGAMEGEEK_TOKEN = 'secret-token';
+        vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response(`
+            <items>
+              <item type="boardgame" id="13">
+                <name type="primary" value="CATAN"/>
+                <yearpublished value="1995"/>
+                <minplayers value="3"/><maxplayers value="4"/><playingtime value="120"/><minage value="10"/>
+                <link type="boardgamecategory" value="Negotiation"/>
+                <link type="boardgamemechanic" value="Trading"/>
+                <statistics><ratings>
+                  <usersrated value="132000"/><average value="7.1"/><bayesaverage value="6.9"/>
+                </ratings></statistics>
+              </item>
+            </items>
+        `, { status: 200 }))));
+
+        await expect(cmd.func({ id: 13 })).resolves.toMatchObject([{
+            id: '13',
+            name: 'CATAN',
+            minPlayers: 3,
+            averageRating: 7.1,
+            categories: 'Negotiation',
+            mechanics: 'Trading',
+        }]);
+    });
+});
+
+describe('boardgamegeek hot', () => {
+    const cmd = getRegistry().get('boardgamegeek/hot');
+
+    it('maps hot list rows', async () => {
+        process.env.BOARDGAMEGEEK_TOKEN = 'secret-token';
+        vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response(`
+            <items>
+              <item id="224517" rank="1">
+                <thumbnail value="https://cf.geekdo-images.com/demo.jpg"/>
+                <name value="Brass: Birmingham"/>
+                <yearpublished value="2018"/>
+              </item>
+            </items>
+        `, { status: 200 }))));
+
+        const rows = await cmd.func({ limit: 1 });
+        expect(String(fetch.mock.calls[0][0])).toContain('/hot?type=boardgame');
+        expect(rows[0]).toMatchObject({ rank: 1, id: '224517', name: 'Brass: Birmingham', yearPublished: 2018 });
+    });
+});
+
+describe('boardgamegeek collection', () => {
+    const cmd = getRegistry().get('boardgamegeek/collection');
+
+    it('maps collection rows and owned filter', async () => {
+        process.env.BOARDGAMEGEEK_TOKEN = 'secret-token';
+        vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response(`
+            <items>
+              <item objectid="13" collid="99" subtype="boardgame">
+                <name>CATAN</name>
+                <yearpublished>1995</yearpublished>
+                <status own="1" wishlist="0" fortrade="1" wanttoplay="0"/>
+                <numplays>12</numplays>
+                <stats><rating value="8"><average value="7.1"/></rating></stats>
+              </item>
+            </items>
+        `, { status: 200 }))));
+
+        const rows = await cmd.func({ username: 'alice', limit: 1 });
+        expect(String(fetch.mock.calls[0][0])).toContain('own=1');
+        expect(rows[0]).toMatchObject({ rank: 1, id: '13', collectionId: '99', name: 'CATAN', own: true, forTrade: true, numPlays: 12, userRating: 8, averageRating: 7.1 });
+    });
+});
+
+describe('boardgamegeek plays', () => {
+    const cmd = getRegistry().get('boardgamegeek/plays');
+
+    it('maps logged plays', async () => {
+        process.env.BOARDGAMEGEEK_TOKEN = 'secret-token';
+        vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response(`
+            <plays>
+              <play id="123" date="2026-07-01" quantity="1" length="45" incomplete="0" nowinstats="1" location="Home">
+                <item name="CATAN" objectid="13"/>
+              </play>
+            </plays>
+        `, { status: 200 }))));
+
+        await expect(cmd.func({ username: 'alice', limit: 1, mindate: '2026-07-01' })).resolves.toMatchObject([{
+            rank: 1,
+            id: '123',
+            date: '2026-07-01',
+            itemId: '13',
+            itemName: 'CATAN',
+        }]);
+    });
+});
+
+describe('boardgamegeek user', () => {
+    const cmd = getRegistry().get('boardgamegeek/user');
+
+    it('maps public profile rows', async () => {
+        process.env.BOARDGAMEGEEK_TOKEN = 'secret-token';
+        vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response(`
+            <user id="7" name="alice">
+              <firstname value="Alice"/><lastname value="Example"/>
+              <country value="US"/><yearregistered value="2010"/>
+              <lastlogin value="2026-07-01"/><traderating value="5"/>
+            </user>
+        `, { status: 200 }))));
+
+        await expect(cmd.func({ username: 'alice' })).resolves.toEqual([{
+            id: '7',
+            username: 'alice',
+            firstName: 'Alice',
+            lastName: 'Example',
+            stateOrProvince: '',
+            country: 'US',
+            yearRegistered: '2010',
+            lastLogin: '2026-07-01',
+            tradeRating: '5',
+            marketRating: '',
+            url: 'https://boardgamegeek.com/user/alice',
+        }]);
+    });
+});
+
+describe('boardgamegeek guild', () => {
+    const cmd = getRegistry().get('boardgamegeek/guild');
+
+    it('maps guild details', async () => {
+        process.env.BOARDGAMEGEEK_TOKEN = 'secret-token';
+        vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response(`
+            <guild id="1229">
+              <name>BoardGameGeek XML API</name>
+              <created value="2009-01-01"/><manager value="admin"/><category value="Tech"/>
+              <website value="https://example.com"/><description>API talk</description>
+              <members count="25"><member name="alice"/></members>
+            </guild>
+        `, { status: 200 }))));
+
+        await expect(cmd.func({ id: 1229 })).resolves.toMatchObject([{
+            id: '1229',
+            name: 'BoardGameGeek XML API',
+            manager: 'admin',
+            memberCount: 25,
+        }]);
+    });
+});
+
+describe('boardgamegeek parser helpers', () => {
+    it('parses representative XML snippets', () => {
+        expect(thingTest.parseThing('<items><item id="1" type="boardgame"><name type="primary" value="One"/></item></items>')[0].name).toBe('One');
+        expect(hotTest.parseHot('<items><item id="1" rank="2"><name value="Hot"/></item></items>')[0].rank).toBe(2);
+        expect(collectionTest.parseCollection('<items><item objectid="1"><name>Owned</name><status own="1"/></item></items>')[0].own).toBe(true);
+        expect(playsTest.parsePlays('<plays><play id="1"><item objectid="2" name="Play"/></play></plays>')[0].itemName).toBe('Play');
+        expect(userTest.parseUser('<user id="1" name="u"><country value="US"/></user>')[0].country).toBe('US');
+        expect(guildTest.parseGuild('<guild id="1"><name>Guild</name><members count="3"/></guild>')[0].memberCount).toBe(3);
     });
 });

--- a/clis/boardgamegeek/collection.js
+++ b/clis/boardgamegeek/collection.js
@@ -1,0 +1,54 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { API_BASE, attrs, blocks, fetchXml, numberValue, positiveInt, requireRows, requiredText, valueTag } from './utils.js';
+
+function parseCollection(xml) {
+    return blocks(xml, 'item').map((item) => {
+        const status = attrs(item.body.match(/<status\b([^>]*)\/?>/)?.[1]);
+        const stats = item.body.match(/<stats\b[\s\S]*?<\/stats>/)?.[0] ?? '';
+        return {
+            id: item.attrs.objectid ?? item.attrs.id ?? '',
+            collectionId: item.attrs.collid ?? '',
+            name: valueTag(item.body, 'name'),
+            yearPublished: numberValue(valueTag(item.body, 'yearpublished')),
+            subtype: item.attrs.subtype ?? '',
+            own: status.own === '1',
+            wishlist: status.wishlist === '1',
+            forTrade: status.fortrade === '1',
+            wantToPlay: status.wanttoplay === '1',
+            numPlays: numberValue(valueTag(item.body, 'numplays')),
+            userRating: numberValue(valueTag(stats, 'rating')),
+            averageRating: numberValue(valueTag(stats, 'average')),
+            url: (item.attrs.objectid ?? item.attrs.id) ? `https://boardgamegeek.com/boardgame/${item.attrs.objectid ?? item.attrs.id}` : '',
+        };
+    }).filter((row) => row.id && row.name);
+}
+
+cli({
+    site: 'boardgamegeek',
+    name: 'collection',
+    access: 'read',
+    description: 'List a public BoardGameGeek user collection',
+    domain: 'boardgamegeek.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'username', positional: true, required: true, help: 'BoardGameGeek username' },
+        { name: 'limit', type: 'int', default: 50, help: 'Max results (1-100)' },
+        { name: 'subtype', default: 'boardgame', choices: ['boardgame', 'boardgameexpansion', 'boardgameaccessory', 'rpgitem', 'rpgissue', 'videogame'], help: 'Collection subtype' },
+        { name: 'own', type: 'boolean', default: true, help: 'Only owned items' },
+    ],
+    columns: ['rank', 'id', 'collectionId', 'name', 'yearPublished', 'subtype', 'own', 'wishlist', 'forTrade', 'wantToPlay', 'numPlays', 'userRating', 'averageRating', 'url'],
+    func: async (args) => {
+        const username = requiredText(args.username, 'username');
+        const limit = positiveInt(args.limit, 50, 100, 'limit');
+        const url = new URL(`${API_BASE}/collection`);
+        url.searchParams.set('username', username);
+        url.searchParams.set('subtype', String(args.subtype ?? 'boardgame').trim());
+        url.searchParams.set('stats', '1');
+        if (args.own !== false) url.searchParams.set('own', '1');
+        const rows = requireRows(parseCollection(await fetchXml(url, 'boardgamegeek collection', { retry202: true })), 'boardgamegeek collection', `No public collection rows found for "${username}".`);
+        return rows.slice(0, limit).map((row, i) => ({ rank: i + 1, ...row }));
+    },
+});
+
+export const __test__ = { parseCollection };

--- a/clis/boardgamegeek/guild.js
+++ b/clis/boardgamegeek/guild.js
@@ -1,0 +1,43 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { API_BASE, attrs, fetchXml, numberValue, positiveInt, requireRows, valueTag } from './utils.js';
+
+function parseGuild(xml) {
+    const match = String(xml ?? '').match(/<guild\b([^>]*)>([\s\S]*?)<\/guild>/);
+    if (!match) return [];
+    const guildAttrs = attrs(match[1]);
+    const body = match[2];
+    return [{
+        id: guildAttrs.id ?? '',
+        name: valueTag(body, 'name'),
+        created: valueTag(body, 'created'),
+        manager: valueTag(body, 'manager'),
+        category: valueTag(body, 'category'),
+        websiteUrl: valueTag(body, 'website'),
+        memberCount: numberValue(attrs(body.match(/<members\b([^>]*)>/)?.[1]).count),
+        description: valueTag(body, 'description'),
+        url: guildAttrs.id ? `https://boardgamegeek.com/guild/${guildAttrs.id}` : '',
+    }].filter((row) => row.id && row.name);
+}
+
+cli({
+    site: 'boardgamegeek',
+    name: 'guild',
+    access: 'read',
+    description: 'Get BoardGameGeek guild details',
+    domain: 'boardgamegeek.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'BGG guild id, e.g. 1229' },
+    ],
+    columns: ['id', 'name', 'created', 'manager', 'category', 'websiteUrl', 'memberCount', 'description', 'url'],
+    func: async (args) => {
+        const id = positiveInt(args.id, null, 999999999, 'id');
+        const url = new URL(`${API_BASE}/guild`);
+        url.searchParams.set('id', String(id));
+        url.searchParams.set('members', '1');
+        return requireRows(parseGuild(await fetchXml(url, 'boardgamegeek guild')), 'boardgamegeek guild', `No BoardGameGeek guild found for id ${id}.`);
+    },
+});
+
+export const __test__ = { parseGuild };

--- a/clis/boardgamegeek/hot.js
+++ b/clis/boardgamegeek/hot.js
@@ -1,0 +1,41 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { API_BASE, attrs, blocks, fetchXml, numberValue, positiveInt, requireRows } from './utils.js';
+
+function parseHot(xml) {
+    return blocks(xml, 'item').map((item) => {
+        const name = attrs(item.body.match(/<name\b([^>]*)\/?>/)?.[1]).value ?? '';
+        const year = attrs(item.body.match(/<yearpublished\b([^>]*)\/?>/)?.[1]).value;
+        const thumbnail = attrs(item.body.match(/<thumbnail\b([^>]*)\/?>/)?.[1]).value ?? '';
+        return {
+            rank: numberValue(item.attrs.rank),
+            id: item.attrs.id ?? '',
+            name,
+            yearPublished: numberValue(year),
+            thumbnailUrl: thumbnail,
+            url: item.attrs.id ? `https://boardgamegeek.com/boardgame/${item.attrs.id}` : '',
+        };
+    }).filter((row) => row.id && row.name);
+}
+
+cli({
+    site: 'boardgamegeek',
+    name: 'hot',
+    access: 'read',
+    description: 'List currently hot BoardGameGeek items',
+    domain: 'boardgamegeek.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'type', default: 'boardgame', choices: ['boardgame', 'rpg', 'videogame', 'boardgameperson', 'rpgperson', 'boardgamecompany', 'rpgcompany', 'videogamecompany'], help: 'Hot list type' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max results (1-50)' },
+    ],
+    columns: ['rank', 'id', 'name', 'yearPublished', 'thumbnailUrl', 'url'],
+    func: async (args) => {
+        const limit = positiveInt(args.limit, 20, 50, 'limit');
+        const url = new URL(`${API_BASE}/hot`);
+        url.searchParams.set('type', String(args.type ?? 'boardgame').trim());
+        return requireRows(parseHot(await fetchXml(url, 'boardgamegeek hot')), 'boardgamegeek hot', 'No hot BoardGameGeek items returned.').slice(0, limit);
+    },
+});
+
+export const __test__ = { parseHot };

--- a/clis/boardgamegeek/plays.js
+++ b/clis/boardgamegeek/plays.js
@@ -1,0 +1,54 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { API_BASE, attrs, blocks, fetchXml, numberValue, optionalDate, positiveInt, requireRows, requiredText } from './utils.js';
+
+function parsePlays(xml) {
+    return blocks(xml, 'play').map((play) => {
+        const item = attrs(play.body.match(/<item\b([^>]*)\/?>/)?.[1]);
+        return {
+            id: play.attrs.id ?? '',
+            date: play.attrs.date ?? '',
+            quantity: numberValue(play.attrs.quantity),
+            length: numberValue(play.attrs.length),
+            incomplete: play.attrs.incomplete === '1',
+            nowInStats: play.attrs.nowinstats === '1',
+            location: play.attrs.location ?? '',
+            itemId: item.objectid ?? '',
+            itemName: item.name ?? '',
+            url: play.attrs.id ? `https://boardgamegeek.com/play/details/${play.attrs.id}` : '',
+        };
+    }).filter((row) => row.id && row.itemId);
+}
+
+cli({
+    site: 'boardgamegeek',
+    name: 'plays',
+    access: 'read',
+    description: 'List recent BoardGameGeek logged plays',
+    domain: 'boardgamegeek.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'username', positional: true, required: true, help: 'BoardGameGeek username' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max results (1-100)' },
+        { name: 'page', type: 'int', default: 1, help: 'Result page (1-1000)' },
+        { name: 'mindate', help: 'Only plays on/after YYYY-MM-DD' },
+        { name: 'maxdate', help: 'Only plays on/before YYYY-MM-DD' },
+    ],
+    columns: ['rank', 'id', 'date', 'quantity', 'length', 'incomplete', 'nowInStats', 'location', 'itemId', 'itemName', 'url'],
+    func: async (args) => {
+        const username = requiredText(args.username, 'username');
+        const limit = positiveInt(args.limit, 20, 100, 'limit');
+        const page = positiveInt(args.page, 1, 1000, 'page');
+        const mindate = optionalDate(args.mindate, 'mindate');
+        const maxdate = optionalDate(args.maxdate, 'maxdate');
+        const url = new URL(`${API_BASE}/plays`);
+        url.searchParams.set('username', username);
+        url.searchParams.set('page', String(page));
+        if (mindate) url.searchParams.set('mindate', mindate);
+        if (maxdate) url.searchParams.set('maxdate', maxdate);
+        const rows = requireRows(parsePlays(await fetchXml(url, 'boardgamegeek plays')), 'boardgamegeek plays', `No public plays found for "${username}".`);
+        return rows.slice(0, limit).map((row, i) => ({ rank: (page - 1) * 100 + i + 1, ...row }));
+    },
+});
+
+export const __test__ = { parsePlays };

--- a/clis/boardgamegeek/search.js
+++ b/clis/boardgamegeek/search.js
@@ -1,0 +1,125 @@
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+
+const SEARCH_URL = 'https://boardgamegeek.com/xmlapi2/search';
+const TOKEN_ENV = 'BOARDGAMEGEEK_TOKEN';
+const UA = 'webcmd-boardgamegeek-adapter (+https://github.com/agentrhq/webcmd)';
+
+function requireQuery(value) {
+    const query = String(value ?? '').trim();
+    if (!query) throw new ArgumentError('boardgamegeek query is required');
+    return query;
+}
+
+function requireLimit(value) {
+    const raw = value == null || value === '' ? 20 : value;
+    const n = Number(raw);
+    if (!Number.isInteger(n) || n < 1 || n > 100) {
+        throw new ArgumentError('boardgamegeek limit must be an integer between 1 and 100');
+    }
+    return n;
+}
+
+function token() {
+    const value = String(process.env[TOKEN_ENV] ?? '').trim();
+    if (!value) {
+        throw new AuthRequiredError('boardgamegeek.com', `Set ${TOKEN_ENV} to a BoardGameGeek XML API application Bearer token.`);
+    }
+    return value;
+}
+
+function decodeXml(value) {
+    return String(value ?? '')
+        .replace(/&quot;/g, '"')
+        .replace(/&apos;/g, "'")
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&amp;/g, '&');
+}
+
+function attrs(xml) {
+    const out = {};
+    for (const match of String(xml ?? '').matchAll(/\s([A-Za-z_:][-A-Za-z0-9_:.]*)="([^"]*)"/g)) {
+        out[match[1]] = decodeXml(match[2]);
+    }
+    return out;
+}
+
+function parseSearch(xml) {
+    const rows = [];
+    for (const match of String(xml ?? '').matchAll(/<item\b([^>]*)>([\s\S]*?)<\/item>/g)) {
+        const itemAttrs = attrs(match[1]);
+        const nameMatch = match[2].match(/<name\b([^>]*)\/?>/);
+        const yearMatch = match[2].match(/<yearpublished\b([^>]*)\/?>/);
+        const name = attrs(nameMatch?.[1]).value ?? '';
+        const yearRaw = attrs(yearMatch?.[1]).value;
+        rows.push({
+            id: itemAttrs.id ?? '',
+            name,
+            type: itemAttrs.type ?? '',
+            yearPublished: yearRaw == null ? null : Number(yearRaw),
+            url: itemAttrs.id ? `https://boardgamegeek.com/boardgame/${itemAttrs.id}` : '',
+        });
+    }
+    return rows.filter((row) => row.id && row.name);
+}
+
+async function fetchXml(url) {
+    const bearer = token();
+    let resp;
+    try {
+        resp = await fetch(url, {
+            headers: {
+                authorization: `Bearer ${bearer}`,
+                'user-agent': UA,
+                accept: 'application/xml,text/xml',
+            },
+        });
+    } catch (err) {
+        throw new CommandExecutionError(`boardgamegeek search request failed: ${err?.message ?? err}`);
+    }
+    if (resp.status === 401 || resp.status === 403) {
+        throw new AuthRequiredError('boardgamegeek.com', `BoardGameGeek XML API rejected ${TOKEN_ENV}.`);
+    }
+    if (resp.status === 429 || resp.status === 500 || resp.status === 503) {
+        throw new CommandExecutionError(`boardgamegeek search is rate limited or busy (HTTP ${resp.status}); retry later.`);
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`boardgamegeek search returned HTTP ${resp.status}`);
+    }
+    return resp.text();
+}
+
+cli({
+    site: 'boardgamegeek',
+    name: 'search',
+    access: 'read',
+    description: 'Search BoardGameGeek games via XML API2',
+    domain: 'boardgamegeek.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Game search terms, e.g. "catan"' },
+        { name: 'type', default: 'boardgame', choices: ['boardgame', 'boardgameexpansion', 'boardgameaccessory', 'videogame', 'rpgitem', 'all'], help: 'BGG thing type or all' },
+        { name: 'exact', type: 'boolean', default: false, help: 'Only exact name matches' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max results (1-100)' },
+    ],
+    columns: ['rank', 'id', 'name', 'type', 'yearPublished', 'url'],
+    func: async (args) => {
+        const query = requireQuery(args.query);
+        const limit = requireLimit(args.limit);
+        const type = String(args.type ?? 'boardgame').trim();
+        const url = new URL(SEARCH_URL);
+        url.searchParams.set('query', query);
+        if (type !== 'all') url.searchParams.set('type', type);
+        if (args.exact) url.searchParams.set('exact', '1');
+
+        const rows = parseSearch(await fetchXml(url));
+        if (!rows.length) {
+            throw new EmptyResultError('boardgamegeek search', `No BoardGameGeek games matched "${query}".`);
+        }
+        return rows.slice(0, limit).map((row, i) => ({ rank: i + 1, ...row }));
+    },
+});
+
+export const __test__ = { parseSearch };

--- a/clis/boardgamegeek/search.js
+++ b/clis/boardgamegeek/search.js
@@ -1,93 +1,22 @@
-import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
 import { cli, Strategy } from '@agentrhq/webcmd/registry';
-
-const SEARCH_URL = 'https://boardgamegeek.com/xmlapi2/search';
-const TOKEN_ENV = 'BOARDGAMEGEEK_TOKEN';
-const UA = 'webcmd-boardgamegeek-adapter (+https://github.com/agentrhq/webcmd)';
-
-function requireQuery(value) {
-    const query = String(value ?? '').trim();
-    if (!query) throw new ArgumentError('boardgamegeek query is required');
-    return query;
-}
-
-function requireLimit(value) {
-    const raw = value == null || value === '' ? 20 : value;
-    const n = Number(raw);
-    if (!Number.isInteger(n) || n < 1 || n > 100) {
-        throw new ArgumentError('boardgamegeek limit must be an integer between 1 and 100');
-    }
-    return n;
-}
-
-function token() {
-    const value = String(process.env[TOKEN_ENV] ?? '').trim();
-    if (!value) {
-        throw new AuthRequiredError('boardgamegeek.com', `Set ${TOKEN_ENV} to a BoardGameGeek XML API application Bearer token.`);
-    }
-    return value;
-}
-
-function decodeXml(value) {
-    return String(value ?? '')
-        .replace(/&quot;/g, '"')
-        .replace(/&apos;/g, "'")
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .replace(/&amp;/g, '&');
-}
-
-function attrs(xml) {
-    const out = {};
-    for (const match of String(xml ?? '').matchAll(/\s([A-Za-z_:][-A-Za-z0-9_:.]*)="([^"]*)"/g)) {
-        out[match[1]] = decodeXml(match[2]);
-    }
-    return out;
-}
+import { API_BASE, attrs, blocks, fetchXml, positiveInt, requireRows, requiredText } from './utils.js';
 
 function parseSearch(xml) {
     const rows = [];
-    for (const match of String(xml ?? '').matchAll(/<item\b([^>]*)>([\s\S]*?)<\/item>/g)) {
-        const itemAttrs = attrs(match[1]);
-        const nameMatch = match[2].match(/<name\b([^>]*)\/?>/);
-        const yearMatch = match[2].match(/<yearpublished\b([^>]*)\/?>/);
+    for (const item of blocks(xml, 'item')) {
+        const nameMatch = item.body.match(/<name\b([^>]*)\/?>/);
+        const yearMatch = item.body.match(/<yearpublished\b([^>]*)\/?>/);
         const name = attrs(nameMatch?.[1]).value ?? '';
         const yearRaw = attrs(yearMatch?.[1]).value;
         rows.push({
-            id: itemAttrs.id ?? '',
+            id: item.attrs.id ?? '',
             name,
-            type: itemAttrs.type ?? '',
+            type: item.attrs.type ?? '',
             yearPublished: yearRaw == null ? null : Number(yearRaw),
-            url: itemAttrs.id ? `https://boardgamegeek.com/boardgame/${itemAttrs.id}` : '',
+            url: item.attrs.id ? `https://boardgamegeek.com/boardgame/${item.attrs.id}` : '',
         });
     }
     return rows.filter((row) => row.id && row.name);
-}
-
-async function fetchXml(url) {
-    const bearer = token();
-    let resp;
-    try {
-        resp = await fetch(url, {
-            headers: {
-                authorization: `Bearer ${bearer}`,
-                'user-agent': UA,
-                accept: 'application/xml,text/xml',
-            },
-        });
-    } catch (err) {
-        throw new CommandExecutionError(`boardgamegeek search request failed: ${err?.message ?? err}`);
-    }
-    if (resp.status === 401 || resp.status === 403) {
-        throw new AuthRequiredError('boardgamegeek.com', `BoardGameGeek XML API rejected ${TOKEN_ENV}.`);
-    }
-    if (resp.status === 429 || resp.status === 500 || resp.status === 503) {
-        throw new CommandExecutionError(`boardgamegeek search is rate limited or busy (HTTP ${resp.status}); retry later.`);
-    }
-    if (!resp.ok) {
-        throw new CommandExecutionError(`boardgamegeek search returned HTTP ${resp.status}`);
-    }
-    return resp.text();
 }
 
 cli({
@@ -106,18 +35,15 @@ cli({
     ],
     columns: ['rank', 'id', 'name', 'type', 'yearPublished', 'url'],
     func: async (args) => {
-        const query = requireQuery(args.query);
-        const limit = requireLimit(args.limit);
+        const query = requiredText(args.query, 'query');
+        const limit = positiveInt(args.limit, 20, 100, 'limit');
         const type = String(args.type ?? 'boardgame').trim();
-        const url = new URL(SEARCH_URL);
+        const url = new URL(`${API_BASE}/search`);
         url.searchParams.set('query', query);
         if (type !== 'all') url.searchParams.set('type', type);
         if (args.exact) url.searchParams.set('exact', '1');
 
-        const rows = parseSearch(await fetchXml(url));
-        if (!rows.length) {
-            throw new EmptyResultError('boardgamegeek search', `No BoardGameGeek games matched "${query}".`);
-        }
+        const rows = requireRows(parseSearch(await fetchXml(url, 'boardgamegeek search')), 'boardgamegeek search', `No BoardGameGeek games matched "${query}".`);
         return rows.slice(0, limit).map((row, i) => ({ rank: i + 1, ...row }));
     },
 });

--- a/clis/boardgamegeek/thing.js
+++ b/clis/boardgamegeek/thing.js
@@ -1,0 +1,47 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { API_BASE, blocks, fetchXml, linkValues, numberValue, positiveInt, primaryName, requireRows, valueTag } from './utils.js';
+
+function parseThing(xml) {
+    return blocks(xml, 'item').map((item) => {
+        const stats = item.body.match(/<ratings\b[\s\S]*?<\/ratings>/)?.[0] ?? '';
+        return {
+            id: item.attrs.id ?? '',
+            name: primaryName(item.body),
+            type: item.attrs.type ?? '',
+            yearPublished: numberValue(valueTag(item.body, 'yearpublished')),
+            minPlayers: numberValue(valueTag(item.body, 'minplayers')),
+            maxPlayers: numberValue(valueTag(item.body, 'maxplayers')),
+            playingTime: numberValue(valueTag(item.body, 'playingtime')),
+            minAge: numberValue(valueTag(item.body, 'minage')),
+            averageRating: numberValue(valueTag(stats, 'average')),
+            bayesAverage: numberValue(valueTag(stats, 'bayesaverage')),
+            usersRated: numberValue(valueTag(stats, 'usersrated')),
+            categories: linkValues(item.body, 'boardgamecategory'),
+            mechanics: linkValues(item.body, 'boardgamemechanic'),
+            url: item.attrs.id ? `https://boardgamegeek.com/boardgame/${item.attrs.id}` : '',
+        };
+    }).filter((row) => row.id && row.name);
+}
+
+cli({
+    site: 'boardgamegeek',
+    name: 'thing',
+    access: 'read',
+    description: 'Get BoardGameGeek item details and ratings',
+    domain: 'boardgamegeek.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'BGG thing id, e.g. 13' },
+    ],
+    columns: ['id', 'name', 'type', 'yearPublished', 'minPlayers', 'maxPlayers', 'playingTime', 'minAge', 'averageRating', 'bayesAverage', 'usersRated', 'categories', 'mechanics', 'url'],
+    func: async (args) => {
+        const id = positiveInt(args.id, null, 999999999, 'id');
+        const url = new URL(`${API_BASE}/thing`);
+        url.searchParams.set('id', String(id));
+        url.searchParams.set('stats', '1');
+        return requireRows(parseThing(await fetchXml(url, 'boardgamegeek thing')), 'boardgamegeek thing', `No BoardGameGeek item found for id ${id}.`);
+    },
+});
+
+export const __test__ = { parseThing };

--- a/clis/boardgamegeek/user.js
+++ b/clis/boardgamegeek/user.js
@@ -1,0 +1,44 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { API_BASE, attrs, fetchXml, requiredText, requireRows, valueTag } from './utils.js';
+
+function parseUser(xml) {
+    const match = String(xml ?? '').match(/<user\b([^>]*)>([\s\S]*?)<\/user>/);
+    if (!match) return [];
+    const userAttrs = attrs(match[1]);
+    const body = match[2];
+    return [{
+        id: userAttrs.id ?? '',
+        username: userAttrs.name ?? '',
+        firstName: valueTag(body, 'firstname'),
+        lastName: valueTag(body, 'lastname'),
+        stateOrProvince: valueTag(body, 'stateorprovince'),
+        country: valueTag(body, 'country'),
+        yearRegistered: valueTag(body, 'yearregistered'),
+        lastLogin: valueTag(body, 'lastlogin'),
+        tradeRating: valueTag(body, 'traderating'),
+        marketRating: valueTag(body, 'marketrating'),
+        url: userAttrs.name ? `https://boardgamegeek.com/user/${encodeURIComponent(userAttrs.name)}` : '',
+    }].filter((row) => row.username);
+}
+
+cli({
+    site: 'boardgamegeek',
+    name: 'user',
+    access: 'read',
+    description: 'Get a public BoardGameGeek user profile',
+    domain: 'boardgamegeek.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'username', positional: true, required: true, help: 'BoardGameGeek username' },
+    ],
+    columns: ['id', 'username', 'firstName', 'lastName', 'stateOrProvince', 'country', 'yearRegistered', 'lastLogin', 'tradeRating', 'marketRating', 'url'],
+    func: async (args) => {
+        const username = requiredText(args.username, 'username');
+        const url = new URL(`${API_BASE}/user`);
+        url.searchParams.set('name', username);
+        return requireRows(parseUser(await fetchXml(url, 'boardgamegeek user')), 'boardgamegeek user', `No BoardGameGeek user found for "${username}".`);
+    },
+});
+
+export const __test__ = { parseUser };

--- a/clis/boardgamegeek/utils.js
+++ b/clis/boardgamegeek/utils.js
@@ -1,0 +1,135 @@
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+
+export const API_BASE = 'https://boardgamegeek.com/xmlapi2';
+const TOKEN_ENV = 'BOARDGAMEGEEK_TOKEN';
+const UA = 'webcmd-boardgamegeek-adapter (+https://github.com/agentrhq/webcmd)';
+
+export function requiredText(value, label) {
+    const text = String(value ?? '').trim();
+    if (!text) throw new ArgumentError(`boardgamegeek ${label} is required`);
+    return text;
+}
+
+export function positiveInt(value, defaultValue, maxValue, label) {
+    const raw = value == null || value === '' ? defaultValue : value;
+    const n = Number(raw);
+    if (!Number.isInteger(n) || n < 1 || n > maxValue) {
+        throw new ArgumentError(`boardgamegeek ${label} must be an integer between 1 and ${maxValue}`);
+    }
+    return n;
+}
+
+export function optionalDate(value, label) {
+    const text = String(value ?? '').trim();
+    if (!text) return null;
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(text)) {
+        throw new ArgumentError(`boardgamegeek ${label} must be YYYY-MM-DD`);
+    }
+    return text;
+}
+
+function token() {
+    const value = String(process.env[TOKEN_ENV] ?? '').trim();
+    if (!value) {
+        throw new AuthRequiredError('boardgamegeek.com', `Set ${TOKEN_ENV} to a BoardGameGeek XML API application Bearer token.`);
+    }
+    return value;
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function fetchXml(url, label, { retry202 = false } = {}) {
+    const bearer = token();
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+        let resp;
+        try {
+            resp = await fetch(url, {
+                headers: {
+                    authorization: `Bearer ${bearer}`,
+                    'user-agent': UA,
+                    accept: 'application/xml,text/xml',
+                },
+            });
+        } catch (err) {
+            throw new CommandExecutionError(`${label} request failed: ${err?.message ?? err}`);
+        }
+        if (resp.status === 202 && retry202 && attempt < 3) {
+            await sleep(1000);
+            continue;
+        }
+        if (resp.status === 401 || resp.status === 403) {
+            throw new AuthRequiredError('boardgamegeek.com', `BoardGameGeek XML API rejected ${TOKEN_ENV}.`);
+        }
+        if (resp.status === 202) {
+            throw new CommandExecutionError(`${label} is queued by BoardGameGeek; retry later.`);
+        }
+        if (resp.status === 429 || resp.status === 500 || resp.status === 503) {
+            throw new CommandExecutionError(`${label} is rate limited or busy (HTTP ${resp.status}); retry later.`);
+        }
+        if (!resp.ok) {
+            throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+        }
+        return resp.text();
+    }
+    throw new CommandExecutionError(`${label} is queued by BoardGameGeek; retry later.`);
+}
+
+export function decodeXml(value) {
+    return String(value ?? '')
+        .replace(/&quot;/g, '"')
+        .replace(/&apos;/g, "'")
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&amp;/g, '&');
+}
+
+export function attrs(xml) {
+    const out = {};
+    for (const match of String(xml ?? '').matchAll(/\s([A-Za-z_:][-A-Za-z0-9_:.]*)="([^"]*)"/g)) {
+        out[match[1]] = decodeXml(match[2]);
+    }
+    return out;
+}
+
+export function blocks(xml, tag) {
+    const out = [];
+    const re = new RegExp(`<${tag}\\b([^>]*)>([\\s\\S]*?)<\\/${tag}>`, 'g');
+    for (const match of String(xml ?? '').matchAll(re)) {
+        out.push({ attrs: attrs(match[1]), body: match[2] });
+    }
+    return out;
+}
+
+export function valueTag(xml, tag) {
+    const selfClosing = String(xml ?? '').match(new RegExp(`<${tag}\\b([^>]*)\\s*\\/>`));
+    if (selfClosing) return attrs(selfClosing[1]).value ?? '';
+    const paired = String(xml ?? '').match(new RegExp(`<${tag}\\b([^>]*)>([\\s\\S]*?)<\\/${tag}>`));
+    if (!paired) return '';
+    return attrs(paired[1]).value ?? decodeXml(paired[2]).replace(/\s+/g, ' ').trim();
+}
+
+export function numberValue(value) {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+}
+
+export function primaryName(body) {
+    const primary = String(body ?? '').match(/<name\b([^>]*\btype="primary"[^>]*)\/?>/);
+    const any = primary ?? String(body ?? '').match(/<name\b([^>]*)\/?>/);
+    return attrs(any?.[1]).value ?? '';
+}
+
+export function linkValues(body, type, max = 5) {
+    const out = [];
+    for (const match of String(body ?? '').matchAll(/<link\b([^>]*)\/?>/g)) {
+        const itemAttrs = attrs(match[1]);
+        if (itemAttrs.type === type && itemAttrs.value) out.push(itemAttrs.value);
+        if (out.length >= max) break;
+    }
+    return out.join(', ');
+}
+
+export function requireRows(rows, label, hint) {
+    if (!rows.length) throw new EmptyResultError(label, hint);
+    return rows;
+}


### PR DESCRIPTION
## Summary
- add BoardGameGeek XML API2 adapter commands
- commands added:
  - `webcmd boardgamegeek search <query>`
  - `webcmd boardgamegeek thing <id>`
  - `webcmd boardgamegeek hot`
  - `webcmd boardgamegeek collection <username>`
  - `webcmd boardgamegeek plays <username>`
  - `webcmd boardgamegeek user <username>`
  - `webcmd boardgamegeek guild <id>`
- share token handling, XML fetch, typed errors, and XML parsing helpers in `clis/boardgamegeek/utils.js`
- uses `BOARDGAMEGEEK_TOKEN` because BGG now requires registered application bearer-token authorization for XML API calls
- regenerate `cli-manifest.json`

## Verification
- `npm run build-manifest`
- `npm run typecheck`
- `npm run check:silent-column-drop`
- `npm run check:typed-error-lint`
- `npm test -- clis/boardgamegeek/boardgamegeek.test.js`
- `npm test`
- `node dist/src/main.js boardgamegeek --help` showed: `collection, guild, hot, plays, search, thing, user`
- live unauthenticated BGG endpoint checks returned HTTP 401, matching BGG docs and adapter `AUTH_REQUIRED` behavior
- `webcmd browser verify` loaded the local synced `hot`, `thing`, and `user` adapters, then stopped at `AUTH_REQUIRED` because this machine does not have `BOARDGAMEGEEK_TOKEN` configured