### PR TITLE
Fix Reddit popular HTML response handling

### DIFF
--- a/clis/reddit/popular.js
+++ b/clis/reddit/popular.js
@@ -12,6 +12,7 @@ cli({
     ],
     columns: ['rank', 'id', 'title', 'subreddit', 'score', 'comments', 'author', 'url', 'created_utc', 'selftext', 'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls'],
     pipeline: [
+        { navigate: 'https://www.reddit.com' },
         { evaluate: `(async () => {
   function decodeHtml(s) {
     if (typeof s !== 'string' || !s) return '';
@@ -43,7 +44,17 @@ cli({
   const res = await fetch('/r/popular.json?limit=' + limit + '&raw_json=1', {
     credentials: 'include'
   });
-  const d = await res.json();
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error('Reddit popular request failed: HTTP ' + res.status + ' ' + text.replace(/\\s+/g, ' ').slice(0, 160));
+  }
+  let d;
+  try {
+    d = JSON.parse(text);
+  } catch {
+    const kind = /^\\s*</.test(text) ? 'HTML' : 'non-JSON';
+    throw new Error('Reddit popular expected JSON but received ' + kind + ': ' + text.replace(/\\s+/g, ' ').slice(0, 160));
+  }
   return (d?.data?.children || []).map(c => ({
     id: c.data.id,
     title: c.data.title,

--- a/clis/reddit/popular.test.js
+++ b/clis/reddit/popular.test.js
@@ -4,6 +4,8 @@ import './popular.js';
 
 describe('reddit popular adapter', () => {
   const command = getRegistry().get('reddit/popular');
+  const evaluate = command?.pipeline?.find((step) => step.evaluate)?.evaluate;
+  const map = command?.pipeline?.find((step) => step.map)?.map;
 
   it('exposes the full post-list shape including the 4 media columns', () => {
     expect(command?.columns).toEqual([
@@ -14,13 +16,20 @@ describe('reddit popular adapter', () => {
   });
 
   it('surfaces media via extractRedditMedia in evaluate + map', () => {
-    expect(command?.pipeline?.[0]?.evaluate).toContain('function extractRedditMedia');
-    expect(command?.pipeline?.[0]?.evaluate).toContain('...extractRedditMedia(c.data)');
-    expect(command?.pipeline?.[1]?.map).toMatchObject({
+    expect(evaluate).toContain('function extractRedditMedia');
+    expect(evaluate).toContain('...extractRedditMedia(c.data)');
+    expect(map).toMatchObject({
       post_hint: '${{ item.post_hint }}',
       url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
       preview_image_url: '${{ item.preview_image_url }}',
       gallery_urls: '${{ item.gallery_urls }}',
     });
+  });
+
+  it('navigates to Reddit and guards HTML responses before JSON parsing', () => {
+    expect(command?.pipeline?.[0]).toEqual({ navigate: 'https://www.reddit.com' });
+    expect(evaluate).toContain('await res.text()');
+    expect(evaluate).toContain('Reddit popular expected JSON');
+    expect(evaluate).not.toContain('await res.json()');
   });
 });


### PR DESCRIPTION
## Summary
- Make `reddit popular` explicitly navigate to `https://www.reddit.com` before fetching `/r/popular.json`
- Guard Reddit JSON parsing so HTML/interstitial responses produce a useful adapter error instead of raw `Unexpected token <`
- Update the Reddit popular adapter test to cover navigation and guarded parsing

## Verification
- `npm run test:adapter -- clis/reddit/popular.test.js`
- `npm run dev -- reddit popular --limit 3 -f json`
- `npm run test:adapter -- clis/reddit/*.test.js`
- `npm run check:typed-error-lint`
- `npm run check:silent-column-drop`
- `npm run typecheck`
- `npm run build`

## Reddit smoke checks
Read-only live commands verified:
- `reddit popular --limit 2`
- `reddit frontpage --limit 2`
- `reddit hot --limit 2`
- `reddit subreddit programming --limit 2`
- `reddit search "web development" --limit 2`
- `reddit subreddit-info programming`
- `reddit user spez`
- `reddit user-posts spez --limit 2`
- `reddit user-comments spez --limit 2`
- `reddit read 1um1euf --limit 2`

Auth-bound commands were not live-verified because the browser session is not logged in. Write commands were help-checked only to avoid mutating a real Reddit account.