### PR TITLE
Add plugin catalog and in-repo Skyscanner plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "clis/",
     "skills/webcmd-*/**",
     "cli-manifest.json",
+    "plugin-catalog.json",
     "scripts/",
     "README.md",
     "LICENSE",

--- a/plugin-catalog.json
+++ b/plugin-catalog.json
@@ -1,0 +1,8 @@
+[
+  {
+    "site": "skyscanner",
+    "description": "Skyscanner flight search commands for warmed browser sessions",
+    "source": "github:agentrhq/webcmd/skyscanner",
+    "homepage": "https://www.skyscanner.com"
+  }
+]

--- a/plugins/skyscanner/README.md
+++ b/plugins/skyscanner/README.md
@@ -1,0 +1,21 @@
+# webcmd-plugin-skyscanner
+
+Skyscanner flight search commands for Webcmd.
+
+## Install
+
+```bash
+webcmd plugin install github:rishabhraj36/webcmd-plugin-skyscanner
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `skyscanner flights <origin> <destination>` | Visible round-trip flight results from a warmed browser session |
+
+## Examples
+
+```bash
+webcmd skyscanner flights nyca lond --depart-date 2026-08-01 --return-date 2026-08-08 --limit 5
+```

--- a/plugins/skyscanner/flights.js
+++ b/plugins/skyscanner/flights.js
@@ -1,0 +1,205 @@
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+
+const HOST = 'www.skyscanner.com';
+const MAX_LIMIT = 30;
+
+function normalizeText(value) {
+    return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function parseLimit(raw, fallback = 10) {
+    if (raw === undefined || raw === null || raw === '') return fallback;
+    const value = Number(raw);
+    if (!Number.isInteger(value)) {
+        throw new ArgumentError(`--limit must be an integer between 1 and ${MAX_LIMIT}, got ${JSON.stringify(raw)}`);
+    }
+    if (value < 1 || value > MAX_LIMIT) {
+        throw new ArgumentError(`--limit must be between 1 and ${MAX_LIMIT}, got ${value}`);
+    }
+    return value;
+}
+
+function normalizeRouteCode(raw, label) {
+    const value = String(raw ?? '').trim().toLowerCase();
+    if (!value) throw new ArgumentError(`${label} is required`);
+    if (!/^[a-z0-9-]+$/.test(value)) {
+        throw new ArgumentError(`${label} must be a Skyscanner route code like "nyca" or "lond"`);
+    }
+    return value;
+}
+
+function normalizeDate(raw, label) {
+    const value = String(raw ?? '').trim();
+    const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (!match) throw new ArgumentError(`${label} must use YYYY-MM-DD format`);
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const date = new Date(Date.UTC(year, month - 1, day));
+    if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
+        throw new ArgumentError(`${label} is not a valid calendar date`);
+    }
+    return `${String(year).slice(2)}${match[2]}${match[3]}`;
+}
+
+function buildFlightsUrl({ origin, destination, departDate, returnDate }) {
+    const from = normalizeRouteCode(origin, 'origin');
+    const to = normalizeRouteCode(destination, 'destination');
+    const outbound = normalizeDate(departDate, '--depart-date');
+    const inbound = normalizeDate(returnDate, '--return-date');
+    return `https://${HOST}/transport/flights/${from}/${to}/${outbound}/${inbound}/`;
+}
+
+function absoluteUrl(href, baseUrl) {
+    const value = String(href ?? '').trim();
+    if (!value) return null;
+    try {
+        return new URL(value, baseUrl || 'https://www.skyscanner.com').href;
+    } catch {
+        return null;
+    }
+}
+
+function unique(values) {
+    const seen = new Set();
+    const result = [];
+    for (const value of values.map(normalizeText).filter(Boolean)) {
+        if (seen.has(value)) continue;
+        seen.add(value);
+        result.push(value);
+    }
+    return result;
+}
+
+function squashRuns(values) {
+    const result = [];
+    for (const value of values.map(normalizeText).filter(Boolean)) {
+        if (result[result.length - 1] === value) continue;
+        result.push(value);
+    }
+    return result;
+}
+
+function extractFlightsFromDocument(doc, limit = 10) {
+    const bodyText = normalizeText(doc?.body?.textContent ?? '');
+    const pageUrl = doc?.location?.href || doc?.URL || 'https://www.skyscanner.com';
+    if (/\/captcha(?:-|\/)|captcha|verify you are human|human verification|access to this page has been denied/i.test(`${pageUrl} ${bodyText.slice(0, 2000)}`)) {
+        return { blocked: true, rows: [] };
+    }
+
+    const tickets = Array.from(doc.querySelectorAll('[data-testid="ticket"]'));
+    const rows = [];
+    for (const ticket of tickets) {
+        if (rows.length >= limit) break;
+        const text = normalizeText(ticket.textContent || '');
+        const priceMatches = text.match(/\$[\d,]+(?:\.\d{2})?/g) || [];
+        const priceText = priceMatches[priceMatches.length - 1] || null;
+        const airlineAlts = Array.from(ticket.querySelectorAll('img[alt]')).map((img) => img.getAttribute('alt'));
+        const airlines = unique(airlineAlts).join(', ') || null;
+        const spanTexts = Array.from(ticket.querySelectorAll('span')).map((span) => normalizeText(span.textContent));
+        const times = squashRuns(spanTexts.filter((value) => /^\d{1,2}:\d{2}\s*(AM|PM)$/i.test(value)));
+        const airportCodes = squashRuns(spanTexts.filter((value) => /^[A-Z]{3}$/.test(value)));
+        const durations = squashRuns(spanTexts.filter((value) => /^\d+h\s+\d{2}$/.test(value)));
+        const stops = squashRuns(spanTexts.filter((value) => /^(Direct|1 stop|2\+ stops)$/i.test(value)));
+        const link = ticket.closest('a[href]') || ticket.querySelector('a[href]');
+        const url = absoluteUrl(link?.getAttribute('href'), pageUrl);
+
+        if (!priceText || !airlines) continue;
+        const row = {
+            rank: 0,
+            priceText,
+            airlines,
+            outboundTime: times[0] && times[1] ? `${times[0]}-${times[1]}` : null,
+            outboundRoute: airportCodes.length >= 2 ? `${airportCodes[0]}-${airportCodes[1]}` : null,
+            outboundDuration: durations[0] || null,
+            outboundStops: stops[0] || null,
+            returnTime: times[2] && times[3] ? `${times[2]}-${times[3]}` : null,
+            returnRoute: airportCodes.length >= 4 ? `${airportCodes[2]}-${airportCodes[3]}` : (airportCodes.length >= 3 ? `${airportCodes[1]}-${airportCodes[2]}` : null),
+            returnDuration: durations[1] || null,
+            returnStops: stops[1] || stops[0] || null,
+            url,
+        };
+        if (!row.outboundTime || !row.outboundRoute || !row.outboundDuration || !row.returnTime || !row.returnRoute || !row.returnDuration || !row.url) {
+            continue;
+        }
+        row.rank = rows.length + 1;
+        rows.push(row);
+    }
+    return { blocked: false, rows };
+}
+
+function buildExtractScript(limit) {
+    return `(() => {
+      const extractFlightsFromDocument = ${extractFlightsFromDocument.toString()};
+      const normalizeText = ${normalizeText.toString()};
+      const absoluteUrl = ${absoluteUrl.toString()};
+      const unique = ${unique.toString()};
+      const squashRuns = ${squashRuns.toString()};
+      return extractFlightsFromDocument(document, ${limit});
+    })()`;
+}
+
+async function readFlightsFromPage(page, limit, timeoutSeconds = 20) {
+    let lastResult = null;
+    for (let second = 0; second <= timeoutSeconds; second += 1) {
+        const result = await page.evaluate(buildExtractScript(limit));
+        if (result && typeof result === 'object') {
+            lastResult = result;
+            if (result.blocked || (Array.isArray(result.rows) && result.rows.length > 0)) {
+                return result;
+            }
+        }
+        if (second < timeoutSeconds) await page.wait(1);
+    }
+    return lastResult;
+}
+
+cli({
+    site: 'skyscanner',
+    name: 'flights',
+    access: 'read',
+    description: 'Skyscanner visible round-trip flight results from a warmed browser session',
+    domain: HOST,
+    strategy: Strategy.UI,
+    navigateBefore: false,
+    args: [
+        { name: 'origin', positional: true, required: true, help: 'Skyscanner origin route code, for example nyca' },
+        { name: 'destination', positional: true, required: true, help: 'Skyscanner destination route code, for example lond' },
+        { name: 'depart-date', required: true, help: 'Outbound date as YYYY-MM-DD' },
+        { name: 'return-date', required: true, help: 'Return date as YYYY-MM-DD' },
+        { name: 'limit', type: 'int', default: 10, help: `Maximum flight rows to return (1-${MAX_LIMIT})` },
+    ],
+    columns: ['rank', 'priceText', 'airlines', 'outboundTime', 'outboundRoute', 'outboundDuration', 'outboundStops', 'returnTime', 'returnRoute', 'returnDuration', 'returnStops', 'url'],
+    func: async (page, kwargs) => {
+        const limit = parseLimit(kwargs.limit);
+        const url = buildFlightsUrl({
+            origin: kwargs.origin,
+            destination: kwargs.destination,
+            departDate: kwargs['depart-date'],
+            returnDate: kwargs['return-date'],
+        });
+
+        await page.goto(url, { waitUntil: 'load', settleMs: 2000 });
+        const result = await readFlightsFromPage(page, limit);
+        if (!result || typeof result !== 'object') {
+            throw new CommandExecutionError('Skyscanner flight extraction returned an unreadable response');
+        }
+        if (result.blocked) {
+            throw new AuthRequiredError(HOST, 'Skyscanner requires browser verification. Open this route in CloakBrowser, solve the CAPTCHA, then rerun the command.');
+        }
+        const rows = Array.isArray(result.rows) ? result.rows : [];
+        if (!rows.length) {
+            throw new EmptyResultError('skyscanner flights', 'No visible flight cards were found. The page may still be loading, blocked, or Skyscanner changed its layout.');
+        }
+        return rows;
+    },
+});
+
+export const __test__ = {
+    buildFlightsUrl,
+    extractFlightsFromDocument,
+    parseLimit,
+    readFlightsFromPage,
+    squashRuns,
+};

--- a/plugins/skyscanner/package.json
+++ b/plugins/skyscanner/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "webcmd-plugin-skyscanner",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Skyscanner flight search commands for Webcmd",
+  "peerDependencies": {
+    "@agentrhq/webcmd": ">=0.1.2"
+  }
+}

--- a/plugins/skyscanner/webcmd-plugin.json
+++ b/plugins/skyscanner/webcmd-plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "skyscanner",
+  "version": "0.1.0",
+  "description": "Skyscanner flight search commands for Webcmd",
+  "webcmd": ">=0.1.2"
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -204,6 +204,7 @@ describe('createProgram root help descriptions', () => {
     const snapshot = new Map(registry);
     const stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const restoreStdoutSpy = () => stdoutSpy.mockImplementation(() => {});
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
     registry.clear();
     try {
       cli({
@@ -246,6 +247,7 @@ name: 'search',
       expect(output).toMatch(/Site adapters[\s\S]*youtube[\s\S]*search \[public\] — Search YouTube/);
       expect(output).toContain('3 built-in commands across 2 apps + 1 sites,');
     } finally {
+      fetchSpy.mockRestore();
       restoreStdoutSpy();
       stdoutSpy.mockClear();
       registry.clear();
@@ -258,6 +260,7 @@ name: 'search',
     const snapshot = new Map(registry);
     const stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const restoreStdoutSpy = () => stdoutSpy.mockImplementation(() => {});
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
     registry.clear();
     try {
       cli({
@@ -294,6 +297,38 @@ name: 'search',
       expect(rows[0]).not.toHaveProperty('adapterKind');
       expect(rows[0]).not.toHaveProperty('section');
     } finally {
+      fetchSpy.mockRestore();
+      restoreStdoutSpy();
+      stdoutSpy.mockClear();
+      registry.clear();
+      for (const [key, value] of snapshot) registry.set(key, value);
+    }
+  });
+
+  it('shows available plugin metadata in list table without pre-install command names', async () => {
+    const registry = getRegistry();
+    const snapshot = new Map(registry);
+    const stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const restoreStdoutSpy = () => stdoutSpy.mockImplementation(() => {});
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
+    registry.clear();
+    try {
+      const program = createProgram('', '');
+      await program.parseAsync(['node', 'webcmd', 'list']);
+      const output = stdoutSpy.mock.calls.flat().join('\n');
+
+      expect(output).toContain('Available plugins');
+      expect(output).toContain('skyscanner');
+      expect(output).toContain('github:agentrhq/webcmd/skyscanner');
+      expect(output).not.toMatch(/\bflights\b/);
+
+      stdoutSpy.mockClear();
+      const jsonProgram = createProgram('', '');
+      await jsonProgram.parseAsync(['node', 'webcmd', 'list', '-f', 'json']);
+      const jsonOutput = stdoutSpy.mock.calls.flat().join('\n');
+      expect(JSON.parse(jsonOutput)).toEqual([]);
+    } finally {
+      fetchSpy.mockRestore();
       restoreStdoutSpy();
       stdoutSpy.mockClear();
       registry.clear();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import { printCompletionScript } from './completion.js';
 import { loadExternalClis, executeExternalCli, installExternalCli, registerExternalCli, isBinaryInstalled, formatExternalCliLabel } from './external.js';
 import { listWebcmdSkills, readWebcmdSkill } from './skills.js';
 import { registerAllCommands } from './commanderAdapter.js';
+import { listAvailablePluginsAsync } from './plugin-catalog.js';
 import { classifyAdapter, formatRootAdapterHelpText, installCommanderNamespaceStructuredHelp, installStructuredHelp, leadingPositionalFromUsage, rootHelpData, type RootAdapterGroups } from './help.js';
 import { EXIT_CODES, getErrorMessage, BrowserConnectError, CliError } from './errors.js';
 import { TargetError, type TargetErrorCode } from './browser/target-errors.js';
@@ -710,7 +711,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     .command('list')
     .description('List all available CLI commands')
     .option('-f, --format <fmt>', 'Output format: table, json, yaml, md, csv', 'table')
-    .action((opts) => {
+    .action(async (opts) => {
       const registry = getRegistry();
       const commands = [...new Set(registry.values())].sort((a, b) => fullName(a).localeCompare(fullName(b)));
       const fmt = opts.format;
@@ -792,7 +793,19 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         console.log();
       }
 
-      console.log(`  ${commands.length} built-in commands across ${appsBySite.size} apps + ${sitesBySite.size} sites, ${externalClis.length} external CLIs`);
+      const availablePlugins = await listAvailablePluginsAsync();
+      if (availablePlugins.length > 0) {
+        console.log('  Available plugins');
+        console.log();
+        for (const plugin of availablePlugins) {
+          console.log(`    ${plugin.site} — ${plugin.description}`);
+          console.log(`      source: ${plugin.source}`);
+          console.log(`      install: webcmd plugin install ${plugin.source}`);
+        }
+        console.log();
+      }
+
+      console.log(`  ${commands.length} built-in commands across ${appsBySite.size} apps + ${sitesBySite.size} sites, ${externalClis.length} external CLIs, ${availablePlugins.length} available plugins`);
       console.log();
     });
 

--- a/src/plugin-catalog.test.ts
+++ b/src/plugin-catalog.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { loadPluginCatalog, listAvailablePlugins, resolvePluginCatalog } from './plugin-catalog.js';
+
+describe('plugin catalog', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+    }
+  });
+
+  function writeCatalog(entries: unknown[]): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-plugin-catalog-'));
+    tempDirs.push(dir);
+    fs.writeFileSync(path.join(dir, 'plugin-catalog.json'), JSON.stringify(entries, null, 2));
+    return dir;
+  }
+
+  function makeTempDir(prefix: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  function okJson(value: unknown) {
+    return { ok: true, json: async () => value };
+  }
+
+  it('loads plugin metadata without exposing pre-install command names', () => {
+    const root = writeCatalog([
+      {
+        site: 'skyscanner',
+        description: 'Search Skyscanner flights',
+        source: 'github:agentrhq/webcmd/skyscanner',
+        commands: ['flights'],
+      },
+    ]);
+
+    expect(loadPluginCatalog(root)).toEqual([
+      {
+        site: 'skyscanner',
+        description: 'Search Skyscanner flights',
+        source: 'github:agentrhq/webcmd/skyscanner',
+      },
+    ]);
+  });
+
+  it('hides catalog plugins that are already installed', () => {
+    const root = writeCatalog([
+      {
+        site: 'skyscanner',
+        description: 'Search Skyscanner flights',
+        source: 'github:agentrhq/webcmd/skyscanner',
+      },
+      {
+        site: 'open-meteo',
+        description: 'Weather forecast commands',
+        source: 'github:agentrhq/webcmd/open-meteo',
+      },
+    ]);
+
+    expect(listAvailablePlugins(new Set(['skyscanner']), root).map(plugin => plugin.site)).toEqual(['open-meteo']);
+  });
+
+  it('uses a fresh remote catalog cache without fetching', async () => {
+    const packageRoot = writeCatalog([
+      {
+        site: 'bundled',
+        description: 'Bundled plugin',
+        source: 'github:agentrhq/webcmd/bundled',
+      },
+    ]);
+    const homeDir = makeTempDir('webcmd-plugin-catalog-home-');
+    const cacheDir = path.join(homeDir, '.webcmd');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, 'plugin-catalog-cache.json'), JSON.stringify({
+      catalogUrl: 'https://example.test/catalog.json',
+      fetchedAt: 1_000,
+      entries: [
+        {
+          site: 'remote',
+          description: 'Remote cached plugin',
+          source: 'github:agentrhq/webcmd/remote',
+          commands: ['hidden'],
+        },
+      ],
+    }));
+    const fetchImpl = vi.fn();
+
+    await expect(resolvePluginCatalog({
+      packageRoot,
+      homeDir,
+      catalogUrl: 'https://example.test/catalog.json',
+      fetchImpl,
+      now: 1_500,
+      ttlMs: 1_000,
+    })).resolves.toEqual([
+      {
+        site: 'remote',
+        description: 'Remote cached plugin',
+        source: 'github:agentrhq/webcmd/remote',
+      },
+    ]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('fetches and caches the remote catalog when cache is stale', async () => {
+    const packageRoot = writeCatalog([]);
+    const homeDir = makeTempDir('webcmd-plugin-catalog-home-');
+    const fetchImpl = vi.fn(async () => okJson([
+      {
+        site: 'new-plugin',
+        description: 'Fresh remote plugin',
+        source: 'github:agentrhq/webcmd/new-plugin',
+      },
+    ]));
+
+    const entries = await resolvePluginCatalog({
+      packageRoot,
+      homeDir,
+      catalogUrl: 'https://example.test/catalog.json',
+      fetchImpl,
+      now: 2_000,
+      ttlMs: 1_000,
+    });
+
+    expect(entries.map(entry => entry.site)).toEqual(['new-plugin']);
+    expect(fetchImpl).toHaveBeenCalledWith('https://example.test/catalog.json', expect.objectContaining({ headers: expect.any(Object) }));
+    const cached = JSON.parse(fs.readFileSync(path.join(homeDir, '.webcmd', 'plugin-catalog-cache.json'), 'utf-8'));
+    expect(cached).toMatchObject({
+      catalogUrl: 'https://example.test/catalog.json',
+      fetchedAt: 2_000,
+      entries,
+    });
+  });
+
+  it('falls back to the bundled catalog when remote fetch fails', async () => {
+    const packageRoot = writeCatalog([
+      {
+        site: 'bundled',
+        description: 'Bundled plugin',
+        source: 'github:agentrhq/webcmd/bundled',
+      },
+    ]);
+    const homeDir = makeTempDir('webcmd-plugin-catalog-home-');
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('offline');
+    });
+
+    await expect(resolvePluginCatalog({
+      packageRoot,
+      homeDir,
+      catalogUrl: 'https://example.test/catalog.json',
+      fetchImpl,
+      now: 2_000,
+      ttlMs: 1_000,
+    })).resolves.toEqual([
+      {
+        site: 'bundled',
+        description: 'Bundled plugin',
+        source: 'github:agentrhq/webcmd/bundled',
+      },
+    ]);
+  });
+});

--- a/src/plugin-catalog.ts
+++ b/src/plugin-catalog.ts
@@ -1,0 +1,170 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { findPackageRoot } from './package-paths.js';
+import { listPlugins } from './plugin.js';
+import { isRecord } from './utils.js';
+
+export const PLUGIN_CATALOG_FILENAME = 'plugin-catalog.json';
+export const PLUGIN_CATALOG_CACHE_FILENAME = 'plugin-catalog-cache.json';
+export const DEFAULT_PLUGIN_CATALOG_URL = 'https://raw.githubusercontent.com/agentrhq/webcmd/main/plugin-catalog.json';
+export const DEFAULT_PLUGIN_CATALOG_TTL_MS = 24 * 60 * 60 * 1000;
+
+const CATALOG_FILE = fileURLToPath(import.meta.url);
+
+export interface PluginCatalogEntry {
+  site: string;
+  description: string;
+  source: string;
+  homepage?: string;
+}
+
+type FetchResponseLike = {
+  ok: boolean;
+  json: () => Promise<unknown>;
+};
+
+type FetchLike = (url: string, init?: { headers?: Record<string, string> }) => Promise<FetchResponseLike>;
+
+interface ResolvePluginCatalogOptions {
+  packageRoot?: string;
+  homeDir?: string;
+  catalogUrl?: string;
+  fetchImpl?: FetchLike;
+  now?: number;
+  ttlMs?: number;
+}
+
+interface PluginCatalogCache {
+  catalogUrl: string;
+  fetchedAt: number;
+  entries: unknown[];
+}
+
+function normalizeCatalogEntry(value: unknown): PluginCatalogEntry | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.site !== 'string' || value.site.trim() === '') return null;
+  if (typeof value.description !== 'string' || value.description.trim() === '') return null;
+  if (typeof value.source !== 'string' || value.source.trim() === '') return null;
+
+  const entry: PluginCatalogEntry = {
+    site: value.site.trim(),
+    description: value.description.trim(),
+    source: value.source.trim(),
+  };
+  if (typeof value.homepage === 'string' && value.homepage.trim()) {
+    entry.homepage = value.homepage.trim();
+  }
+  return entry;
+}
+
+function normalizeCatalogEntries(parsed: unknown): PluginCatalogEntry[] {
+  if (!Array.isArray(parsed)) return [];
+
+  const bySite = new Map<string, PluginCatalogEntry>();
+  for (const raw of parsed) {
+    const entry = normalizeCatalogEntry(raw);
+    if (!entry) continue;
+    bySite.set(entry.site, entry);
+  }
+  return [...bySite.values()].sort((a, b) => a.site.localeCompare(b.site));
+}
+
+export function loadPluginCatalog(packageRoot = findPackageRoot(CATALOG_FILE)): PluginCatalogEntry[] {
+  const catalogPath = path.join(packageRoot, PLUGIN_CATALOG_FILENAME);
+  try {
+    return normalizeCatalogEntries(JSON.parse(fs.readFileSync(catalogPath, 'utf-8')));
+  } catch {
+    return [];
+  }
+}
+
+export function installedPluginNames(): Set<string> {
+  try {
+    return new Set(listPlugins().map(plugin => plugin.name));
+  } catch {
+    return new Set();
+  }
+}
+
+export function listAvailablePlugins(
+  installed = installedPluginNames(),
+  packageRoot = findPackageRoot(CATALOG_FILE),
+): PluginCatalogEntry[] {
+  return loadPluginCatalog(packageRoot).filter(plugin => !installed.has(plugin.site));
+}
+
+function getCatalogCachePath(homeDir: string): string {
+  return path.join(homeDir, '.webcmd', PLUGIN_CATALOG_CACHE_FILENAME);
+}
+
+function readFreshCachedCatalog(cachePath: string, catalogUrl: string, now: number, ttlMs: number): PluginCatalogEntry[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed)) return null;
+  if (parsed.catalogUrl !== catalogUrl) return null;
+  if (typeof parsed.fetchedAt !== 'number' || !Number.isFinite(parsed.fetchedAt)) return null;
+  if (now - parsed.fetchedAt > ttlMs) return null;
+  const entries = normalizeCatalogEntries(parsed.entries);
+  return entries.length > 0 || Array.isArray(parsed.entries) ? entries : null;
+}
+
+function writeCatalogCache(cachePath: string, cache: PluginCatalogCache): void {
+  try {
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    fs.writeFileSync(cachePath, JSON.stringify(cache, null, 2) + '\n', { mode: 0o600 });
+  } catch {
+    // Catalog caching is best-effort; webcmd list should still work offline.
+  }
+}
+
+async function fetchRemoteCatalog(catalogUrl: string, fetchImpl: FetchLike): Promise<PluginCatalogEntry[] | null> {
+  const response = await fetchImpl(catalogUrl, {
+    headers: {
+      accept: 'application/json',
+      'user-agent': 'webcmd-plugin-catalog',
+    },
+  });
+  if (!response.ok) return null;
+  const entries = normalizeCatalogEntries(await response.json());
+  return entries.length > 0 ? entries : null;
+}
+
+export async function resolvePluginCatalog(options: ResolvePluginCatalogOptions = {}): Promise<PluginCatalogEntry[]> {
+  const packageRoot = options.packageRoot ?? findPackageRoot(CATALOG_FILE);
+  const homeDir = options.homeDir ?? os.homedir();
+  const catalogUrl = options.catalogUrl ?? process.env.WEBCMD_PLUGIN_CATALOG_URL ?? DEFAULT_PLUGIN_CATALOG_URL;
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  const now = options.now ?? Date.now();
+  const ttlMs = options.ttlMs ?? DEFAULT_PLUGIN_CATALOG_TTL_MS;
+  const cachePath = getCatalogCachePath(homeDir);
+
+  const cached = readFreshCachedCatalog(cachePath, catalogUrl, now, ttlMs);
+  if (cached) return cached;
+
+  if (typeof fetchImpl === 'function') {
+    try {
+      const remote = await fetchRemoteCatalog(catalogUrl, fetchImpl as FetchLike);
+      if (remote) {
+        writeCatalogCache(cachePath, { catalogUrl, fetchedAt: now, entries: remote });
+        return remote;
+      }
+    } catch {
+      // Remote catalog updates are opportunistic; fall back to bundled metadata.
+    }
+  }
+
+  return loadPluginCatalog(packageRoot);
+}
+
+export async function listAvailablePluginsAsync(
+  installed = installedPluginNames(),
+  options: ResolvePluginCatalogOptions = {},
+): Promise<PluginCatalogEntry[]> {
+  return (await resolvePluginCatalog(options)).filter(plugin => !installed.has(plugin.site));
+}

--- a/webcmd-plugin.json
+++ b/webcmd-plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "webcmd",
+  "version": "0.2.0",
+  "description": "Webcmd plugin catalog",
+  "webcmd": ">=0.2.0",
+  "plugins": {
+    "skyscanner": {
+      "path": "plugins/skyscanner",
+      "version": "0.1.0",
+      "description": "Skyscanner flight search commands for Webcmd",
+      "webcmd": ">=0.2.0"
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds an in-repo plugin catalog and moves Skyscanner into the new `plugins/` layout so Webcmd can advertise installable plugins without shipping their source code in the npm package.

Also adds runtime catalog refresh from the Webcmd GitHub repo, with a local cache and bundled fallback, so new plugin listings can appear without requiring a new npm release.

Related issue:

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Adapter Notes

- [x] Updated generated or lean docs when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Checks run:

```bash
npm run typecheck
npx vitest run --project unit src/plugin-catalog.test.ts src/cli.test.ts
HOME=/private/tmp/webcmd-test-home.88P3sP npm test