### PR TITLE
docs: clarify Webcmd agent onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,26 @@ Webcmd requires **Node.js >= 20**.
 ```bash
 node --version
 npm install -g @agentrhq/webcmd
+webcmd --version
 ```
 
-### 2. Verify the browser runtime
+### 2. Teach your agent Webcmd
+
+The CLI install is the same for everyone. Pick one agent-support path:
+
+| Agent harness | Install Webcmd agent support |
+|---------------|------------------------------|
+| Codex | `codex plugin marketplace add agentrhq/webcmd`, then open `/plugins` and install Webcmd. |
+| Claude Code | `npx skills add agentrhq/webcmd --skill webcmd -a claude-code` |
+| Cursor | `npx skills add agentrhq/webcmd --skill webcmd -a cursor` |
+| Gemini CLI | `npx skills add agentrhq/webcmd --skill webcmd -a gemini-cli` |
+| OpenCode | `npx skills add agentrhq/webcmd --skill webcmd -a opencode` |
+| Hermes Agent | `npx skills add agentrhq/webcmd --skill webcmd -a hermes-agent` |
+| Any skills-compatible agent | `npx skills add agentrhq/webcmd --skill webcmd` |
+
+Codex users do not need the `npx skills add` command when they install the Webcmd plugin. The plugin bundles the discovery skill for Codex.
+
+### 3. Verify the browser runtime
 
 ```bash
 webcmd doctor
@@ -41,7 +58,7 @@ webcmd doctor
 
 `doctor` checks the Webcmd browser bridge: daemon status, runtime wiring, profile selection, and a live connectivity probe. Pure public adapters and local passthrough commands do not need a green browser check, but `COOKIE`, `INTERCEPT`, `UI`, and `webcmd browser` workflows do.
 
-### 3. Discover commands
+### 4. Discover commands
 
 ```bash
 webcmd list
@@ -52,7 +69,7 @@ webcmd reddit hot --help
 
 `webcmd list -f json` is the source of truth for agents. It emits one row per command with the site, command name, arguments, output columns, browser requirement, and strategy.
 
-### 4. Run your first adapters
+### 5. Run your first adapters
 
 ```bash
 webcmd hackernews top --limit 5
@@ -111,15 +128,15 @@ Agents usually want `-f json`; humans usually want the default table.
 
 ## For AI Agents
 
-Webcmd is designed to be driven by coding agents such as Codex, Claude Code, Cursor, and similar tools.
+Webcmd is designed to be driven by coding agents such as Codex, Claude Code, Cursor, and similar tools. Install the CLI once, then install the agent support that matches your harness from the Quick Start table.
 
-Install Webcmd skills into the agent environment with your agent's skill manager:
+The installable skill is a discovery entrypoint. Runtime workflow skills are served by the installed CLI so instructions stay in sync with your Webcmd version:
 
 ```bash
-npx skills add agentrhq/webcmd
+webcmd skills list
+webcmd skills get webcmd-usage
+webcmd skills get webcmd-browser
 ```
-
-Or install/copy only the skills you need from [`skills/`](./skills/) into your agent's skills root. These skills teach agents when to use adapters, when to drive the browser, how to author new adapters, and how to repair failing commands.
 
 | Skill | When to use |
 |-------|-------------|

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ The CLI install is the same for everyone. Pick one agent-support path:
 | Agent harness | Install Webcmd agent support |
 |---------------|------------------------------|
 | Codex | `codex plugin marketplace add agentrhq/webcmd`, then open `/plugins` and install Webcmd. |
-| Claude Code | `npx skills add agentrhq/webcmd --skill webcmd -a claude-code` |
+| Claude Code | `/plugin marketplace add agentrhq/webcmd`, then `/plugin install webcmd@webcmd` |
 | Cursor | `npx skills add agentrhq/webcmd --skill webcmd -a cursor` |
 | Gemini CLI | `npx skills add agentrhq/webcmd --skill webcmd -a gemini-cli` |
 | OpenCode | `npx skills add agentrhq/webcmd --skill webcmd -a opencode` |
 | Hermes Agent | `npx skills add agentrhq/webcmd --skill webcmd -a hermes-agent` |
 | Any skills-compatible agent | `npx skills add agentrhq/webcmd --skill webcmd` |
 
-Codex users do not need the `npx skills add` command when they install the Webcmd plugin. The plugin bundles the discovery skill for Codex.
+Codex and Claude Code users do not need the `npx skills add` command when they install the Webcmd plugin for their agent. The plugin bundles the Webcmd discovery skill.
 
 ### 3. Verify the browser runtime
 

--- a/docs/plugins-and-skills.mdx
+++ b/docs/plugins-and-skills.mdx
@@ -54,6 +54,7 @@ Webcmd has two install surfaces:
 | Agent surface | Recommended install |
 | --- | --- |
 | Codex | Install the Webcmd plugin from the Codex plugin marketplace. |
+| Claude Code | Install the Webcmd plugin from the Claude Code plugin marketplace. |
 | Other skill-aware agents | Install the Webcmd discovery skill with `npx skills add agentrhq/webcmd --skill webcmd`. |
 
 Install the CLI separately with `npm install -g @agentrhq/webcmd`. The skill or plugin teaches the agent how to use the `webcmd` binary; it should not be treated as the CLI package itself.

--- a/docs/plugins-and-skills.mdx
+++ b/docs/plugins-and-skills.mdx
@@ -49,6 +49,15 @@ You can run those yourself, but they are usually part of an agent task.
 
 Skills are instructions for agents. They help the agent choose the right workflow instead of guessing.
 
+Webcmd has two install surfaces:
+
+| Agent surface | Recommended install |
+| --- | --- |
+| Codex | Install the Webcmd plugin from the Codex plugin marketplace. |
+| Other skill-aware agents | Install the Webcmd discovery skill with `npx skills add agentrhq/webcmd --skill webcmd`. |
+
+Install the CLI separately with `npm install -g @agentrhq/webcmd`. The skill or plugin teaches the agent how to use the `webcmd` binary; it should not be treated as the CLI package itself.
+
 Common skills:
 
 | Skill | Purpose |
@@ -69,10 +78,10 @@ Use the Webcmd adapter-author skill to create this command. If the site changes 
 
 ## Installing Skills for Agents
 
-If your agent supports skills, install or copy the relevant Webcmd skills from the package. Then tell the agent to use them.
+If your agent supports skills, install the Webcmd discovery skill. Then tell the agent to load the runtime workflow it needs.
 
 ```text
-Before working on this site, load the Webcmd usage and adapter-author skills. Prefer an existing adapter if one exists.
+Before working on this site, load the Webcmd usage workflow and prefer an existing adapter if one exists.
 ```
 
 ## Recommended Agent Behavior

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -21,6 +21,22 @@ webcmd --version
 webcmd --help
 ```
 
+## Install Agent Support
+
+The CLI install is universal. The second step depends on the agent harness you use:
+
+| Agent harness | Install Webcmd agent support |
+| --- | --- |
+| Codex | `codex plugin marketplace add agentrhq/webcmd`, then open `/plugins` and install Webcmd. |
+| Claude Code | `npx skills add agentrhq/webcmd --skill webcmd -a claude-code` |
+| Cursor | `npx skills add agentrhq/webcmd --skill webcmd -a cursor` |
+| Gemini CLI | `npx skills add agentrhq/webcmd --skill webcmd -a gemini-cli` |
+| OpenCode | `npx skills add agentrhq/webcmd --skill webcmd -a opencode` |
+| Hermes Agent | `npx skills add agentrhq/webcmd --skill webcmd -a hermes-agent` |
+| Any skills-compatible agent | `npx skills add agentrhq/webcmd --skill webcmd` |
+
+Codex plugin installs already include the Webcmd discovery skill, so Codex users do not need a separate `npx skills add` step.
+
 ## Verify the Runtime
 
 Agents use Webcmd for public commands, authenticated browser workflows, local CLIs, and adapter authoring. Verify the local runtime before asking an agent to create commands:

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -28,14 +28,14 @@ The CLI install is universal. The second step depends on the agent harness you u
 | Agent harness | Install Webcmd agent support |
 | --- | --- |
 | Codex | `codex plugin marketplace add agentrhq/webcmd`, then open `/plugins` and install Webcmd. |
-| Claude Code | `npx skills add agentrhq/webcmd --skill webcmd -a claude-code` |
+| Claude Code | `/plugin marketplace add agentrhq/webcmd`, then `/plugin install webcmd@webcmd` |
 | Cursor | `npx skills add agentrhq/webcmd --skill webcmd -a cursor` |
 | Gemini CLI | `npx skills add agentrhq/webcmd --skill webcmd -a gemini-cli` |
 | OpenCode | `npx skills add agentrhq/webcmd --skill webcmd -a opencode` |
 | Hermes Agent | `npx skills add agentrhq/webcmd --skill webcmd -a hermes-agent` |
 | Any skills-compatible agent | `npx skills add agentrhq/webcmd --skill webcmd` |
 
-Codex plugin installs already include the Webcmd discovery skill, so Codex users do not need a separate `npx skills add` step.
+Codex and Claude Code plugin installs already include the Webcmd discovery skill, so users on those agents do not need a separate `npx skills add` step.
 
 ## Verify the Runtime
 


### PR DESCRIPTION
## Summary
- Moves first-use guidance earlier in the README and docs quickstart.
- Separates the universal CLI install from the agent-harness support install.
- Adds a harness table for Codex, Claude Code, Cursor, Gemini CLI, OpenCode, Hermes Agent, and generic skills-compatible agents.
- Clarifies that Codex and Claude Code users install native Webcmd plugins instead of also running `npx skills add`.

## Reasoning
Webcmd has two different installation concerns: the executable CLI and the agent instructions that teach a harness how to use that CLI. Comparable projects document those as separate steps: Agent Browser uses a CLI plus one discovery skill, Playwright CLI documents CLI install plus skill install, and Codex/Claude Code both provide native plugin marketplace paths. This PR makes that mental model explicit for new users before they reach lower-level adapter details.

## Industry practice followed
- Keep the universal executable install first.
- Put agent-specific setup in a table so users do not read irrelevant harness instructions.
- Treat Codex and Claude Code plugin installs and `npx skills add` as alternatives, not cumulative setup.
- Keep detailed workflow skills behind runtime discovery so the README remains short.

## Follow-up dependency
This is intentionally a draft because the `--skill webcmd` and `webcmd skills get ...` paths are completed by the single-discovery-skill PR. The Codex plugin and Claude Code plugin PRs then provide native marketplace install paths for those two agents.

## Testing
- Docs-only change; no runtime tests run.