### PR TITLE
Add BigBasket adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -2024,6 +2024,228 @@
     "sourceFile": "bbc/topic.js"
   },
   {
+    "site": "bigbasket",
+    "name": "add-to-cart",
+    "description": "Add a BigBasket product to cart",
+    "access": "write",
+    "domain": "www.bigbasket.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "product",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Product ID or URL"
+      },
+      {
+        "name": "quantity",
+        "type": "int",
+        "default": 1,
+        "required": false,
+        "help": "Quantity to add (max 20)"
+      }
+    ],
+    "columns": [
+      "ok",
+      "product_id",
+      "quantity",
+      "url",
+      "message"
+    ],
+    "type": "js",
+    "modulePath": "bigbasket/add-to-cart.js",
+    "sourceFile": "bigbasket/add-to-cart.js",
+    "navigateBefore": "https://www.bigbasket.com"
+  },
+  {
+    "site": "bigbasket",
+    "name": "cart",
+    "description": "Read BigBasket cart line items",
+    "access": "read",
+    "domain": "www.bigbasket.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "product_id",
+      "title",
+      "quantity",
+      "price",
+      "line_total",
+      "availability",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "bigbasket/cart.js",
+    "sourceFile": "bigbasket/cart.js",
+    "navigateBefore": "https://www.bigbasket.com"
+  },
+  {
+    "site": "bigbasket",
+    "name": "category",
+    "description": "Read BigBasket category product cards",
+    "access": "read",
+    "domain": "www.bigbasket.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "category",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Category URL or slug"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Maximum products to return (max 50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "product_id",
+      "title",
+      "brand",
+      "pack_size",
+      "price",
+      "mrp",
+      "discount",
+      "availability",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "bigbasket/category.js",
+    "sourceFile": "bigbasket/category.js",
+    "navigateBefore": "https://www.bigbasket.com"
+  },
+  {
+    "site": "bigbasket",
+    "name": "checkout",
+    "description": "Open BigBasket checkout review without placing an order",
+    "access": "write",
+    "domain": "www.bigbasket.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "ok",
+      "stage",
+      "cart_total",
+      "address_ready",
+      "delivery_ready",
+      "payment_ready",
+      "next_action",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "bigbasket/checkout.js",
+    "sourceFile": "bigbasket/checkout.js",
+    "navigateBefore": "https://www.bigbasket.com"
+  },
+  {
+    "site": "bigbasket",
+    "name": "location",
+    "description": "Show the selected BigBasket delivery location",
+    "access": "read",
+    "domain": "www.bigbasket.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "selected",
+      "label",
+      "area",
+      "city",
+      "pincode",
+      "source"
+    ],
+    "type": "js",
+    "modulePath": "bigbasket/location.js",
+    "sourceFile": "bigbasket/location.js",
+    "navigateBefore": "https://www.bigbasket.com"
+  },
+  {
+    "site": "bigbasket",
+    "name": "product",
+    "description": "Read BigBasket product details",
+    "access": "read",
+    "domain": "www.bigbasket.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "product",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Product ID or URL"
+      }
+    ],
+    "columns": [
+      "product_id",
+      "title",
+      "brand",
+      "pack_size",
+      "price",
+      "mrp",
+      "discount",
+      "availability",
+      "delivery",
+      "image_url",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "bigbasket/product.js",
+    "sourceFile": "bigbasket/product.js",
+    "navigateBefore": "https://www.bigbasket.com"
+  },
+  {
+    "site": "bigbasket",
+    "name": "search",
+    "description": "Search BigBasket products",
+    "access": "read",
+    "domain": "www.bigbasket.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search query"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Maximum products to return (max 50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "product_id",
+      "title",
+      "brand",
+      "pack_size",
+      "price",
+      "mrp",
+      "discount",
+      "availability",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "bigbasket/search.js",
+    "sourceFile": "bigbasket/search.js",
+    "navigateBefore": "https://www.bigbasket.com"
+  },
+  {
     "site": "binance",
     "name": "asks",
     "description": "Order book ask prices for a trading pair",

--- a/clis/bigbasket/add-to-cart.js
+++ b/clis/bigbasket/add-to-cart.js
@@ -1,0 +1,82 @@
+import { CommandExecutionError } from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { DOMAIN, parseQuantityArg, resolveProductInput, safeGoto, SITE } from './utils.js';
+
+function addToCartEvaluate(productId, quantity) {
+  return `
+    (async () => {
+      const productId = ${JSON.stringify(productId)};
+      const quantity = ${Number(quantity) || 1};
+      const clean = (value) => value == null ? '' : String(value).replace(/\\s+/g, ' ').trim();
+      const text = clean(document.body?.innerText || '');
+      if (/select\\s+(?:size|weight|pack|option)|choose\\s+(?:size|weight|pack|option)/i.test(text)) {
+        return { ok: false, message: 'OPTION_REQUIRED' };
+      }
+
+      const quantityInput = document.querySelector('input[type="number"], input[aria-label*="quantity" i]');
+      if (quantityInput && quantity > 1) {
+        quantityInput.value = String(quantity);
+        quantityInput.dispatchEvent(new Event('input', { bubbles: true }));
+        quantityInput.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+
+      const buttons = Array.from(document.querySelectorAll('button, [role="button"], a'));
+      const button = buttons.find((node) => {
+        const label = clean(node.textContent || node.getAttribute('aria-label') || node.getAttribute('title'));
+        return /^(add|add to basket|add to cart|basket)$/i.test(label) || /add\\s*(to)?\\s*(basket|cart)/i.test(label);
+      });
+      if (!button) return { ok: false, message: 'ADD_BUTTON_NOT_FOUND' };
+      button.click();
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      const afterText = clean(document.body?.innerText || '');
+      const ok = /added|basket|cart/i.test(afterText) && !/failed|error/i.test(afterText);
+      return {
+        ok,
+        message: ok ? 'SUCCESS' : 'UNCONFIRMED',
+        product_id: productId,
+        url: location.href,
+      };
+    })()
+  `;
+}
+
+cli({
+  site: SITE,
+  name: 'add-to-cart',
+  access: 'write',
+  description: 'Add a BigBasket product to cart',
+  domain: DOMAIN,
+  strategy: Strategy.COOKIE,
+  browser: true,
+  args: [
+    { name: 'product', required: true, positional: true, help: 'Product ID or URL' },
+    { name: 'quantity', type: 'int', default: 1, help: 'Quantity to add (max 20)' },
+  ],
+  columns: ['ok', 'product_id', 'quantity', 'url', 'message'],
+  func: async (page, kwargs) => {
+    const product = resolveProductInput(kwargs.product);
+    const quantity = parseQuantityArg(kwargs.quantity, 1, 20);
+    await safeGoto(page, product.url, 'bigbasket add-to-cart');
+    if (page.wait) await page.wait(2);
+    const result = await page.evaluate(addToCartEvaluate(product.productId, quantity)).catch((error) => {
+      throw new CommandExecutionError(`bigbasket add-to-cart evaluation failed: ${error?.message || error}`);
+    });
+    if (result?.message === 'OPTION_REQUIRED') {
+      throw new CommandExecutionError('This BigBasket product requires option selection and is not supported in v1.');
+    }
+    if (result?.message === 'ADD_BUTTON_NOT_FOUND') {
+      throw new CommandExecutionError('Could not find a BigBasket add-to-cart button.');
+    }
+    if (!result?.ok) {
+      throw new CommandExecutionError('Failed to confirm BigBasket add-to-cart success.');
+    }
+    return [{
+      ok: true,
+      product_id: product.productId,
+      quantity,
+      url: result.url || product.url,
+      message: 'Added to cart',
+    }];
+  },
+});

--- a/clis/bigbasket/bigbasket.test.js
+++ b/clis/bigbasket/bigbasket.test.js
@@ -1,0 +1,255 @@
+import { describe, expect, it } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@agentrhq/webcmd/errors';
+import { getRegistry } from '@agentrhq/webcmd/registry';
+import './search.js';
+import './category.js';
+import './product.js';
+import './add-to-cart.js';
+import './cart.js';
+import './checkout.js';
+import './location.js';
+import { CART_EVALUATE } from './cart.js';
+import { CHECKOUT_REVIEW_EVALUATE } from './checkout.js';
+import {
+  buildSearchUrl,
+  normalizeLocationState,
+  normalizeProductRow,
+  parseLimitArg,
+  parseQuantityArg,
+  productCardsEvaluate,
+  resolveCategoryUrl,
+  resolveProductInput,
+} from './utils.js';
+
+describe('bigbasket helpers', () => {
+  it('builds search and category URLs', () => {
+    expect(buildSearchUrl('amul milk')).toContain('/ps/?q=amul%20milk');
+    expect(resolveCategoryUrl('/pc/fruits-vegetables/vegetables/')).toBe('https://www.bigbasket.com/pc/fruits-vegetables/vegetables/');
+    expect(resolveCategoryUrl('fruits-vegetables/vegetables')).toBe('https://www.bigbasket.com/pc/fruits-vegetables/vegetables/');
+  });
+
+  it('parses product ids and URLs', () => {
+    expect(resolveProductInput('https://www.bigbasket.com/pd/40022638/fresho-banana-robusta-1-kg/')).toMatchObject({
+      productId: '40022638',
+      url: 'https://www.bigbasket.com/pd/40022638/fresho-banana-robusta-1-kg/',
+    });
+    expect(resolveProductInput('40022638')).toEqual({
+      productId: '40022638',
+      url: 'https://www.bigbasket.com/pd/40022638/',
+    });
+  });
+
+  it('fails fast on bad numbers and malformed inputs', () => {
+    expect(() => buildSearchUrl('   ')).toThrow(ArgumentError);
+    expect(() => resolveProductInput('banana')).toThrow(ArgumentError);
+    expect(() => parseLimitArg(0, 20, 50)).toThrow(ArgumentError);
+    expect(() => parseLimitArg(51, 20, 50)).toThrow(ArgumentError);
+    expect(() => parseQuantityArg(0, 1, 20)).toThrow(ArgumentError);
+  });
+
+  it('normalizes product rows', () => {
+    expect(normalizeProductRow({
+      product_id: '40022638',
+      title: 'Fresho Banana',
+      brand: 'Fresho',
+      pack_size: '1 kg',
+      price: '₹54',
+      mrp: '₹70',
+      discount: '23% OFF',
+      availability: 'In stock',
+      url: '/pd/40022638/fresho-banana/',
+    }, 0)).toEqual({
+      rank: 1,
+      product_id: '40022638',
+      title: 'Fresho Banana',
+      brand: 'Fresho',
+      pack_size: '1 kg',
+      price: 54,
+      mrp: 70,
+      discount: '23% OFF',
+      availability: 'In stock',
+      url: 'https://www.bigbasket.com/pd/40022638/fresho-banana/',
+    });
+  });
+
+  it('normalizes schema availability URLs', () => {
+    expect(normalizeProductRow({
+      product_id: '40090893',
+      title: 'Amul Gold Full Cream Milk',
+      availability: 'https://schema.org/InStock',
+      url: '/pd/40090893/amul-amul-gold/',
+    }, 0).availability).toBe('In stock');
+  });
+
+  it('normalizes selected location without leaking full address fields', () => {
+    expect(normalizeLocationState({
+      selectedAddressInfo: JSON.stringify({
+        nick: 'Home',
+        area: 'NTPC Township',
+        city_name: 'Noida',
+        pin: 201307,
+        address1: 'Block C-03 / 79',
+        address2: 'Samridhi',
+        landmark: 'Near something',
+        lat: 28.586165986798466,
+        lng: 77.35627826303244,
+        member: { full_name: 'Private Name' },
+      }),
+      selected_address_id: '218320015',
+    })).toEqual({
+      selected: true,
+      label: 'Home',
+      area: 'NTPC Township',
+      city: 'Noida',
+      pincode: '201307',
+      source: 'selectedAddressInfo',
+    });
+  });
+
+  it('extracts product title when image anchor appears before title anchor', () => {
+    const dom = new JSDOM(`
+      <ul>
+        <li>
+          <div><a href="/pd/40090893/amul-amul-gold-500-ml-pouch/"><img alt="milk"></a></div>
+          <h3>
+            <a href="/pd/40090893/amul-amul-gold-500-ml-pouch/">
+              <span>Amul</span>
+              <div><h3>Gold Full Cream Milk</h3></div>
+            </a>
+          </h3>
+          <span>500 ml - Pouch</span>
+          <span>₹34.00</span>
+          <button>Add</button>
+        </li>
+      </ul>
+    `, { runScripts: 'outside-only', url: 'https://www.bigbasket.com/ps/?q=milk' });
+
+    const result = dom.window.eval(productCardsEvaluate(3));
+
+    expect(result.rows[0]).toMatchObject({
+      product_id: '40090893',
+      brand: 'Amul',
+      title: 'Gold Full Cream Milk',
+      pack_size: '500 ml - Pouch',
+      price: '₹34.00',
+    });
+  });
+
+  it('uses listing URL title param when visible anchor text is only the brand', () => {
+    const dom = new JSDOM(`
+      <ul>
+        <li>
+          <a href="/pd/40090894/amul-taaza-500-ml-pouch/?t_s=Taaza+Milk"><span>Amul</span></a>
+          <span>500 ml</span>
+          <span>₹26.00</span>
+          <button>Add</button>
+        </li>
+      </ul>
+    `, { runScripts: 'outside-only', url: 'https://www.bigbasket.com/ps/?q=milk' });
+
+    const result = dom.window.eval(productCardsEvaluate(3));
+
+    expect(result.rows[0]).toMatchObject({
+      product_id: '40090894',
+      brand: 'Amul',
+      title: 'Taaza Milk',
+    });
+  });
+});
+
+describe('bigbasket registry shape', () => {
+  it('registers approved commands with expected access classes', () => {
+    expect(getRegistry().get('bigbasket/search').access).toBe('read');
+    expect(getRegistry().get('bigbasket/product').access).toBe('read');
+    expect(getRegistry().get('bigbasket/category').access).toBe('read');
+    expect(getRegistry().get('bigbasket/add-to-cart').access).toBe('write');
+    expect(getRegistry().get('bigbasket/cart').access).toBe('read');
+    expect(getRegistry().get('bigbasket/checkout').access).toBe('write');
+    expect(getRegistry().get('bigbasket/location').access).toBe('read');
+  });
+
+  it('keeps checkout in review mode', () => {
+    const checkout = getRegistry().get('bigbasket/checkout');
+    expect(checkout.columns).toEqual([
+      'ok', 'stage', 'cart_total', 'address_ready', 'delivery_ready', 'payment_ready', 'next_action', 'url',
+    ]);
+  });
+});
+
+describe('bigbasket read commands', () => {
+  it('rejects invalid read arguments before navigation', async () => {
+    const fakePage = { goto: () => { throw new Error('should not navigate'); } };
+
+    await expect(getRegistry().get('bigbasket/search').func(fakePage, { query: '   ' })).rejects.toThrow(ArgumentError);
+    await expect(getRegistry().get('bigbasket/category').func(fakePage, { category: 'bad' })).rejects.toThrow(ArgumentError);
+    await expect(getRegistry().get('bigbasket/product').func(fakePage, { product: 'banana' })).rejects.toThrow(ArgumentError);
+  });
+
+  it('wraps read navigation failures as CommandExecutionError', async () => {
+    const fakePage = { goto: () => Promise.reject(new Error('browser down')) };
+
+    await expect(getRegistry().get('bigbasket/search').func(fakePage, { query: 'milk' })).rejects.toThrow(CommandExecutionError);
+    await expect(getRegistry().get('bigbasket/category').func(fakePage, { category: 'fruits-vegetables/vegetables' })).rejects.toThrow(CommandExecutionError);
+    await expect(getRegistry().get('bigbasket/product').func(fakePage, { product: '40022638' })).rejects.toThrow(CommandExecutionError);
+  });
+});
+
+describe('bigbasket cart and checkout commands', () => {
+  it('rejects invalid add-to-cart arguments before navigation', async () => {
+    const fakePage = { goto: () => { throw new Error('should not navigate'); } };
+
+    await expect(getRegistry().get('bigbasket/add-to-cart').func(fakePage, {})).rejects.toThrow(ArgumentError);
+    await expect(getRegistry().get('bigbasket/add-to-cart').func(fakePage, { product: 'banana' })).rejects.toThrow(ArgumentError);
+    await expect(getRegistry().get('bigbasket/add-to-cart').func(fakePage, { product: '40022638', quantity: 0 })).rejects.toThrow(ArgumentError);
+  });
+
+  it('wraps cart and add-to-cart navigation failures as CommandExecutionError', async () => {
+    const fakePage = { goto: () => Promise.reject(new Error('browser down')) };
+
+    await expect(getRegistry().get('bigbasket/add-to-cart').func(fakePage, { product: '40022638' })).rejects.toThrow(CommandExecutionError);
+    await expect(getRegistry().get('bigbasket/cart').func(fakePage, {})).rejects.toThrow(CommandExecutionError);
+    await expect(getRegistry().get('bigbasket/checkout').func(fakePage, {})).rejects.toThrow(CommandExecutionError);
+  });
+
+  it('reports auth-required state for cart and checkout instead of recommendation rows', async () => {
+    const fakePage = {
+      goto: () => Promise.resolve(),
+      wait: () => Promise.resolve(),
+      evaluate: () => Promise.resolve({ authRequired: true, rows: [] }),
+    };
+
+    await expect(getRegistry().get('bigbasket/cart').func(fakePage, {})).rejects.toThrow(AuthRequiredError);
+    await expect(getRegistry().get('bigbasket/checkout').func(fakePage, {})).rejects.toThrow(AuthRequiredError);
+  });
+
+  it('keeps before-checkout recommendations out of cart rows', () => {
+    const dom = new JSDOM(`
+      <main>
+        <section>
+          <h1>My Basket</h1>
+          <article>
+            <a href="/pd/40090893/amul-amul-gold/">Amul Gold Full Cream Milk</a>
+            <span>Qty 1</span>
+            <span>₹36</span>
+          </article>
+        </section>
+        <section>
+          <article>
+            <a href="/pd/40321402/rubiks-cube/?nc=beforeyoucheckout">Rubik's Cube</a>
+            <span>₹449</span>
+          </article>
+        </section>
+      </main>
+    `, { runScripts: 'outside-only', url: 'https://www.bigbasket.com/basket/' });
+
+    const result = dom.window.eval(CART_EVALUATE);
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].product_id).toBe('40090893');
+  });
+
+  it('keeps checkout extractor free of final payment/order submission clicks', () => {
+    expect(CHECKOUT_REVIEW_EVALUATE).not.toMatch(/place\\s*order|submit\\s*payment|pay\\s*now|make\\s*payment/i);
+  });
+});

--- a/clis/bigbasket/cart.js
+++ b/clis/bigbasket/cart.js
@@ -1,0 +1,81 @@
+import { AuthRequiredError, EmptyResultError } from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { CART_URL, DOMAIN, parseMoney, safeGoto, SITE, toBigBasketUrl } from './utils.js';
+
+export const CART_EVALUATE = `
+  (() => {
+    const clean = (value) => value == null ? '' : String(value).replace(/\\s+/g, ' ').trim();
+    const bodyText = clean(document.body?.innerText || document.body?.textContent || '');
+    if (/Login\\/ Sign up|Login\\/ Sign Up|Enter Phone number|Using OTP/i.test(bodyText)) {
+      return { authRequired: true, rows: [], href: location.href };
+    }
+    if (!/my basket|basket|cart|checkout|subtotal|total/i.test(bodyText) || /My Smart Basket/i.test(bodyText)) {
+      return { rows: [], notCart: true, href: location.href, text: bodyText };
+    }
+    const itemRoots = Array.from(document.querySelectorAll('[data-testid*="cart"], [class*="Cart"], [class*="cart"], [class*="Basket"], [class*="basket"], li, article'))
+      .filter((node) => /₹|rs\\.?|qty|quantity/i.test(clean(node.textContent || '')));
+    const seen = new Set();
+    const rows = [];
+
+    for (const root of itemRoots) {
+      const bucket = root.closest('section, [class*="Recommendation"], [class*="recommend"], [class*="Carousel"], [class*="carousel"]');
+      if (/before you checkout|recommend|you may also like|frequently bought/i.test(clean(bucket?.textContent || ''))) continue;
+      const link = root.querySelector('a[href*="/pd/"]');
+      const href = link?.href || link?.getAttribute('href') || '';
+      if (/beforeyoucheckout/i.test(href)) continue;
+      const productId = href.match(/\\/pd\\/(\\d{4,})/)?.[1] || '';
+      const title = clean(link?.textContent) || clean(root.querySelector('h1,h2,h3,[class*="name"],[class*="Name"]')?.textContent);
+      if (!productId || !title || seen.has(productId)) continue;
+      seen.add(productId);
+      const text = clean(root.textContent || '');
+      const money = text.match(/(?:₹|Rs\\.?)[\\s\\d,.]+/gi) || [];
+      const quantity = Number(text.match(/(?:qty|quantity)\\D*(\\d+)/i)?.[1] || 1);
+      rows.push({
+        product_id: productId,
+        title,
+        quantity,
+        price: money[0] || '',
+        line_total: money[money.length - 1] || money[0] || '',
+        availability: /out of stock|unavailable/i.test(text) ? 'Out of stock' : '',
+        url: href,
+      });
+    }
+    return { rows, href: location.href, text: bodyText };
+  })()
+`;
+
+cli({
+  site: SITE,
+  name: 'cart',
+  access: 'read',
+  description: 'Read BigBasket cart line items',
+  domain: DOMAIN,
+  strategy: Strategy.COOKIE,
+  browser: true,
+  args: [],
+  columns: ['product_id', 'title', 'quantity', 'price', 'line_total', 'availability', 'url'],
+  func: async (page) => {
+    await safeGoto(page, CART_URL, 'bigbasket cart');
+    if (page.wait) await page.wait(2);
+    const result = await page.evaluate(CART_EVALUATE);
+    if (result?.authRequired) {
+      throw new AuthRequiredError('bigbasket.com', 'Log into BigBasket in the Webcmd browser session to read cart items.');
+    }
+    const rows = (result?.rows || []).map((row) => ({
+      product_id: row.product_id || '',
+      title: row.title || '',
+      quantity: row.quantity || 1,
+      price: parseMoney(row.price),
+      line_total: parseMoney(row.line_total),
+      availability: row.availability || '',
+      url: toBigBasketUrl(row.url),
+    })).filter((row) => row.product_id && row.title);
+    if (!rows.length) {
+      const hint = result?.notCart
+        ? 'BigBasket did not expose a cart view in the current session.'
+        : 'BigBasket cart is empty or no visible cart items were found.';
+      throw new EmptyResultError('bigbasket cart', hint);
+    }
+    return rows;
+  },
+});

--- a/clis/bigbasket/category.js
+++ b/clis/bigbasket/category.js
@@ -1,0 +1,30 @@
+import { EmptyResultError } from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { DOMAIN, normalizeProductRow, parseLimitArg, productCardsEvaluate, resolveCategoryUrl, safeGoto, SITE } from './utils.js';
+
+cli({
+  site: SITE,
+  name: 'category',
+  access: 'read',
+  description: 'Read BigBasket category product cards',
+  domain: DOMAIN,
+  strategy: Strategy.COOKIE,
+  browser: true,
+  args: [
+    { name: 'category', required: true, positional: true, help: 'Category URL or slug' },
+    { name: 'limit', type: 'int', default: 20, help: 'Maximum products to return (max 50)' },
+  ],
+  columns: ['rank', 'product_id', 'title', 'brand', 'pack_size', 'price', 'mrp', 'discount', 'availability', 'url'],
+  func: async (page, kwargs) => {
+    const url = resolveCategoryUrl(kwargs.category);
+    const limit = parseLimitArg(kwargs.limit, 20, 50);
+    await safeGoto(page, url, 'bigbasket category');
+    if (page.wait) await page.wait(2);
+    const result = await page.evaluate(productCardsEvaluate(limit));
+    const rows = (result?.rows || []).map(normalizeProductRow).filter((row) => row.product_id && row.title);
+    if (!rows.length) {
+      throw new EmptyResultError('bigbasket category', `No BigBasket products found at ${url}.`);
+    }
+    return rows;
+  },
+});

--- a/clis/bigbasket/checkout.js
+++ b/clis/bigbasket/checkout.js
@@ -1,0 +1,71 @@
+import { AuthRequiredError } from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { CART_URL, DOMAIN, parseMoney, safeGoto, SITE } from './utils.js';
+
+export const CHECKOUT_REVIEW_EVALUATE = `
+  (async () => {
+    const clean = (value) => value == null ? '' : String(value).replace(/\\s+/g, ' ').trim();
+    const initialText = clean(document.body?.innerText || '');
+    if (/Login\\/ Sign up|Login\\/ Sign Up|Enter Phone number|Using OTP/i.test(initialText)) {
+      return { ok: false, stage: 'login', url: location.href };
+    }
+    const button = Array.from(document.querySelectorAll('button, [role="button"], a')).find((node) => {
+      const label = clean(node.textContent || node.getAttribute('aria-label') || node.getAttribute('title'));
+      return /checkout|proceed/i.test(label);
+    });
+    if (button) {
+      button.click();
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+    const text = clean(document.body?.innerText || '');
+    const money = text.match(/(?:₹|Rs\\.?)[\\s\\d,.]+/gi) || [];
+    const addressReady = /address|deliver/i.test(text) && !/add\\s+address|select\\s+address/i.test(text);
+    const deliveryReady = /delivery|slot/i.test(text) && !/select\\s+(?:delivery|slot)/i.test(text);
+    const paymentReady = /payment|upi|card|cash/i.test(text);
+    const stage = /login|sign\\s*in|mobile number/i.test(text) ? 'login' :
+      /address/i.test(text) ? 'address' :
+      /delivery|slot/i.test(text) ? 'delivery' :
+      /payment|upi|card|cash/i.test(text) ? 'payment-review' :
+      'cart';
+    return {
+      ok: Boolean(button || /checkout|payment|address|delivery/i.test(text)),
+      stage,
+      cart_total: money[money.length - 1] || '',
+      address_ready: addressReady,
+      delivery_ready: deliveryReady,
+      payment_ready: paymentReady,
+      next_action: paymentReady ? 'Review payment options manually; command stops before final submission.' : 'Complete the visible checkout requirement manually.',
+      url: location.href,
+    };
+  })()
+`;
+
+cli({
+  site: SITE,
+  name: 'checkout',
+  access: 'write',
+  description: 'Open BigBasket checkout review without placing an order',
+  domain: DOMAIN,
+  strategy: Strategy.COOKIE,
+  browser: true,
+  args: [],
+  columns: ['ok', 'stage', 'cart_total', 'address_ready', 'delivery_ready', 'payment_ready', 'next_action', 'url'],
+  func: async (page) => {
+    await safeGoto(page, CART_URL, 'bigbasket checkout');
+    if (page.wait) await page.wait(2);
+    const result = await page.evaluate(CHECKOUT_REVIEW_EVALUATE);
+    if ((result?.stage === 'login' && result?.ok === false) || result?.authRequired === true) {
+      throw new AuthRequiredError('bigbasket.com', 'Log into BigBasket in the Webcmd browser session to open checkout review.');
+    }
+    return [{
+      ok: Boolean(result?.ok),
+      stage: result?.stage || 'cart',
+      cart_total: parseMoney(result?.cart_total),
+      address_ready: Boolean(result?.address_ready),
+      delivery_ready: Boolean(result?.delivery_ready),
+      payment_ready: Boolean(result?.payment_ready),
+      next_action: result?.next_action || 'Open BigBasket checkout manually.',
+      url: result?.url || CART_URL,
+    }];
+  },
+});

--- a/clis/bigbasket/location.js
+++ b/clis/bigbasket/location.js
@@ -1,0 +1,30 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { DOMAIN, HOME_URL, normalizeLocationState, safeGoto, SITE } from './utils.js';
+
+const LOCATION_EVALUATE = `
+  (() => {
+    const read = (key) => localStorage.getItem(key) || sessionStorage.getItem(key) || '';
+    return {
+      selectedAddressInfo: read('selectedAddressInfo'),
+      selected_address_id: read('selected_address_id'),
+      pin: read('pin') || read('pincode'),
+    };
+  })()
+`;
+
+cli({
+  site: SITE,
+  name: 'location',
+  access: 'read',
+  description: 'Show the selected BigBasket delivery location',
+  domain: DOMAIN,
+  strategy: Strategy.COOKIE,
+  browser: true,
+  args: [],
+  columns: ['selected', 'label', 'area', 'city', 'pincode', 'source'],
+  func: async (page) => {
+    await safeGoto(page, HOME_URL, 'bigbasket location');
+    if (page.wait) await page.wait(1);
+    return [normalizeLocationState(await page.evaluate(LOCATION_EVALUATE))];
+  },
+});

--- a/clis/bigbasket/product.js
+++ b/clis/bigbasket/product.js
@@ -1,0 +1,79 @@
+import { CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { DOMAIN, normalizeProductRow, resolveProductInput, safeGoto, SITE } from './utils.js';
+
+function productDetailEvaluate(productId) {
+  return `
+    (() => {
+      const productId = ${JSON.stringify(productId)};
+      const clean = (value) => value == null ? '' : String(value).replace(/\\s+/g, ' ').trim();
+      const jsonLd = Array.from(document.querySelectorAll('script[type="application/ld+json"]'))
+        .map((node) => {
+          try { return JSON.parse(node.textContent || 'null'); } catch { return null; }
+        })
+        .flatMap((doc) => Array.isArray(doc) ? doc : [doc])
+        .find((doc) => /product/i.test(String(doc?.['@type'] || '')));
+      const offers = Array.isArray(jsonLd?.offers) ? jsonLd.offers[0] : jsonLd?.offers;
+      const text = clean(document.body?.innerText || '');
+      const title = clean(jsonLd?.name) || clean(document.querySelector('h1,h2,[class*="ProductName"],[class*="product-name"]')?.textContent);
+      const image = Array.isArray(jsonLd?.image) ? jsonLd.image[0] : jsonLd?.image;
+      const priceText = clean(offers?.price) || clean(document.querySelector('[class*="price"], [class*="Price"]')?.textContent);
+      const mrpText = clean(document.querySelector('del,[class*="mrp"],[class*="MRP"]')?.textContent);
+      const packSize = text.match(/\\b\\d+(?:\\.\\d+)?\\s*(?:kg|g|gm|ml|l|ltr|pcs?|pack)\\b/i)?.[0] || '';
+      const availability = /out of stock|unavailable/i.test(text) ? 'Out of stock' : clean(offers?.availability || '');
+      const delivery = text.match(/Delivery\\s+in\\s+\\d+\\s*(?:mins?|minutes?|hours?)/i)?.[0] || '';
+      return {
+        product_id: productId,
+        title,
+        brand: clean(jsonLd?.brand?.name || jsonLd?.brand),
+        pack_size: packSize,
+        price: priceText,
+        mrp: mrpText,
+        discount: text.match(/\\d+%\\s*off/i)?.[0] || '',
+        availability,
+        delivery,
+        image_url: clean(image),
+        url: location.href,
+      };
+    })()
+  `;
+}
+
+cli({
+  site: SITE,
+  name: 'product',
+  access: 'read',
+  description: 'Read BigBasket product details',
+  domain: DOMAIN,
+  strategy: Strategy.COOKIE,
+  browser: true,
+  args: [
+    { name: 'product', required: true, positional: true, help: 'Product ID or URL' },
+  ],
+  columns: ['product_id', 'title', 'brand', 'pack_size', 'price', 'mrp', 'discount', 'availability', 'delivery', 'image_url', 'url'],
+  func: async (page, kwargs) => {
+    const product = resolveProductInput(kwargs.product);
+    await safeGoto(page, product.url, 'bigbasket product');
+    if (page.wait) await page.wait(2);
+    const raw = await page.evaluate(productDetailEvaluate(product.productId)).catch((error) => {
+      throw new CommandExecutionError(`bigbasket product extraction failed: ${error?.message || error}`);
+    });
+    const row = normalizeProductRow(raw, 0);
+    if (!row.product_id || !row.title) {
+      throw new EmptyResultError('bigbasket product', `No product details found for ${product.productId}.`);
+    }
+    return [{
+      product_id: row.product_id,
+      title: row.title,
+      brand: row.brand,
+      pack_size: row.pack_size,
+      price: row.price,
+      mrp: row.mrp,
+      discount: row.discount,
+      availability: row.availability,
+      delivery: raw.delivery || '',
+      image_url: raw.image_url || '',
+      url: row.url,
+    }];
+  },
+});

--- a/clis/bigbasket/search.js
+++ b/clis/bigbasket/search.js
@@ -1,0 +1,30 @@
+import { EmptyResultError } from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { buildSearchUrl, DOMAIN, normalizeProductRow, parseLimitArg, productCardsEvaluate, safeGoto, SITE } from './utils.js';
+
+cli({
+  site: SITE,
+  name: 'search',
+  access: 'read',
+  description: 'Search BigBasket products',
+  domain: DOMAIN,
+  strategy: Strategy.COOKIE,
+  browser: true,
+  args: [
+    { name: 'query', required: true, positional: true, help: 'Search query' },
+    { name: 'limit', type: 'int', default: 20, help: 'Maximum products to return (max 50)' },
+  ],
+  columns: ['rank', 'product_id', 'title', 'brand', 'pack_size', 'price', 'mrp', 'discount', 'availability', 'url'],
+  func: async (page, kwargs) => {
+    const url = buildSearchUrl(kwargs.query);
+    const limit = parseLimitArg(kwargs.limit, 20, 50);
+    await safeGoto(page, url, 'bigbasket search');
+    if (page.wait) await page.wait(2);
+    const result = await page.evaluate(productCardsEvaluate(limit));
+    const rows = (result?.rows || []).map(normalizeProductRow).filter((row) => row.product_id && row.title);
+    if (!rows.length) {
+      throw new EmptyResultError('bigbasket search', `No BigBasket products matched "${kwargs.query}".`);
+    }
+    return rows;
+  },
+});

--- a/clis/bigbasket/utils.js
+++ b/clis/bigbasket/utils.js
@@ -1,0 +1,207 @@
+import { ArgumentError, CommandExecutionError } from '@agentrhq/webcmd/errors';
+
+export const SITE = 'bigbasket';
+export const DOMAIN = 'www.bigbasket.com';
+export const HOME_URL = 'https://www.bigbasket.com/';
+export const CART_URL = 'https://www.bigbasket.com/basket/';
+export const CHECKOUT_URL = 'https://www.bigbasket.com/checkout/';
+
+export function cleanText(value) {
+  return typeof value === 'string'
+    ? value.replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim()
+    : '';
+}
+
+export function parseMoney(value) {
+  const text = cleanText(String(value ?? ''));
+  if (!text) return null;
+  const match = text.replace(/,/g, '').match(/(\d+(?:\.\d+)?)/);
+  if (!match) return null;
+  const num = Number(match[1]);
+  return Number.isFinite(num) ? num : null;
+}
+
+function normalizeAvailability(value) {
+  const text = cleanText(value);
+  if (/instock$/i.test(text) || /\bin stock\b/i.test(text)) return 'In stock';
+  if (/outofstock$/i.test(text) || /out of stock|unavailable/i.test(text)) return 'Out of stock';
+  return text;
+}
+
+export function parseLimitArg(raw, fallback, max) {
+  if (raw === undefined || raw === null || raw === '') return fallback;
+  const num = Number(raw);
+  if (!Number.isInteger(num) || num < 1 || num > max) {
+    throw new ArgumentError(`--limit must be an integer between 1 and ${max} (got ${raw})`);
+  }
+  return num;
+}
+
+export function parseQuantityArg(raw, fallback, max) {
+  if (raw === undefined || raw === null || raw === '') return fallback;
+  const num = Number(raw);
+  if (!Number.isInteger(num) || num < 1 || num > max) {
+    throw new ArgumentError(`--quantity must be an integer between 1 and ${max} (got ${raw})`);
+  }
+  return num;
+}
+
+export function buildSearchUrl(query) {
+  const normalized = cleanText(query);
+  if (!normalized) throw new ArgumentError('bigbasket search query cannot be empty');
+  return `${HOME_URL}ps/?q=${encodeURIComponent(normalized)}`;
+}
+
+export function toBigBasketUrl(value) {
+  const text = cleanText(value);
+  if (!text) return '';
+  try {
+    const url = new URL(text.startsWith('http') ? text : text.startsWith('/') ? text : `/${text}`, HOME_URL);
+    if (url.hostname !== DOMAIN) {
+      throw new Error('not bigbasket');
+    }
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return '';
+  }
+}
+
+export function resolveCategoryUrl(input) {
+  const text = cleanText(input);
+  if (!text) throw new ArgumentError('bigbasket category requires a category URL or slug');
+  if (!text.startsWith('http') && !text.includes('/')) {
+    throw new ArgumentError('bigbasket category expects a category path such as fruits-vegetables/vegetables');
+  }
+  const prefixed = text.startsWith('http') || text.startsWith('/pc/') ? text : `/pc/${text.replace(/^\/+/, '')}/`;
+  const url = toBigBasketUrl(prefixed);
+  if (!url || !new URL(url).pathname.startsWith('/pc/')) {
+    throw new ArgumentError('bigbasket category expects a BigBasket /pc/<category>/ URL or slug');
+  }
+  return url;
+}
+
+export function resolveProductInput(input) {
+  const text = cleanText(input);
+  if (!text) throw new ArgumentError('bigbasket product requires a product ID or URL');
+  if (/^\d{4,}$/.test(text)) {
+    return { productId: text, url: `${HOME_URL}pd/${text}/` };
+  }
+  const url = toBigBasketUrl(text);
+  if (!url) throw new ArgumentError('bigbasket product expects a BigBasket product ID or /pd/<id>/ URL');
+  const match = new URL(url).pathname.match(/^\/pd\/(\d{4,})(?:\/|$)/);
+  if (!match) throw new ArgumentError('bigbasket product expects a BigBasket product ID or /pd/<id>/ URL');
+  return { productId: match[1], url };
+}
+
+export function normalizeProductRow(raw, rank) {
+  const url = toBigBasketUrl(raw.url || raw.href || '');
+  const productId = cleanText(raw.product_id || raw.productId || raw.id || url.match(/\/pd\/(\d{4,})/)?.[1] || '');
+  return {
+    rank: rank + 1,
+    product_id: productId,
+    title: cleanText(raw.title || raw.name),
+    brand: cleanText(raw.brand),
+    pack_size: cleanText(raw.pack_size || raw.packSize || raw.size),
+    price: parseMoney(raw.price),
+    mrp: parseMoney(raw.mrp || raw.original_price || raw.originalPrice),
+    discount: cleanText(raw.discount),
+    availability: normalizeAvailability(raw.availability || raw.stock),
+    url,
+  };
+}
+
+function parseJsonObject(raw) {
+  try {
+    const value = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+  } catch {
+    return {};
+  }
+}
+
+export function normalizeLocationState(raw = {}) {
+  const info = parseJsonObject(raw.selectedAddressInfo || raw.selected_address_info || raw.address);
+  const pincode = cleanText(String(info.pin || info.pincode || raw.pin || raw.pincode || ''));
+  return {
+    selected: Boolean(raw.selected_address_id || raw.selectedAddressId || info.id || pincode),
+    label: cleanText(info.nick || info.nickname || raw.label || raw.nick),
+    area: cleanText(info.area || info.locality || raw.area),
+    city: cleanText(info.city_name || info.city || raw.city),
+    pincode,
+    source: raw.selectedAddressInfo || raw.selected_address_info ? 'selectedAddressInfo' : '',
+  };
+}
+
+export async function safeGoto(page, url, label) {
+  await page.goto(url).catch((error) => {
+    throw new CommandExecutionError(`${label} navigation failed: ${error?.message || error}`);
+  });
+}
+
+export function productCardsEvaluate(limit) {
+  return `
+    (() => {
+      const limit = ${Number(limit) || 20};
+      const clean = (value) => value == null ? '' : String(value).replace(/\\s+/g, ' ').trim();
+      const leafText = (root) => Array.from(root.querySelectorAll('*'))
+        .filter((node) => node.children.length === 0)
+        .map((node) => clean(node.textContent))
+        .filter(Boolean);
+      const anchors = Array.from(document.querySelectorAll('a[href*="/pd/"]'));
+      const byProductId = new Map();
+      const rows = [];
+
+      for (const anchor of anchors) {
+        const href = anchor.href || anchor.getAttribute('href') || '';
+        const productId = href.match(/\\/pd\\/(\\d{4,})/)?.[1] || '';
+        if (!productId) continue;
+
+        const root = anchor.closest('li, article, [data-testid], [class*="Product"], [class*="product"], [class*="SKU"], [class*="sku"]') || anchor;
+        const productAnchors = Array.from(root.querySelectorAll('a[href*="/pd/"]'))
+          .filter((node) => (node.href || node.getAttribute('href') || '').includes('/pd/' + productId + '/'));
+        const titleAnchor = productAnchors.find((node) => clean(node.textContent)) || anchor;
+        const titleParam = (() => {
+          try { return clean(new URL(href, location.origin).searchParams.get('t_s')); } catch { return ''; }
+        })();
+        const texts = leafText(root);
+        const joined = texts.join(' | ');
+        const brand = clean(titleAnchor.querySelector('span')?.textContent);
+        const visibleTitle =
+          clean(titleAnchor.getAttribute('title')) ||
+          clean(titleAnchor.querySelector('h1,h2,h3,[class*="name"],[class*="Name"]')?.textContent) ||
+          clean(titleAnchor.textContent).replace(brand, '').trim() ||
+          texts.find((text) => /[A-Za-z]/.test(text) && !/₹|rs\\.?|add|cart|off/i.test(text)) ||
+          '';
+        const title = !visibleTitle || visibleTitle === brand ? titleParam : visibleTitle;
+        const price = texts.find((text) => /₹|rs\\.?/i.test(text) && !/mrp/i.test(text)) || '';
+        const mrp = texts.find((text) => /mrp/i.test(text)) || '';
+        const discount = texts.find((text) => /%\\s*off|save/i.test(text)) || '';
+        const packSize = texts.find((text) => /\\b\\d+(?:\\.\\d+)?\\s*(?:kg|g|gm|ml|l|ltr|pcs?|pack)\\b/i.test(text)) || '';
+        const availability = /out of stock|unavailable/i.test(joined) ? 'Out of stock' : '';
+
+        const row = {
+          product_id: productId,
+          title,
+          brand,
+          pack_size: packSize,
+          price,
+          mrp,
+          discount,
+          availability,
+          url: href,
+        };
+        const existing = byProductId.get(productId);
+        if (!existing || (!existing.title && row.title)) byProductId.set(productId, row);
+      }
+
+      for (const row of byProductId.values()) {
+        rows.push(row);
+        if (rows.length >= limit) break;
+      }
+
+      const bodyText = clean(document.body?.innerText || '');
+      return { rows, bodyText, href: location.href };
+    })()
+  `;
+}


### PR DESCRIPTION
## Summary
- add built-in BigBasket adapter commands for search, product, category, add-to-cart, cart, and checkout
- keep checkout review-only so it never submits payment or places an order
- fail closed for anonymous cart/checkout sessions instead of returning recommendation rows

## Verification
- npm run test:adapter -- clis/bigbasket/bigbasket.test.js
- npm run typecheck
- npm test
- live smoke: search/category/product/add-to-cart work; cart/checkout require login in the current anonymous session