### PR TITLE
Add Blinkit adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -2371,6 +2371,295 @@
     "sourceFile": "binance/trades.js"
   },
   {
+    "site": "blinkit",
+    "name": "add-to-cart",
+    "description": "Add a Blinkit product to cart",
+    "access": "write",
+    "domain": "blinkit.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "productId",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Blinkit product id"
+      },
+      {
+        "name": "quantity",
+        "type": "int",
+        "default": 1,
+        "required": false,
+        "help": "Quantity to add (default 1, max 12)"
+      },
+      {
+        "name": "lat",
+        "type": "str",
+        "required": false,
+        "help": "Delivery latitude (defaults to current Blinkit browser location)"
+      },
+      {
+        "name": "lon",
+        "type": "str",
+        "required": false,
+        "help": "Delivery longitude (defaults to current Blinkit browser location)"
+      }
+    ],
+    "columns": [
+      "status",
+      "productId",
+      "quantity",
+      "itemCount",
+      "itemsTotal",
+      "payable",
+      "message"
+    ],
+    "type": "js",
+    "modulePath": "blinkit/add-to-cart.js",
+    "sourceFile": "blinkit/add-to-cart.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "blinkit",
+    "name": "cart",
+    "description": "Show the current Blinkit cart",
+    "access": "read",
+    "domain": "blinkit.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "status",
+      "productId",
+      "name",
+      "variant",
+      "price",
+      "quantity",
+      "total",
+      "itemCount",
+      "payable",
+      "cartState"
+    ],
+    "type": "js",
+    "modulePath": "blinkit/cart.js",
+    "sourceFile": "blinkit/cart.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "blinkit",
+    "name": "checkout",
+    "description": "Review Blinkit checkout totals and blockers without placing an order",
+    "access": "read",
+    "domain": "blinkit.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "status",
+      "itemCount",
+      "itemsTotal",
+      "deliveryCharge",
+      "handlingCharge",
+      "payable",
+      "cartState",
+      "checkoutBlocked",
+      "validations"
+    ],
+    "type": "js",
+    "modulePath": "blinkit/checkout.js",
+    "sourceFile": "blinkit/checkout.js",
+    "navigateBefore": false,
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "blinkit",
+    "name": "location",
+    "description": "Show the selected Blinkit delivery location",
+    "access": "read",
+    "domain": "blinkit.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "selected",
+      "label",
+      "area",
+      "city",
+      "pincode",
+      "hasCoordinates",
+      "source"
+    ],
+    "type": "js",
+    "modulePath": "blinkit/location.js",
+    "sourceFile": "blinkit/location.js",
+    "navigateBefore": "https://blinkit.com"
+  },
+  {
+    "site": "blinkit",
+    "name": "login",
+    "description": "Open Blinkit login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "blinkit.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "phone",
+      "user_id"
+    ],
+    "type": "js",
+    "modulePath": "blinkit/auth.js",
+    "sourceFile": "blinkit/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "blinkit",
+    "name": "place-order",
+    "description": "Submit the visible Blinkit final order/payment action. Requires --confirm.",
+    "access": "write",
+    "domain": "blinkit.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "confirm",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Required acknowledgement that this may place/pay for a real order"
+      }
+    ],
+    "columns": [
+      "status",
+      "confirmed",
+      "itemCount",
+      "payable",
+      "orderId",
+      "url",
+      "message"
+    ],
+    "type": "js",
+    "modulePath": "blinkit/place-order.js",
+    "sourceFile": "blinkit/place-order.js",
+    "navigateBefore": false,
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "blinkit",
+    "name": "product",
+    "description": "Read Blinkit product details for a delivery location",
+    "access": "read",
+    "domain": "blinkit.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "productId",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Blinkit product id"
+      },
+      {
+        "name": "lat",
+        "type": "str",
+        "required": false,
+        "help": "Delivery latitude (defaults to current Blinkit browser location)"
+      },
+      {
+        "name": "lon",
+        "type": "str",
+        "required": false,
+        "help": "Delivery longitude (defaults to current Blinkit browser location)"
+      }
+    ],
+    "columns": [
+      "productId",
+      "name",
+      "brand",
+      "variant",
+      "price",
+      "mrp",
+      "currency",
+      "inventory",
+      "available",
+      "imageUrl",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "blinkit/product.js",
+    "sourceFile": "blinkit/product.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "blinkit",
+    "name": "search",
+    "description": "Search Blinkit products for a delivery location",
+    "access": "read",
+    "domain": "blinkit.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search keyword"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max results (max 48)"
+      },
+      {
+        "name": "lat",
+        "type": "str",
+        "required": false,
+        "help": "Delivery latitude (defaults to current Blinkit browser location)"
+      },
+      {
+        "name": "lon",
+        "type": "str",
+        "required": false,
+        "help": "Delivery longitude (defaults to current Blinkit browser location)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "productId",
+      "name",
+      "brand",
+      "variant",
+      "price",
+      "mrp",
+      "currency",
+      "inventory",
+      "available",
+      "imageUrl",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "blinkit/search.js",
+    "sourceFile": "blinkit/search.js",
+    "navigateBefore": false
+  },
+  {
     "site": "bloomberg",
     "name": "businessweek",
     "description": "Bloomberg Businessweek top stories",

--- a/clis/blinkit/add-to-cart.js
+++ b/clis/blinkit/add-to-cart.js
@@ -1,0 +1,123 @@
+import { CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import {
+  DOMAIN,
+  ensureCartHasItems,
+  openCartPanel,
+  parseQuantity,
+  readCartState,
+  requireProductId,
+  resolveCoordinates,
+  summarizeCartResponse,
+} from './utils.js';
+
+function buildCartItemEvaluate(productId, lat, lon) {
+  return `
+    (async () => {
+      const headers = { lat: ${JSON.stringify(lat)}, lon: ${JSON.stringify(lon)}, app_client: 'consumer_web' };
+      const resp = await fetch('/v1/layout/product/' + ${JSON.stringify(productId)}, { method: 'POST', credentials: 'include', headers });
+      const json = await resp.json().catch(() => null);
+      if (!resp.ok || !json) return { ok: false, status: resp.status };
+      const snippets = json?.response?.snippets || [];
+      const strip = snippets.find((snippet) => snippet?.widget_type === 'product_atc_strip')?.data || {};
+      const action = strip.stepper_data_v2?.increment_actions?.default?.find((item) => item?.add_to_cart)
+        || strip.rfc_actions_v2?.default?.find((item) => item?.remove_from_cart);
+      const cartItem = action?.add_to_cart?.cart_item || action?.remove_from_cart?.cart_item || null;
+      return [Boolean(cartItem), resp.status, cartItem, strip.inventory, strip.is_sold_out === true];
+    })()
+  `;
+}
+
+function buildWriteCartEvaluate(cartItem, quantity) {
+  return `
+    (() => {
+      const cartItem = ${JSON.stringify(cartItem)};
+      const quantity = ${quantity};
+      const readJson = (key, fallback) => {
+        try { return JSON.parse(localStorage.getItem(key) || 'null') || fallback; } catch { return fallback; }
+      };
+      const cart = readJson('cart', { count: 0, total: 0, chargeableDeliveryCost: 0, items: {}, promoInfo: [], paymentMode: null, step: [], version: 1, promo_id: '', CartAddressScreenVisible: false, uniqueSkuInCart: 0, cart_type: '', cart_state: 'invalid' });
+      const id = String(cartItem.product_id);
+      const current = cart.items?.[id]?.quantity || 0;
+      cart.items = cart.items || {};
+      cart.items[id] = {
+        product: {
+          product_id: cartItem.product_id,
+          price: cartItem.price,
+          image_url: cartItem.image_url,
+          unit: cartItem.unit,
+          mrp: cartItem.mrp,
+          group_id: cartItem.group_id,
+          merchant_id: cartItem.merchant_id,
+          name: cartItem.product_name || cartItem.display_name,
+          brand: cartItem.brand
+        },
+        quantity: current + quantity
+      };
+      const values = Object.values(cart.items);
+      cart.count = values.reduce((sum, item) => sum + Number(item.quantity || 0), 0);
+      cart.total = values.reduce((sum, item) => sum + Number(item.quantity || 0) * Number(item.product?.price || 0), 0);
+      cart.uniqueSkuInCart = values.length;
+      cart.version = 1;
+      localStorage.setItem('cart', JSON.stringify(cart));
+      window.__reduxStore__?.dispatch?.({ type: 'SYNC_CART', cart });
+      return [true, id, cart.items[id].quantity, cart.count, cart.total];
+    })()
+  `;
+}
+
+cli({
+  site: 'blinkit',
+  name: 'add-to-cart',
+  access: 'write',
+  description: 'Add a Blinkit product to cart',
+  domain: DOMAIN,
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  args: [
+    { name: 'productId', required: true, positional: true, help: 'Blinkit product id' },
+    { name: 'quantity', type: 'int', default: 1, help: 'Quantity to add (default 1, max 12)' },
+    { name: 'lat', help: 'Delivery latitude (defaults to current Blinkit browser location)' },
+    { name: 'lon', help: 'Delivery longitude (defaults to current Blinkit browser location)' },
+  ],
+  columns: ['status', 'productId', 'quantity', 'itemCount', 'itemsTotal', 'payable', 'message'],
+  func: async (page, kwargs) => {
+    const productId = requireProductId(kwargs.productId);
+    const quantity = parseQuantity(kwargs.quantity);
+
+    await page.goto(`https://blinkit.com/prn/x/prid/${productId}`).catch((error) => {
+      throw new CommandExecutionError(`blinkit add-to-cart navigation failed: ${error?.message || error}`);
+    });
+    const { lat, lon } = await resolveCoordinates(page, kwargs);
+    const found = await page.evaluate(buildCartItemEvaluate(productId, lat, lon)).catch((error) => {
+      throw new CommandExecutionError(`blinkit add-to-cart product read failed: ${error?.message || error}`);
+    });
+    const [foundOk, , cartItem, , soldOut] = Array.isArray(found) ? found : [];
+    if (!foundOk || !cartItem) throw new EmptyResultError('blinkit add-to-cart', `No cart payload for product ${productId}`);
+    if (soldOut) throw new CommandExecutionError(`Product ${productId} is sold out`);
+
+    const updated = await page.evaluate(buildWriteCartEvaluate(cartItem, quantity)).catch((error) => {
+      throw new CommandExecutionError(`blinkit add-to-cart write failed: ${error?.message || error}`);
+    });
+    const [updatedOk, , updatedQuantity] = Array.isArray(updated) ? updated : [];
+    if (!updatedOk) throw new CommandExecutionError(`Could not add product ${productId} to cart`);
+
+    await openCartPanel(page);
+    const summary = summarizeCartResponse(await readCartState(page));
+    ensureCartHasItems(summary);
+    return [{
+      status: 'added',
+      productId,
+      quantity: updatedQuantity,
+      itemCount: summary.itemCount,
+      itemsTotal: summary.itemsTotal,
+      payable: summary.payable,
+      message: `Added ${quantity}`,
+    }];
+  },
+});
+
+export const __test__ = {
+  buildWriteCartEvaluate,
+};

--- a/clis/blinkit/auth.js
+++ b/clis/blinkit/auth.js
@@ -1,0 +1,99 @@
+import { AuthRequiredError, TimeoutError } from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { BASE, DOMAIN } from './utils.js';
+
+const DEFAULT_TIMEOUT_SECONDS = 300;
+
+async function probeBlinkitIdentity(page) {
+  const probe = await page.evaluate(`
+    (() => {
+      const readJson = (key) => {
+        try { return JSON.parse(localStorage.getItem(key) || 'null'); } catch { return null; }
+      };
+      const state = window.__reduxStore__?.getState?.();
+      const auth = state?.data?.auth || readJson('auth') || {};
+      const user = state?.data?.user || readJson('user') || {};
+      const text = document.body.innerText || '';
+      if (!auth.accessToken && /^Login$/m.test(text)) return { kind: 'auth', detail: 'Blinkit login button is still visible' };
+      if (!auth.accessToken) return { kind: 'auth', detail: 'Blinkit auth access token missing' };
+      return {
+        ok: true,
+        phone: auth.phoneNumber || user.phone || user.profile?.phone || '',
+        user_id: user.id || user.user_id || user.profile?.id || ''
+      };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError(DOMAIN, probe.detail);
+  return { phone: probe?.phone || '', user_id: probe?.user_id || '' };
+}
+
+function buildOpenLoginEvaluate() {
+  return `
+    (() => {
+      const readJson = (key) => {
+        try { return JSON.parse(localStorage.getItem(key) || 'null'); } catch { return null; }
+      };
+      const state = window.__reduxStore__?.getState?.();
+      const auth = state?.data?.auth || readJson('auth') || {};
+      if (auth.accessToken) return { opened: false, detail: 'already_logged_in' };
+
+      const dialogText = document.querySelector('[role="dialog"]')?.innerText || '';
+      if (/Enter mobile number|Log in or Sign up/i.test(dialogText)) {
+        return { opened: true, detail: 'login_dialog_visible' };
+      }
+
+      const target = Array.from(document.querySelectorAll('button, [role="button"], a, div'))
+        .find((node) => (node.innerText || node.textContent || '').trim() === 'Login');
+      target?.dispatchEvent?.(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+      return { opened: Boolean(target), detail: target ? 'clicked_login' : 'login_button_missing' };
+    })()
+  `;
+}
+
+cli({
+  site: 'blinkit',
+  name: 'login',
+  access: 'write',
+  description: 'Open Blinkit login and wait until the browser session is authenticated',
+  domain: DOMAIN,
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  defaultWindowMode: 'foreground',
+  siteSession: 'persistent',
+  args: [
+    { name: 'timeout', type: 'int', default: DEFAULT_TIMEOUT_SECONDS, help: 'Maximum seconds to wait for the user to finish login' },
+  ],
+  columns: ['status', 'logged_in', 'phone', 'user_id'],
+  func: async (page, kwargs) => {
+    await page.goto(BASE);
+    await page.wait(1);
+    try {
+      const identity = await probeBlinkitIdentity(page);
+      return [{ status: 'already_logged_in', logged_in: true, ...identity }];
+    } catch (error) {
+      if (!(error instanceof AuthRequiredError)) throw error;
+    }
+
+    const opened = await page.evaluate(buildOpenLoginEvaluate()).catch(() => null);
+    const timeoutSeconds = Number(kwargs.timeout ?? DEFAULT_TIMEOUT_SECONDS);
+    const deadline = Date.now() + timeoutSeconds * 1000;
+    let lastMessage = opened?.opened ? '' : opened?.detail || '';
+    while (Date.now() < deadline) {
+      await page.wait(2);
+      try {
+        const identity = await probeBlinkitIdentity(page);
+        return [{ status: 'login_complete', logged_in: true, ...identity }];
+      } catch (error) {
+        if (!(error instanceof AuthRequiredError)) throw error;
+        lastMessage = error.message;
+      }
+    }
+    throw new TimeoutError('blinkit login', timeoutSeconds, lastMessage || 'Finish OTP login in the opened Blinkit tab and retry.');
+  },
+});
+
+export const __test__ = {
+  buildOpenLoginEvaluate,
+  probeBlinkitIdentity,
+};

--- a/clis/blinkit/blinkit.test.js
+++ b/clis/blinkit/blinkit.test.js
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import { ArgumentError } from '@agentrhq/webcmd/errors';
+import { getRegistry } from '@agentrhq/webcmd/registry';
+import { __test__ as authTest } from './auth.js';
+import { __test__ as searchTest } from './search.js';
+import { __test__ as productTest } from './product.js';
+import { __test__ as addToCartTest } from './add-to-cart.js';
+import { __test__ as placeOrderTest } from './place-order.js';
+import { normalizeLocationState, resolveCoordinates } from './utils.js';
+import './cart.js';
+import './checkout.js';
+import './location.js';
+
+describe('blinkit helpers', () => {
+  it('rejects invalid external args before browser work', () => {
+    expect(() => searchTest.parseLimit(0)).toThrow(ArgumentError);
+    expect(() => searchTest.parseLimit(49)).toThrow(ArgumentError);
+    expect(() => searchTest.parseCoordinate('91', 'lat', '28.413333')).toThrow(ArgumentError);
+    expect(() => searchTest.parseCoordinate('181', 'lon', '77.072833')).toThrow(ArgumentError);
+  });
+
+  it('normalizes product snippets from Blinkit layout search', () => {
+    const row = searchTest.normalizeSnippet({
+      widget_type: 'product_card_snippet_type_2',
+      data: {
+        identity: { id: '19512' },
+        name: { text: 'Amul Taaza Toned Milk' },
+        brand_name: { text: 'Amul' },
+        variant: { text: '500 ml' },
+        normal_price: { text: '₹30' },
+        inventory: 12,
+        merchant_id: '31719',
+        eta_tag: { title: { text: 'earliest' } },
+        image: { url: 'https://cdn.grofers.com/product.png' },
+      },
+    }, 1);
+
+    expect(row).toMatchObject({
+      rank: 1,
+      productId: '19512',
+      name: 'Amul Taaza Toned Milk',
+      brand: 'Amul',
+      variant: '500 ml',
+      price: 30,
+      currency: 'INR',
+      inventory: 12,
+      available: true,
+      url: 'https://blinkit.com/prn/x/prid/19512',
+    });
+  });
+
+  it('normalizes product detail snippets', () => {
+    const row = productTest.normalizeProduct([
+      { widget_type: 'text_right_icons_rating_snippet_type', data: { title: { text: 'Amul Taaza Toned Milk' } } },
+      {
+        widget_type: 'product_atc_strip',
+        data: {
+          identity: { id: '19512' },
+          variant: { text: '500 ml' },
+          normal_price: { text: '₹30' },
+          product_id: '19512',
+          stepper_data_v2: {
+            increment_actions: {
+              default: [{ add_to_cart: { cart_item: { product_id: 19512, product_name: 'Amul Taaza Toned Milk', price: 30, mrp: 30, unit: '500 ml' } } }],
+            },
+          },
+        },
+      },
+    ], '19512');
+    expect(row).toMatchObject({ productId: '19512', name: 'Amul Taaza Toned Milk', price: 30 });
+  });
+
+  it('keeps place-order no-op unless --confirm is passed', async () => {
+    const command = getRegistry().get('blinkit/place-order');
+    const fakePage = { goto: () => { throw new Error('should not navigate'); } };
+    await expect(command.func(fakePage, {})).resolves.toMatchObject([{ status: 'no-op', confirmed: false }]);
+  });
+
+  it('builds the cart write script from product payload', () => {
+    const script = addToCartTest.buildWriteCartEvaluate({ product_id: 19512, price: 30, mrp: 30, unit: '500 ml' }, 2);
+    expect(script).toContain('localStorage.setItem');
+    expect(script).toContain('SYNC_CART');
+  });
+
+  it('opens the Blinkit login dialog before waiting for OTP', () => {
+    const script = authTest.buildOpenLoginEvaluate();
+    expect(script).toContain('Login');
+    expect(script).toContain('click');
+    expect(script).toContain('Enter mobile number');
+  });
+
+  it('uses the current Blinkit browser location when coordinates are not explicit', async () => {
+    const page = {
+      evaluate: async () => ({ lat: 12.9110953, lon: 77.6292907 }),
+    };
+
+    await expect(resolveCoordinates(page, {})).resolves.toEqual({ lat: '12.9110953', lon: '77.6292907' });
+    await expect(resolveCoordinates(page, { lat: '1', lon: '2' })).resolves.toEqual({ lat: '1', lon: '2' });
+  });
+
+  it('normalizes selected location without leaking exact address or coordinates', () => {
+    expect(normalizeLocationState({
+      address: 'Block C-03 / 79, Private Building',
+      city: 'Bengaluru',
+      locality: 'HSR Layout',
+      pinCode: '560102',
+      coords: { lat: 12.9110953, lon: 77.6292907 },
+    })).toEqual({
+      selected: true,
+      label: '',
+      area: 'HSR Layout',
+      city: 'Bengaluru',
+      pincode: '560102',
+      hasCoordinates: true,
+      source: 'browser',
+    });
+  });
+
+  it('reports empty checkout instead of failing before items are added', async () => {
+    const command = getRegistry().get('blinkit/checkout');
+    let readCartState = false;
+    const fakePage = {
+      goto: async () => {},
+      wait: async () => {},
+      evaluate: async (script) => {
+        if (script.includes('loggedIn')) {
+          readCartState = true;
+          return {
+            ok: true,
+            loggedIn: true,
+            storedCart: { items: {}, count: 0, total: 0, cart_state: 'valid' },
+          };
+        }
+        if (script.includes('cartResponse')) return false;
+        return true;
+      },
+    };
+
+    await expect(command.func(fakePage, {})).resolves.toMatchObject([{ status: 'empty', itemCount: 0 }]);
+    expect(readCartState).toBe(true);
+  });
+});
+
+describe('blinkit registry shape', () => {
+  it('registers the buying-path commands', () => {
+    for (const name of ['login', 'location', 'search', 'product', 'add-to-cart', 'cart', 'checkout', 'place-order']) {
+      expect(getRegistry().get(`blinkit/${name}`)).toBeDefined();
+    }
+  });
+
+  it('marks only cart-changing commands as write', () => {
+    expect(getRegistry().get('blinkit/search').access).toBe('read');
+    expect(getRegistry().get('blinkit/product').access).toBe('read');
+    expect(getRegistry().get('blinkit/location').access).toBe('read');
+    expect(getRegistry().get('blinkit/cart').access).toBe('read');
+    expect(getRegistry().get('blinkit/checkout').access).toBe('read');
+    expect(getRegistry().get('blinkit/login').access).toBe('write');
+    expect(getRegistry().get('blinkit/add-to-cart').access).toBe('write');
+    expect(getRegistry().get('blinkit/place-order').access).toBe('write');
+  });
+
+  it('place-order script only targets final order/payment buttons', () => {
+    const script = placeOrderTest.buildPlaceOrderEvaluate();
+    expect(script).toContain('place order');
+    expect(script).toContain('cash on delivery');
+    expect(script).not.toContain('Proceed');
+  });
+});

--- a/clis/blinkit/cart.js
+++ b/clis/blinkit/cart.js
@@ -1,0 +1,34 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { DOMAIN, openCartPanel, readCartState, summarizeCartResponse } from './utils.js';
+
+cli({
+  site: 'blinkit',
+  name: 'cart',
+  access: 'read',
+  description: 'Show the current Blinkit cart',
+  domain: DOMAIN,
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  args: [],
+  columns: ['status', 'productId', 'name', 'variant', 'price', 'quantity', 'total', 'itemCount', 'payable', 'cartState'],
+  func: async (page) => {
+    await openCartPanel(page);
+    const summary = summarizeCartResponse(await readCartState(page));
+    if (!summary.items.length) {
+      return [{ status: 'empty', itemCount: 0, payable: summary.payable, cartState: summary.cartState }];
+    }
+    return summary.items.map((item) => ({
+      status: summary.status,
+      productId: item.productId,
+      name: item.name,
+      variant: item.variant,
+      price: item.price,
+      quantity: item.quantity,
+      total: item.total,
+      itemCount: summary.itemCount,
+      payable: summary.payable,
+      cartState: summary.cartState,
+    }));
+  },
+});

--- a/clis/blinkit/checkout.js
+++ b/clis/blinkit/checkout.js
@@ -1,0 +1,32 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { DOMAIN, openCartPanel, readCartState, summarizeCartResponse } from './utils.js';
+
+cli({
+  site: 'blinkit',
+  name: 'checkout',
+  access: 'read',
+  description: 'Review Blinkit checkout totals and blockers without placing an order',
+  domain: DOMAIN,
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  defaultWindowMode: 'foreground',
+  args: [],
+  columns: ['status', 'itemCount', 'itemsTotal', 'deliveryCharge', 'handlingCharge', 'payable', 'cartState', 'checkoutBlocked', 'validations'],
+  func: async (page) => {
+    await openCartPanel(page);
+    const state = await readCartState(page);
+    const summary = summarizeCartResponse(state);
+    return [{
+      status: state.loggedIn ? summary.status : 'login_required',
+      itemCount: summary.itemCount,
+      itemsTotal: summary.itemsTotal,
+      deliveryCharge: summary.deliveryCharge,
+      handlingCharge: summary.handlingCharge,
+      payable: summary.payable,
+      cartState: summary.cartState,
+      checkoutBlocked: summary.checkoutBlocked,
+      validations: summary.validations,
+    }];
+  },
+});

--- a/clis/blinkit/location.js
+++ b/clis/blinkit/location.js
@@ -1,0 +1,29 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { DOMAIN, gotoBlinkit, normalizeLocationState } from './utils.js';
+
+const LOCATION_EVALUATE = `
+  (() => {
+    const readJson = (key) => {
+      try { return JSON.parse(localStorage.getItem(key) || 'null'); } catch { return null; }
+    };
+    return window.__reduxStore__?.getState?.()?.data?.location || readJson('location') || {};
+  })()
+`;
+
+cli({
+  site: 'blinkit',
+  name: 'location',
+  access: 'read',
+  description: 'Show the selected Blinkit delivery location',
+  domain: DOMAIN,
+  strategy: Strategy.COOKIE,
+  browser: true,
+  args: [],
+  columns: ['selected', 'label', 'area', 'city', 'pincode', 'hasCoordinates', 'source'],
+  func: async (page) => {
+    await gotoBlinkit(page, '/');
+    if (page.wait) await page.wait(1);
+    return [normalizeLocationState(await page.evaluate(LOCATION_EVALUATE))];
+  },
+});
+

--- a/clis/blinkit/place-order.js
+++ b/clis/blinkit/place-order.js
@@ -1,0 +1,78 @@
+import { ArgumentError, CommandExecutionError } from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { DOMAIN, ensureCartHasItems, ensureLoggedIn, openCartPanel, readCartState, summarizeCartResponse } from './utils.js';
+
+function buildPlaceOrderEvaluate() {
+  return `
+    (async () => {
+      const finalLabels = [/^place order$/i, /^pay( now)?$/i, /^cash on delivery$/i];
+      const buttons = Array.from(document.querySelectorAll('button, [role="button"], a'));
+      const target = buttons.find((node) => {
+        const text = (node.innerText || node.textContent || '').trim().replace(/\\s+/g, ' ');
+        return text && finalLabels.some((pattern) => pattern.test(text));
+      });
+      if (!target) {
+        return { ok: false, status: 'blocked', message: 'No final place-order/payment button is visible. Complete address/payment selection in the browser checkout first.' };
+      }
+      target.click();
+      await new Promise((resolve) => setTimeout(resolve, 3500));
+      const text = document.body.innerText || '';
+      const orderMatch = text.match(/order(?:\\s+id)?[:#\\s-]*([A-Z0-9-]{6,})/i);
+      if (/payment failed|try again|could not/i.test(text)) {
+        return { ok: false, status: 'failed', message: 'Blinkit reported a payment/order failure', url: location.href };
+      }
+      return { ok: true, status: orderMatch ? 'placed' : 'submitted', orderId: orderMatch?.[1] || '', url: location.href };
+    })()
+  `;
+}
+
+cli({
+  site: 'blinkit',
+  name: 'place-order',
+  access: 'write',
+  description: 'Submit the visible Blinkit final order/payment action. Requires --confirm.',
+  domain: DOMAIN,
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  defaultWindowMode: 'foreground',
+  args: [
+    { name: 'confirm', type: 'bool', default: false, help: 'Required acknowledgement that this may place/pay for a real order' },
+  ],
+  columns: ['status', 'confirmed', 'itemCount', 'payable', 'orderId', 'url', 'message'],
+  func: async (page, kwargs) => {
+    if (!kwargs.confirm) {
+      return [{
+        status: 'no-op',
+        confirmed: false,
+        message: 'Pass --confirm to submit a real Blinkit order/payment action.',
+      }];
+    }
+    if (kwargs.confirm !== true) throw new ArgumentError('--confirm must be a boolean flag');
+
+    await openCartPanel(page);
+    const state = await readCartState(page);
+    ensureLoggedIn(state, 'blinkit place-order');
+    const summary = summarizeCartResponse(state);
+    ensureCartHasItems(summary);
+    if (summary.checkoutBlocked) throw new CommandExecutionError('Blinkit checkout is blocked for this cart');
+
+    const result = await page.evaluate(buildPlaceOrderEvaluate()).catch((error) => {
+      throw new CommandExecutionError(`blinkit place-order failed: ${error?.message || error}`);
+    });
+    if (!result?.status) throw new CommandExecutionError('blinkit place-order returned no status');
+    return [{
+      status: result.status,
+      confirmed: true,
+      itemCount: summary.itemCount,
+      payable: summary.payable,
+      orderId: result.orderId || '',
+      url: result.url || '',
+      message: result.message || '',
+    }];
+  },
+});
+
+export const __test__ = {
+  buildPlaceOrderEvaluate,
+};

--- a/clis/blinkit/product.js
+++ b/clis/blinkit/product.js
@@ -1,0 +1,63 @@
+import { CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { DOMAIN, normalizeProductSnippet, requireProductId, resolveCoordinates } from './utils.js';
+
+function buildProductEvaluate(productId, lat, lon) {
+  return `
+    (async () => {
+      const headers = { lat: ${JSON.stringify(lat)}, lon: ${JSON.stringify(lon)}, app_client: 'consumer_web' };
+      const resp = await fetch('/v1/layout/product/' + ${JSON.stringify(productId)}, { method: 'POST', credentials: 'include', headers });
+      const raw = await resp.text();
+      let json;
+      try { json = JSON.parse(raw); } catch { return { ok: false, status: resp.status, error: raw.slice(0, 200) }; }
+      if (!resp.ok || json.error) return { ok: false, status: resp.status, error: json.error || json.message || raw.slice(0, 200) };
+      return { ok: true, snippets: json?.response?.snippets || [] };
+    })()
+  `;
+}
+
+function normalizeProduct(snippets, productId) {
+  const title = snippets.find((snippet) => snippet?.widget_type === 'text_right_icons_rating_snippet_type');
+  const strip = snippets.find((snippet) => snippet?.widget_type === 'product_atc_strip');
+  const row = normalizeProductSnippet(strip) ?? normalizeProductSnippet(title);
+  if (!row) return null;
+  const titleText = title?.data?.title?.text;
+  return { ...row, productId, name: titleText || row.name };
+}
+
+cli({
+  site: 'blinkit',
+  name: 'product',
+  access: 'read',
+  description: 'Read Blinkit product details for a delivery location',
+  domain: DOMAIN,
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  args: [
+    { name: 'productId', required: true, positional: true, help: 'Blinkit product id' },
+    { name: 'lat', help: 'Delivery latitude (defaults to current Blinkit browser location)' },
+    { name: 'lon', help: 'Delivery longitude (defaults to current Blinkit browser location)' },
+  ],
+  columns: ['productId', 'name', 'brand', 'variant', 'price', 'mrp', 'currency', 'inventory', 'available', 'imageUrl', 'url'],
+  func: async (page, kwargs) => {
+    const productId = requireProductId(kwargs.productId);
+    await page.goto(`https://blinkit.com/prn/x/prid/${productId}`).catch((error) => {
+      throw new CommandExecutionError(`blinkit product navigation failed: ${error?.message || error}`);
+    });
+    const { lat, lon } = await resolveCoordinates(page, kwargs);
+    const result = await page.evaluate(buildProductEvaluate(productId, lat, lon)).catch((error) => {
+      throw new CommandExecutionError(`blinkit product request failed: ${error?.message || error}`);
+    });
+    if (!result?.ok) {
+      throw new CommandExecutionError(`blinkit product failed: HTTP ${result?.status ?? 'unknown'} ${result?.error ?? ''}`.trim());
+    }
+    const row = normalizeProduct(result.snippets ?? [], productId);
+    if (!row) throw new EmptyResultError('blinkit product', `No product data for ${productId}`);
+    return [row];
+  },
+});
+
+export const __test__ = {
+  normalizeProduct,
+};

--- a/clis/blinkit/search.js
+++ b/clis/blinkit/search.js
@@ -1,0 +1,89 @@
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { BASE, MAX_LIMIT, normalizeProductSnippet, parseCoordinate, parseLimit, parsePrice, resolveCoordinates } from './utils.js';
+
+function buildSearchEvaluate(query, limit, lat, lon) {
+  return `
+    (async () => {
+      const query = ${JSON.stringify(query)};
+      const limit = ${limit};
+      const headers = {
+        lat: ${JSON.stringify(lat)},
+        lon: ${JSON.stringify(lon)},
+        app_client: 'consumer_web'
+      };
+      const rows = [];
+      let url = '/v1/layout/search?q=' + encodeURIComponent(query) + '&search_type=type_to_search';
+
+      for (let page = 0; url && rows.length < limit && page < 8; page += 1) {
+        const resp = await fetch(url, { method: 'POST', credentials: 'include', headers });
+        const raw = await resp.text();
+        let json;
+        try {
+          json = JSON.parse(raw);
+        } catch {
+          return { ok: false, status: resp.status, error: raw.slice(0, 200) };
+        }
+        if (!resp.ok || json.error) {
+          return { ok: false, status: resp.status, error: json.error || json.message || raw.slice(0, 200) };
+        }
+        const snippets = Array.isArray(json?.response?.snippets) ? json.response.snippets : [];
+        rows.push(...snippets.filter((snippet) => snippet?.widget_type === 'product_card_snippet_type_2'));
+        url = json?.response?.pagination?.next_url || '';
+      }
+
+      return { ok: true, rows: rows.slice(0, limit) };
+    })()
+  `;
+}
+
+cli({
+  site: 'blinkit',
+  name: 'search',
+  access: 'read',
+  description: 'Search Blinkit products for a delivery location',
+  domain: 'blinkit.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  args: [
+    { name: 'query', required: true, positional: true, help: 'Search keyword' },
+    { name: 'limit', type: 'int', default: 20, help: `Max results (max ${MAX_LIMIT})` },
+    { name: 'lat', help: 'Delivery latitude (defaults to current Blinkit browser location)' },
+    { name: 'lon', help: 'Delivery longitude (defaults to current Blinkit browser location)' },
+  ],
+  columns: ['rank', 'productId', 'name', 'brand', 'variant', 'price', 'mrp', 'currency', 'inventory', 'available', 'imageUrl', 'url'],
+  func: async (page, kwargs) => {
+    const query = String(kwargs.query ?? '').trim();
+    if (!query) throw new ArgumentError('query cannot be empty');
+
+    const limit = parseLimit(kwargs.limit);
+    const pageUrl = `${BASE}/s/?q=${encodeURIComponent(query)}`;
+    await page.goto(pageUrl).catch((error) => {
+      throw new CommandExecutionError(`blinkit search navigation failed: ${error?.message || error}`);
+    });
+    const { lat, lon } = await resolveCoordinates(page, kwargs);
+
+    const result = await page.evaluate(buildSearchEvaluate(query, limit, lat, lon)).catch((error) => {
+      throw new CommandExecutionError(`blinkit search request failed: ${error?.message || error}`);
+    });
+    if (!result?.ok) {
+      throw new CommandExecutionError(`blinkit search failed: HTTP ${result?.status ?? 'unknown'} ${result?.error ?? ''}`.trim());
+    }
+
+    const rows = (result.rows ?? [])
+      .map((snippet, index) => normalizeProductSnippet(snippet, index + 1))
+      .filter(Boolean);
+    if (!rows.length) {
+      throw new EmptyResultError('blinkit search', `No products matched "${query}" at ${lat},${lon}`);
+    }
+    return rows;
+  },
+});
+
+export const __test__ = {
+  normalizeSnippet: normalizeProductSnippet,
+  parseCoordinate,
+  parseLimit,
+  parsePrice,
+};

--- a/clis/blinkit/utils.js
+++ b/clis/blinkit/utils.js
@@ -1,0 +1,223 @@
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+
+export const BASE = 'https://blinkit.com';
+export const DOMAIN = 'blinkit.com';
+export const DEFAULT_LAT = '28.413333';
+export const DEFAULT_LON = '77.072833';
+export const MAX_LIMIT = 48;
+
+export function parseLimit(raw) {
+  if (raw === undefined || raw === null || raw === '') return 20;
+  const limit = Number(raw);
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    throw new ArgumentError(`--limit must be an integer between 1 and ${MAX_LIMIT}`);
+  }
+  return limit;
+}
+
+export function parseQuantity(raw) {
+  const quantity = raw === undefined || raw === null || raw === '' ? 1 : Number(raw);
+  if (!Number.isInteger(quantity) || quantity < 1 || quantity > 12) {
+    throw new ArgumentError('--quantity must be an integer between 1 and 12');
+  }
+  return quantity;
+}
+
+export function parseCoordinate(raw, label, fallback) {
+  const value = raw === undefined || raw === null || raw === '' ? fallback : String(raw);
+  const n = Number(value);
+  const max = label === 'lat' ? 90 : 180;
+  if (!Number.isFinite(n) || n < -max || n > max) {
+    throw new ArgumentError(`--${label} must be a number between ${-max} and ${max}`);
+  }
+  return String(n);
+}
+
+export async function resolveCoordinates(page, kwargs = {}) {
+  const explicitLat = kwargs.lat !== undefined && kwargs.lat !== null && kwargs.lat !== '';
+  const explicitLon = kwargs.lon !== undefined && kwargs.lon !== null && kwargs.lon !== '';
+  const location = explicitLat && explicitLon ? null : await page.evaluate(`
+    (() => {
+      const readJson = (key) => {
+        try { return JSON.parse(localStorage.getItem(key) || 'null'); } catch { return null; }
+      };
+      const coords = window.__reduxStore__?.getState?.()?.data?.location?.coords || readJson('location')?.coords || {};
+      return { lat: coords.lat, lon: coords.lon };
+    })()
+  `).catch(() => null);
+  return {
+    lat: parseCoordinate(explicitLat ? kwargs.lat : location?.lat, 'lat', DEFAULT_LAT),
+    lon: parseCoordinate(explicitLon ? kwargs.lon : location?.lon, 'lon', DEFAULT_LON),
+  };
+}
+
+export function normalizeLocationState(location = {}) {
+  const coords = location.coords || {};
+  return {
+    selected: Boolean(location.locality || location.area || location.city || location.pinCode || location.pincode || coords.lat || coords.lon),
+    label: String(location.label || location.name || location.type || '').trim(),
+    area: String(location.locality || location.area || location.landmark || '').trim(),
+    city: String(location.city || location.cityName || '').trim(),
+    pincode: String(location.pinCode || location.pincode || location.pin || '').trim(),
+    hasCoordinates: Boolean(coords.lat || coords.lon),
+    source: 'browser',
+  };
+}
+
+export function requireProductId(raw) {
+  const value = String(raw ?? '').trim();
+  const match = value.match(/(?:prid\/)?(\d{3,})$/) || value.match(/\/prid\/(\d{3,})/);
+  if (!match) throw new ArgumentError('productId must be a Blinkit product id, for example 19512');
+  return match[1];
+}
+
+export function parsePrice(text) {
+  const match = String(text ?? '').replace(/,/g, '').match(/(\d+(?:\.\d+)?)/);
+  return match ? Number(match[1]) : null;
+}
+
+export function text(node) {
+  return String(node?.text ?? '').trim();
+}
+
+export function productUrl(productId) {
+  return productId ? `${BASE}/prn/x/prid/${productId}` : '';
+}
+
+export function normalizeProductSnippet(snippet, rank = undefined) {
+  const data = snippet?.data ?? {};
+  const cart = data.atc_action?.add_to_cart?.cart_item
+    ?? data.stepper_data_v2?.increment_actions?.default?.find((action) => action?.add_to_cart)?.add_to_cart?.cart_item
+    ?? data.rfc_actions_v2?.default?.find((action) => action?.remove_from_cart)?.remove_from_cart?.cart_item
+    ?? {};
+  const productId = String(data.product_id ?? data.meta?.product_id ?? cart.product_id ?? data.identity?.id ?? '').trim();
+  const name = text(data.display_name) || text(data.name) || text(data.title) || String(cart.product_name ?? cart.display_name ?? '').trim();
+  if (!productId || !name) return null;
+
+  const price = cart.price ?? parsePrice(text(data.normal_price) || text(data.info_text));
+  const mrp = cart.mrp ?? parsePrice(text(data.mrp));
+  return {
+    ...(rank === undefined ? {} : { rank }),
+    productId,
+    name,
+    brand: text(data.brand_name) || String(cart.brand ?? '').trim(),
+    variant: text(data.variant) || String(cart.unit ?? '').trim(),
+    price: Number.isFinite(Number(price)) ? Number(price) : null,
+    mrp: Number.isFinite(Number(mrp)) ? Number(mrp) : null,
+    currency: 'INR',
+    inventory: Number.isFinite(Number(data.inventory ?? cart.inventory)) ? Number(data.inventory ?? cart.inventory) : null,
+    available: data.is_sold_out === true ? false : data.product_state !== 'unavailable',
+    imageUrl: data.image?.url || cart.image_url || '',
+    url: productUrl(productId),
+  };
+}
+
+export function normalizeCartItem(item, fallbackId = '') {
+  const product = item?.product ?? item ?? {};
+  const productId = String(product.product_id ?? item?.product_id ?? fallbackId ?? '').trim();
+  const quantity = Number(item?.quantity ?? product.quantity ?? 0);
+  if (!productId || !quantity) return null;
+  const price = Number(product.price ?? product.unit_price ?? parsePrice(product.total_price));
+  return {
+    productId,
+    name: String(product.name ?? product.product_name ?? product.display_name ?? '').trim(),
+    variant: String(product.unit ?? '').trim(),
+    price: Number.isFinite(price) ? price : null,
+    quantity,
+    total: Number.isFinite(price) ? price * quantity : null,
+    inventory: Number.isFinite(Number(product.inventory_limit ?? product.inventory)) ? Number(product.inventory_limit ?? product.inventory) : null,
+    merchantId: String(product.merchant_id ?? '').trim(),
+    imageUrl: product.image_url || product.image_url_v2 || product.png_image_url || '',
+  };
+}
+
+export function summarizeCartResponse(response) {
+  const cartData = response?.cart_data ?? {};
+  const bill = cartData.bill_details ?? {};
+  const items = Array.isArray(cartData.items)
+    ? cartData.items.map((item) => normalizeCartItem(item)).filter(Boolean)
+    : [];
+  const storedItems = response?.storedCart?.items && typeof response.storedCart.items === 'object'
+    ? Object.entries(response.storedCart.items).map(([id, item]) => normalizeCartItem(item, id)).filter(Boolean)
+    : [];
+  const finalItems = items.length ? items : storedItems;
+  return {
+    status: finalItems.length ? 'ok' : 'empty',
+    itemCount: Number(bill.total_items ?? response?.storedCart?.count ?? finalItems.reduce((sum, item) => sum + item.quantity, 0) ?? 0),
+    itemsTotal: Number(bill.total_cost ?? response?.storedCart?.total ?? 0),
+    deliveryCharge: Number(bill.delivery_charge ?? 0),
+    handlingCharge: Number(bill.additional_charge ?? 0),
+    payable: Number(bill.payable_amount ?? bill.bill_total ?? response?.storedCart?.total ?? 0),
+    cartState: response?.cart_state ?? cartData.cart_state ?? response?.storedCart?.cart_state ?? '',
+    checkoutBlocked: Boolean(cartData.checkout_block_details),
+    validations: (cartData.validations ?? []).map((validation) => validation?.code).filter(Boolean).join(','),
+    items: finalItems,
+  };
+}
+
+export async function gotoBlinkit(page, path = '/') {
+  await page.goto(`${BASE}${path}`).catch((error) => {
+    throw new CommandExecutionError(`blinkit navigation failed: ${error?.message || error}`);
+  });
+}
+
+export async function openCartPanel(page) {
+  await gotoBlinkit(page, '/');
+  await page.wait(1);
+  await page.evaluate(`
+    (() => {
+      const nodes = Array.from(document.querySelectorAll('[role="button"], header div, header button, header a'));
+      const target = nodes
+        .filter((node) => {
+          const value = node.innerText || node.textContent || '';
+          return /My Cart/i.test(value) || (/\\d+\\s+items?/i.test(value) && /₹\\s*\\d+/i.test(value));
+        })
+        .sort((a, b) => (a.innerText || a.textContent || '').length - (b.innerText || b.textContent || '').length)[0];
+      target?.dispatchEvent?.(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+      return Boolean(target);
+    })()
+  `).catch((error) => {
+    throw new CommandExecutionError(`blinkit cart open failed: ${error?.message || error}`);
+  });
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    await page.wait(1);
+    const ready = await page.evaluate(`
+      (() => Boolean(window.__reduxStore__?.getState?.()?.ui?.cart?.cartScreen?.cartResponse?.cart_data))
+    `).catch(() => false);
+    if (ready) return;
+  }
+}
+
+export async function readCartState(page) {
+  const result = await page.evaluate(`
+    (() => {
+      const readJson = (key) => {
+        try { return JSON.parse(localStorage.getItem(key) || 'null'); } catch { return null; }
+      };
+      const state = window.__reduxStore__?.getState?.();
+      const response = state?.ui?.cart?.cartScreen?.cartResponse || null;
+      return {
+        ok: true,
+        loggedIn: !/^Login$/m.test(document.body.innerText || '') && Boolean(readJson('auth')?.accessToken || state?.data?.auth?.accessToken),
+        response,
+        storedCart: state?.data?.cart || readJson('cart') || null,
+        checkout: state?.ui?.checkout || readJson('checkout') || null,
+        location: state?.data?.location || readJson('location') || null,
+      };
+    })()
+  `).catch((error) => {
+    throw new CommandExecutionError(`blinkit cart state read failed: ${error?.message || error}`);
+  });
+  if (!result?.ok) throw new CommandExecutionError('blinkit cart state read failed');
+  return result;
+}
+
+export function ensureLoggedIn(state, action = 'Blinkit command') {
+  if (!state?.loggedIn) {
+    throw new AuthRequiredError(DOMAIN, `${action} requires a logged-in Blinkit browser session. Run webcmd blinkit login first.`);
+  }
+}
+
+export function ensureCartHasItems(summary) {
+  if (!summary.itemCount) throw new EmptyResultError('blinkit cart', 'Cart is empty');
+}


### PR DESCRIPTION
## Summary
- Add a Blinkit adapter with the seven-command buying path: `login`, `search`, `product`, `add-to-cart`, `cart`, `checkout`, and `place-order`.
- Share Blinkit parsing/cart helpers across commands and regenerate `cli-manifest.json`.
- Gate `place-order` behind `--confirm`; without it, the command returns a no-op row and touches no order/payment action.

## Validation
- `npm run test:adapter -- clis/blinkit/blinkit.test.js`
- `npm run typecheck`
- `npm run dev -- validate`
- `npm run dev -- blinkit --help -f yaml` confirms `command_count: 7`
- Live smoke tested `search`, `product`, `add-to-cart`, `cart`, `checkout`, and `place-order` without `--confirm`

## Notes
- Did not live-run `place-order --confirm` because it can place/pay for a real Blinkit order.
- Successful OTP login still requires a real user interaction in the opened browser session.
