### PR TITLE
feat: install bundled Webcmd skills

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "files": [
     "dist/src/",
     "clis/",
-    "skills/webcmd-*/**",
+    "skills/**",
     "cli-manifest.json",
     "scripts/",
     "README.md",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ import { render as renderOutput } from './output.js';
 import { PKG_VERSION } from './version.js';
 import { printCompletionScript } from './completion.js';
 import { loadExternalClis, executeExternalCli, installExternalCli, registerExternalCli, isBinaryInstalled, formatExternalCliLabel } from './external.js';
-import { listWebcmdSkills, readWebcmdSkill } from './skills.js';
+import { installWebcmdSkill, listWebcmdSkills, updateWebcmdSkill, type WebcmdSkillInstallResult } from './skills.js';
 import { registerAllCommands } from './commanderAdapter.js';
 import { classifyAdapter, formatRootAdapterHelpText, installCommanderNamespaceStructuredHelp, installStructuredHelp, leadingPositionalFromUsage, rootHelpData, type RootAdapterGroups } from './help.js';
 import { EXIT_CODES, getErrorMessage, BrowserConnectError, CliError } from './errors.js';
@@ -76,6 +76,24 @@ function parseDurationMs(raw: unknown, flagName: string): number | null | { erro
 
 function timestampFromRaw(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : Date.now();
+}
+
+function handleSkillLinkCommand(action: () => WebcmdSkillInstallResult, json: boolean, verb: string): void {
+  try {
+    const result = action();
+    if (json) {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+    console.log(`Webcmd skills ${verb}: ${result.skills.length}`);
+    for (const skill of result.skills) {
+      console.log(`${skill.name}: ${skill.destination ? `${skill.destination} -> ` : ''}${skill.stableLink}`);
+    }
+  } catch (err) {
+    console.error(`Error: ${getErrorMessage(err)}`);
+    if (err instanceof CliError && err.hint) console.error(`Hint: ${err.hint}`);
+    process.exitCode = err instanceof CliError ? err.exitCode : EXIT_CODES.GENERIC_ERROR;
+  }
 }
 
 function toIsoTimestamp(timestamp: unknown): string | undefined {
@@ -824,11 +842,21 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
 
   const skillsCmd = program
     .command('skills')
-    .description('Read bundled Webcmd skills');
+    .description('List, install, and update bundled Webcmd skills')
+    .action(() => {
+      const rows = listWebcmdSkills();
+      renderOutput(rows, {
+        fmt: 'table',
+        fmtExplicit: false,
+        columns: ['name', 'description', 'version', 'path'],
+        title: 'webcmd/skills/list',
+        source: 'webcmd skills',
+      });
+    });
 
   skillsCmd
     .command('list')
-    .description('List bundled webcmd-* skills')
+    .description('List bundled Webcmd skills')
     .option('-f, --format <fmt>', 'Output format: table, json, yaml, md, csv', 'table')
     .action((opts) => {
       const rows = listWebcmdSkills();
@@ -842,27 +870,29 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     });
 
   skillsCmd
-    .command('read')
-    .description("Print a bundled webcmd-* skill's SKILL.md or reference file")
-    .argument('<skill>', 'Skill name, or skill/path like webcmd-browser/references/foo.md')
-    .argument('[path]', 'Path under the skill directory')
-    .option('--json', 'Output a JSON envelope instead of raw markdown', false)
-    .action((skill: string, skillPath: string | undefined, opts) => {
-      let result: ReturnType<typeof readWebcmdSkill>;
-      try {
-        result = readWebcmdSkill(skill, skillPath ?? '');
-      } catch (err) {
-        console.error(`Error: ${getErrorMessage(err)}`);
-        if (err instanceof CliError && err.hint) console.error(`Hint: ${err.hint}`);
-        process.exitCode = err instanceof CliError ? err.exitCode : EXIT_CODES.GENERIC_ERROR;
-        return;
-      }
-      if (opts.json) {
-        console.log(JSON.stringify(result, null, 2));
-        return;
-      }
-      process.stdout.write(result.content);
-      if (!result.content.endsWith('\n')) process.stdout.write('\n');
+    .command('install')
+    .description('Install bundled Webcmd skills into an agent skills folder')
+    .option('-p, --provider <provider>', 'Agent provider: agents, codex, claude', 'agents')
+    .option('-s, --scope <scope>', 'Install scope: user/global or project/local', 'user')
+    .option('--json', 'Output a JSON envelope', false)
+    .action((opts) => {
+      handleSkillLinkCommand(() => installWebcmdSkill({
+        provider: opts.provider,
+        scope: opts.scope,
+      }), opts.json, 'installed');
+    });
+
+  skillsCmd
+    .command('update')
+    .description('Refresh bundled Webcmd skill symlinks after updating the package')
+    .option('-p, --provider <provider>', 'Also repair provider link: agents, codex, claude')
+    .option('-s, --scope <scope>', 'Also repair scoped link: user/global or project/local')
+    .option('--json', 'Output a JSON envelope', false)
+    .action((opts) => {
+      handleSkillLinkCommand(() => updateWebcmdSkill({
+        provider: opts.provider,
+        scope: opts.scope,
+      }), opts.json, 'updated');
     });
 
   const authCmd = registerAuthCommands(program);

--- a/src/skills.test.ts
+++ b/src/skills.test.ts
@@ -4,18 +4,18 @@ import * as path from 'node:path';
 import yaml from 'js-yaml';
 import { describe, expect, it } from 'vitest';
 import { ArgumentError } from './errors.js';
-import { listWebcmdSkills, readWebcmdSkill } from './skills.js';
+import { installWebcmdSkill, listWebcmdSkills, updateWebcmdSkill } from './skills.js';
 
-function makePackageRoot(): string {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-skills-'));
-  fs.mkdirSync(path.join(root, 'skills', 'webcmd-browser', 'references'), { recursive: true });
+function makePackageRoot(label = 'current'): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `webcmd-skills-${label}-`));
+  fs.mkdirSync(path.join(root, 'skills', 'webcmd-browser'), { recursive: true });
   fs.mkdirSync(path.join(root, 'skills', 'webcmd-autofix'), { recursive: true });
   fs.mkdirSync(path.join(root, 'skills', 'smart-search'), { recursive: true });
   fs.writeFileSync(path.join(root, 'package.json'), '{"name":"@agentrhq/webcmd"}\n');
   fs.writeFileSync(path.join(root, 'skills', 'webcmd-browser', 'SKILL.md'), [
     '---',
     'name: webcmd-browser',
-    'description: Browser control skill',
+    `description: Browser control skill ${label}`,
     'version: 1.2.3',
     '---',
     '',
@@ -24,7 +24,6 @@ function makePackageRoot(): string {
     'Body.',
     '',
   ].join('\n'));
-  fs.writeFileSync(path.join(root, 'skills', 'webcmd-browser', 'references', 'targets.md'), '# Targets\n');
   fs.writeFileSync(path.join(root, 'skills', 'webcmd-autofix', 'SKILL.md'), [
     '---',
     'name: webcmd-autofix',
@@ -42,11 +41,15 @@ function makePackageRoot(): string {
   return root;
 }
 
+function real(filePath: string): string {
+  return fs.realpathSync(filePath);
+}
+
 describe('webcmd skills content', () => {
   it('keeps bundled skill frontmatter valid yaml', () => {
     const skillsRoot = path.join(process.cwd(), 'skills');
     const skillNames = fs.readdirSync(skillsRoot, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory() && entry.name.startsWith('webcmd-'))
+      .filter((entry) => entry.isDirectory())
       .map((entry) => entry.name);
 
     for (const name of skillNames) {
@@ -57,10 +60,11 @@ describe('webcmd skills content', () => {
     }
   });
 
-  it('lists only webcmd-prefixed skills', () => {
+  it('lists bundled skills', () => {
     const root = makePackageRoot();
 
     expect(listWebcmdSkills(root).map((skill) => skill.name)).toEqual([
+      'smart-search',
       'webcmd-autofix',
       'webcmd-browser',
     ]);
@@ -68,26 +72,57 @@ describe('webcmd skills content', () => {
       .toBe('Fix adapters: keep scope narrow');
   });
 
-  it('reads a skill SKILL.md and reference file', () => {
-    const root = makePackageRoot();
+  it('keeps the expected installable skill set', () => {
+    const skills = fs.readdirSync(path.join(process.cwd(), 'skills'), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
 
-    expect(readWebcmdSkill('webcmd-browser', '', root)).toMatchObject({
-      skill: 'webcmd-browser',
-      path: 'SKILL.md',
-    });
-    expect(readWebcmdSkill('webcmd-browser/references/targets.md', '', root)).toMatchObject({
-      skill: 'webcmd-browser',
-      path: 'references/targets.md',
-      content: '# Targets\n',
-    });
-    expect(readWebcmdSkill('webcmd-browser', 'references/targets.md', root).content).toBe('# Targets\n');
+    expect(skills).toEqual([
+      'smart-search',
+      'webcmd-adapter-author',
+      'webcmd-autofix',
+      'webcmd-browser',
+      'webcmd-browser-sitemap',
+      'webcmd-sitemap-author',
+      'webcmd-usage',
+    ]);
   });
 
-  it('rejects non-webcmd skills and path traversal', () => {
-    const root = makePackageRoot();
+  it('installs bundled skills once and refreshes them after package updates', () => {
+    const firstRoot = makePackageRoot('first');
+    const secondRoot = makePackageRoot('second');
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-home-'));
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-project-'));
 
-    expect(() => readWebcmdSkill('smart-search', '', root)).toThrow(ArgumentError);
-    expect(() => readWebcmdSkill('webcmd-browser/../smart-search/SKILL.md', '', root)).toThrow(ArgumentError);
-    expect(() => readWebcmdSkill('webcmd-browser', '../../package.json', root)).toThrow(ArgumentError);
+    const installed = installWebcmdSkill({ packageRoot: firstRoot, homeDir, cwd, provider: 'codex', scope: 'project' });
+
+    expect(installed).toMatchObject({
+      provider: 'codex',
+      scope: 'project',
+    });
+    expect(installed.skills.map((skill) => skill.name)).toEqual(['smart-search', 'webcmd-autofix', 'webcmd-browser']);
+    for (const skill of installed.skills) {
+      expect(skill.source).toBe(path.join(firstRoot, 'skills', skill.name));
+      expect(skill.stableLink).toBe(path.join(homeDir, '.webcmd', 'skills', skill.name));
+      expect(skill.destination).toBe(path.join(cwd, '.agents', 'skills', skill.name));
+      expect(real(skill.destination!)).toBe(real(skill.source));
+    }
+
+    const updated = updateWebcmdSkill({ packageRoot: secondRoot, homeDir });
+
+    expect(updated.skills.every((skill) => skill.destination === undefined)).toBe(true);
+    for (const skill of installed.skills) {
+      expect(real(skill.destination!)).toBe(real(path.join(secondRoot, 'skills', skill.name)));
+    }
+  });
+
+  it('refuses to replace real files or directories', () => {
+    const packageRoot = makePackageRoot();
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-home-'));
+    const stablePath = path.join(homeDir, '.webcmd', 'skills', 'smart-search');
+    fs.mkdirSync(stablePath, { recursive: true });
+
+    expect(() => updateWebcmdSkill({ packageRoot, homeDir })).toThrow(ArgumentError);
   });
 });

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import yaml from 'js-yaml';
@@ -14,10 +15,25 @@ export interface WebcmdSkillInfo {
   path: string;
 }
 
-export interface WebcmdSkillReadResult {
-  skill: string;
-  path: string;
-  content: string;
+export interface WebcmdSkillInstallOptions {
+  provider?: string;
+  scope?: string;
+  packageRoot?: string;
+  homeDir?: string;
+  cwd?: string;
+}
+
+export interface WebcmdSkillLink {
+  name: string;
+  source: string;
+  stableLink: string;
+  destination?: string;
+}
+
+export interface WebcmdSkillInstallResult {
+  provider?: SkillProvider;
+  scope?: SkillScope;
+  skills: WebcmdSkillLink[];
 }
 
 interface SkillFrontmatter {
@@ -25,6 +41,9 @@ interface SkillFrontmatter {
   description?: unknown;
   version?: unknown;
 }
+
+type SkillProvider = 'agents' | 'codex' | 'claude';
+type SkillScope = 'user' | 'project';
 
 export function getSkillsRoot(packageRoot: string = findPackageRoot(MODULE_FILE)): string {
   return path.join(packageRoot, 'skills');
@@ -35,39 +54,96 @@ export function listWebcmdSkills(packageRoot?: string): WebcmdSkillInfo[] {
   if (!fs.existsSync(skillsRoot)) return [];
 
   return fs.readdirSync(skillsRoot, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory() && entry.name.startsWith('webcmd-'))
+    .filter((entry) => entry.isDirectory())
     .map((entry) => readSkillInfo(skillsRoot, entry.name))
     .filter((entry): entry is WebcmdSkillInfo => entry !== null)
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export function readWebcmdSkill(target: string, relpath = '', packageRoot?: string): WebcmdSkillReadResult {
-  const { name, pathInSkill } = parseSkillTarget(target, relpath);
-  if (!name.startsWith('webcmd-')) {
-    throw new ArgumentError(`Unknown Webcmd skill: ${name}`, 'Run "webcmd skills list" to see available Webcmd skills.');
-  }
+export function installWebcmdSkill(options: WebcmdSkillInstallOptions = {}): WebcmdSkillInstallResult {
+  const provider = normalizeProvider(options.provider);
+  const scope = normalizeScope(options.scope);
+  const skills = updateStableSkillLinks(options)
+    .map((skill) => {
+      const destination = destinationFor(skill.name, provider, scope, options);
+      replaceDirectorySymlink(skill.stableLink, destination);
+      return { ...skill, destination };
+    });
+  return { provider, scope, skills };
+}
 
-  const skillsRoot = getSkillsRoot(packageRoot);
-  const skillRoot = path.join(skillsRoot, name);
-  if (!isDirectory(skillRoot) || !fs.existsSync(path.join(skillRoot, 'SKILL.md'))) {
-    throw new ArgumentError(`Unknown Webcmd skill: ${name}`, 'Run "webcmd skills list" to see available Webcmd skills.');
-  }
+export function updateWebcmdSkill(options: WebcmdSkillInstallOptions = {}): WebcmdSkillInstallResult {
+  const skills = updateStableSkillLinks(options);
+  if (options.provider === undefined && options.scope === undefined) return { skills };
 
-  const relativePath = normalizeSkillPath(pathInSkill || 'SKILL.md');
-  const absolutePath = path.resolve(skillRoot, relativePath);
-  const relativeToRoot = path.relative(skillRoot, absolutePath);
-  if (relativeToRoot.startsWith('..') || path.isAbsolute(relativeToRoot)) {
-    throw new ArgumentError(`Invalid skill path: ${relativePath}`, 'Skill paths must stay inside the selected Webcmd skill.');
-  }
-  if (!fs.existsSync(absolutePath) || !fs.statSync(absolutePath).isFile()) {
-    throw new ArgumentError(`Skill file not found: ${name}/${relativePath}`, 'Run "webcmd skills list <skill>" is not supported yet; read SKILL.md or a known references/... file.');
-  }
-
+  const provider = normalizeProvider(options.provider);
+  const scope = normalizeScope(options.scope);
   return {
-    skill: name,
-    path: relativePath,
-    content: fs.readFileSync(absolutePath, 'utf8'),
+    provider,
+    scope,
+    skills: skills.map((skill) => {
+      const destination = destinationFor(skill.name, provider, scope, options);
+      replaceDirectorySymlink(skill.stableLink, destination);
+      return { ...skill, destination };
+    }),
   };
+}
+
+function updateStableSkillLinks(options: WebcmdSkillInstallOptions): WebcmdSkillLink[] {
+  const skillsRoot = getSkillsRoot(options.packageRoot);
+  const skills = listWebcmdSkills(options.packageRoot);
+  if (skills.length === 0) {
+    throw new ArgumentError(`No Webcmd skills found: ${skillsRoot}`, 'Install a package that includes skills/*/SKILL.md.');
+  }
+
+  return skills.map((skill) => {
+    const source = path.join(skillsRoot, skill.name);
+    const stableLink = path.join(options.homeDir ?? os.homedir(), '.webcmd', 'skills', skill.name);
+    replaceDirectorySymlink(source, stableLink);
+    return { name: skill.name, source, stableLink };
+  });
+}
+
+function destinationFor(name: string, provider: SkillProvider, scope: SkillScope, options: WebcmdSkillInstallOptions): string {
+  const base = scope === 'project' ? options.cwd ?? process.cwd() : options.homeDir ?? os.homedir();
+  const agentDir = provider === 'claude' ? '.claude' : '.agents';
+  return path.join(base, agentDir, 'skills', name);
+}
+
+function normalizeProvider(raw = 'agents'): SkillProvider {
+  const value = raw.trim().toLowerCase();
+  if (value === 'agents' || value === 'codex') return value;
+  if (value === 'claude' || value === 'claude-code' || value === 'claude_code') return 'claude';
+  throw new ArgumentError(`Unsupported skill provider: ${raw}`, 'Use one of: agents, codex, claude.');
+}
+
+function normalizeScope(raw = 'user'): SkillScope {
+  const value = raw.trim().toLowerCase();
+  if (value === 'user' || value === 'global') return 'user';
+  if (value === 'project' || value === 'local') return 'project';
+  throw new ArgumentError(`Unsupported skill scope: ${raw}`, 'Use one of: user, global, project, local.');
+}
+
+function replaceDirectorySymlink(target: string, linkPath: string): void {
+  const current = safeLstat(linkPath);
+  if (current) {
+    if (!current.isSymbolicLink()) {
+      throw new ArgumentError(`Refusing to replace non-symlink path: ${linkPath}`, 'Remove it manually or choose a different scope/provider.');
+    }
+    fs.unlinkSync(linkPath);
+  }
+
+  fs.mkdirSync(path.dirname(linkPath), { recursive: true });
+  fs.symlinkSync(target, linkPath, process.platform === 'win32' ? 'junction' : 'dir');
+}
+
+function safeLstat(filePath: string): fs.Stats | null {
+  try {
+    return fs.lstatSync(filePath);
+  } catch (err) {
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') return null;
+    throw err;
+  }
 }
 
 function readSkillInfo(skillsRoot: string, name: string): WebcmdSkillInfo | null {
@@ -81,32 +157,6 @@ function readSkillInfo(skillsRoot: string, name: string): WebcmdSkillInfo | null
     version: typeof fm.version === 'string' || typeof fm.version === 'number' ? String(fm.version) : '',
     path: `${name}/SKILL.md`,
   };
-}
-
-function parseSkillTarget(target: string, relpath: string): { name: string; pathInSkill: string } {
-  const normalizedTarget = normalizeSkillPath(target);
-  if (relpath) {
-    return { name: normalizedTarget, pathInSkill: relpath };
-  }
-  const slash = normalizedTarget.indexOf('/');
-  if (slash === -1) {
-    return { name: normalizedTarget, pathInSkill: '' };
-  }
-  return {
-    name: normalizedTarget.slice(0, slash),
-    pathInSkill: normalizedTarget.slice(slash + 1),
-  };
-}
-
-function normalizeSkillPath(raw: string): string {
-  const normalized = raw.trim().replace(/\\/g, '/');
-  if (!normalized || normalized.includes('\0')) {
-    throw new ArgumentError('Skill path must be non-empty.');
-  }
-  if (normalized.startsWith('/') || normalized.split('/').some((part) => part === '..')) {
-    throw new ArgumentError(`Invalid skill path: ${raw}`, 'Use a path relative to a Webcmd skill directory.');
-  }
-  return path.posix.normalize(normalized);
 }
 
 function parseFrontmatter(content: string): SkillFrontmatter {


### PR DESCRIPTION
## Summary
- Keeps all seven Webcmd workflow skills as separate installable skills under `skills/`.
- Updates `webcmd skills install` to install all bundled skills at once via symlinks.
- Updates `webcmd skills update` to refresh all stable skill symlinks after package updates.
- Removes `webcmd skills read` / `webcmd skills get`; the skill command surface is now only `list`, `install`, and `update`.
- Updates package publishing metadata to include `skills/**`.
- Updates tests for listing, frontmatter validation, symlink installation, update refresh, and refusal to overwrite real files.

## Reasoning
The first step is still installing the Webcmd CLI. After that, users can run one command to install the seven agent skills separately but in one shot:

```bash
webcmd skills install
```

That creates one stable Webcmd-managed symlink per skill and one agent-facing symlink per skill:

```text
~/.agents/skills/<skill> -> ~/.webcmd/skills/<skill> -> current Webcmd package skills/<skill>
```

This avoids asking users to approve seven individual installer prompts, while still leaving the agent with seven normal skills instead of one discovery skill that has to serve runtime markdown through `read` or `get`.

`webcmd skills update` keeps the same symlink model: it repoints the stable `~/.webcmd/skills/<skill>` links to the currently installed package, and optionally repairs provider/scope links when those flags are passed.

## Testing
- `npm test -- src/skills.test.ts`
- `npm run typecheck`
- `npm run dev -- skills --help`
- `npm run dev -- skills list -f json`
- Temporary HOME smoke: `webcmd skills install --json` creates 7 `.agents/skills/*` symlinks
- `git diff --check`
