### PR TITLE
Fix sitemap author skill frontmatter

### DIFF
--- a/skills/webcmd-sitemap-author/SKILL.md
+++ b/skills/webcmd-sitemap-author/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: webcmd-sitemap-author
-description: Use when creating or maintaining Webcmd site sitemaps: agent-facing navigation, page-state, action, workflow, API-reference, pitfall, and fallback knowledge for a website. Use after browser exploration discovers durable site context, when a sitemap is stale, or when promoting local site knowledge into the repo.
+description: 'Use when creating or maintaining Webcmd site sitemaps: agent-facing navigation, page-state, action, workflow, API-reference, pitfall, and fallback knowledge for a website. Use after browser exploration discovers durable site context, when a sitemap is stale, or when promoting local site knowledge into the repo.'
 allowed-tools: Bash(webcmd:*), Read, Edit, Write, Grep
 ---
 

--- a/src/skills.test.ts
+++ b/src/skills.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import yaml from 'js-yaml';
 import { describe, expect, it } from 'vitest';
 import { ArgumentError } from './errors.js';
 import { listWebcmdSkills, readWebcmdSkill } from './skills.js';
@@ -42,6 +43,20 @@ function makePackageRoot(): string {
 }
 
 describe('webcmd skills content', () => {
+  it('keeps bundled skill frontmatter valid yaml', () => {
+    const skillsRoot = path.join(process.cwd(), 'skills');
+    const skillNames = fs.readdirSync(skillsRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && entry.name.startsWith('webcmd-'))
+      .map((entry) => entry.name);
+
+    for (const name of skillNames) {
+      const content = fs.readFileSync(path.join(skillsRoot, name, 'SKILL.md'), 'utf8');
+      const end = content.indexOf('\n---', 4);
+      expect(end, name).toBeGreaterThan(0);
+      expect(() => yaml.load(content.slice(4, end)), name).not.toThrow();
+    }
+  });
+
   it('lists only webcmd-prefixed skills', () => {
     const root = makePackageRoot();
 


### PR DESCRIPTION
## Summary
- quote the webcmd-sitemap-author description so strict YAML parsers accept the skill frontmatter
- add a regression test that parses bundled webcmd-* skill frontmatter with js-yaml

## Verification
- npm test -- --run src/skills.test.ts
- npm run typecheck
- npm test
- npm run dev -- skills list -f json