### PR TITLE
feat: install bundled Webcmd skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,13 @@ Webcmd is designed to be driven by coding agents such as Codex, Claude Code, Cur
 
 ## Install skills (also refreshes existing installs)
 
-Install Webcmd skills into the agent environment with your agent's skill manager:
+Install Webcmd skills into your agent environment:
 
 ```bash
-npx skills add agentrhq/webcmd
+webcmd skills install
 ```
 
-Or install/copy only the skills you need from [`skills/`](./skills/) into your agent's skills root.
+The installer asks whether to install globally or locally, then asks for the coding agent (`agents`, `codex`, `claude`) or a custom skills path. For scripts, pass flags such as `--scope project --provider codex` or `--path ./my-skills`.
 
 ### Which skill to use
 

--- a/docs/plugins-and-skills.mdx
+++ b/docs/plugins-and-skills.mdx
@@ -69,7 +69,13 @@ Use the Webcmd adapter-author skill to create this command. If the site changes 
 
 ## Installing Skills for Agents
 
-If your agent supports skills, install or copy the relevant Webcmd skills from the package. Then tell the agent to use them.
+Install the bundled Webcmd skills and answer the prompts for global/local scope and agent target.
+
+```bash
+webcmd skills install
+```
+
+For automation, pass `--scope`, `--provider`, or `--path`.
 
 ```text
 Before working on this site, load the Webcmd usage and adapter-author skills. Prefer an existing adapter if one exists.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "files": [
     "dist/src/",
     "clis/",
-    "skills/webcmd-*/**",
+    "skills/**",
     "cli-manifest.json",
     "scripts/",
     "README.md",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import * as readline from 'node:readline/promises';
 import { fileURLToPath } from 'node:url';
 import { Command, InvalidArgumentError, Option } from 'commander';
 import { findPackageRoot, getBuiltEntryCandidates } from './package-paths.js';
@@ -17,10 +18,10 @@ import { render as renderOutput } from './output.js';
 import { PKG_VERSION } from './version.js';
 import { printCompletionScript } from './completion.js';
 import { loadExternalClis, executeExternalCli, installExternalCli, registerExternalCli, isBinaryInstalled, formatExternalCliLabel } from './external.js';
-import { listWebcmdSkills, readWebcmdSkill } from './skills.js';
+import { installWebcmdSkill, listWebcmdSkills, updateWebcmdSkill, type WebcmdSkillInstallResult } from './skills.js';
 import { registerAllCommands } from './commanderAdapter.js';
 import { classifyAdapter, formatRootAdapterHelpText, installCommanderNamespaceStructuredHelp, installStructuredHelp, leadingPositionalFromUsage, rootHelpData, type RootAdapterGroups } from './help.js';
-import { EXIT_CODES, getErrorMessage, BrowserConnectError, CliError } from './errors.js';
+import { EXIT_CODES, getErrorMessage, BrowserConnectError, CliError, ArgumentError } from './errors.js';
 import { TargetError, type TargetErrorCode } from './browser/target-errors.js';
 import { resolveTargetJs, getTextResolvedJs, getValueResolvedJs, getAttributesResolvedJs, selectResolvedJs, isAutocompleteResolvedJs, type ResolveOptions, type TargetMatchLevel } from './browser/target-resolver.js';
 import { buildFindJs, buildSemanticFindJs, isFindError, type FindResult, type FindError, type SemanticFindOptions } from './browser/find.js';
@@ -76,6 +77,81 @@ function parseDurationMs(raw: unknown, flagName: string): number | null | { erro
 
 function timestampFromRaw(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : Date.now();
+}
+
+type SkillLinkCommandOptions = {
+  provider?: string;
+  scope?: string;
+  path?: string;
+  json?: boolean;
+};
+
+function isInteractiveInstall(opts: SkillLinkCommandOptions): boolean {
+  return !opts.json && process.stdin.isTTY === true && process.stdout.isTTY === true;
+}
+
+async function resolveSkillInstallOptions(opts: SkillLinkCommandOptions): Promise<SkillLinkCommandOptions> {
+  if (!isInteractiveInstall(opts)) return opts;
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const scope = opts.scope ?? await choosePrompt(rl, 'Where should Webcmd install skills?', [
+      { key: '1', label: 'Global', value: 'user', aliases: ['global', 'user', 'g'] },
+      { key: '2', label: 'Local project', value: 'project', aliases: ['local', 'project', 'l'] },
+    ], '1');
+    const provider = opts.provider ?? (opts.path ? undefined : await choosePrompt(rl, 'Which coding agent should use them?', [
+      { key: '1', label: 'Agents', value: 'agents', aliases: ['agents', 'agent', 'a'] },
+      { key: '2', label: 'Codex', value: 'codex', aliases: ['codex', 'c'] },
+      { key: '3', label: 'Claude', value: 'claude', aliases: ['claude', 'claude-code'] },
+      { key: '4', label: 'Custom path', value: 'custom', aliases: ['custom', 'path'] },
+    ], '1'));
+    const customPath = opts.path ?? (provider === 'custom' ? await nonEmptyPrompt(rl, 'Skills directory path: ') : undefined);
+    return { ...opts, scope, provider: provider === 'custom' ? undefined : provider, path: customPath };
+  } finally {
+    rl.close();
+  }
+}
+
+async function choosePrompt<T extends string>(
+  rl: readline.Interface,
+  question: string,
+  choices: Array<{ key: string; label: string; value: T; aliases: string[] }>,
+  defaultKey: string,
+): Promise<T> {
+  console.log(question);
+  for (const choice of choices) console.log(`  ${choice.key}) ${choice.label}`);
+  while (true) {
+    const answer = (await rl.question(`Choose [${defaultKey}]: `)).trim().toLowerCase() || defaultKey;
+    const choice = choices.find((item) => item.key === answer || item.aliases.includes(answer));
+    if (choice) return choice.value;
+    console.log(`Choose one of: ${choices.map((item) => item.key).join(', ')}`);
+  }
+}
+
+async function nonEmptyPrompt(rl: readline.Interface, question: string): Promise<string> {
+  while (true) {
+    const answer = (await rl.question(question)).trim();
+    if (answer) return answer;
+    console.log('Path is required.');
+  }
+}
+
+async function handleSkillLinkCommand(action: () => WebcmdSkillInstallResult | Promise<WebcmdSkillInstallResult>, json: boolean, verb: string): Promise<void> {
+  try {
+    const result = await action();
+    if (json) {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+    console.log(`Webcmd skills ${verb}: ${result.skills.length}`);
+    for (const skill of result.skills) {
+      console.log(`${skill.name}: ${skill.destination ? `${skill.destination} -> ` : ''}${skill.stableLink}`);
+    }
+  } catch (err) {
+    console.error(`Error: ${getErrorMessage(err)}`);
+    if (err instanceof CliError && err.hint) console.error(`Hint: ${err.hint}`);
+    process.exitCode = err instanceof CliError ? err.exitCode : EXIT_CODES.GENERIC_ERROR;
+  }
 }
 
 function toIsoTimestamp(timestamp: unknown): string | undefined {
@@ -824,11 +900,21 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
 
   const skillsCmd = program
     .command('skills')
-    .description('Read bundled Webcmd skills');
+    .description('List, install, and update bundled Webcmd skills')
+    .action(() => {
+      const rows = listWebcmdSkills();
+      renderOutput(rows, {
+        fmt: 'table',
+        fmtExplicit: false,
+        columns: ['name', 'description', 'version', 'path'],
+        title: 'webcmd/skills/list',
+        source: 'webcmd skills',
+      });
+    });
 
   skillsCmd
     .command('list')
-    .description('List bundled webcmd-* skills')
+    .description('List bundled Webcmd skills')
     .option('-f, --format <fmt>', 'Output format: table, json, yaml, md, csv', 'table')
     .action((opts) => {
       const rows = listWebcmdSkills();
@@ -842,27 +928,39 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     });
 
   skillsCmd
-    .command('read')
-    .description("Print a bundled webcmd-* skill's SKILL.md or reference file")
-    .argument('<skill>', 'Skill name, or skill/path like webcmd-browser/references/foo.md')
-    .argument('[path]', 'Path under the skill directory')
-    .option('--json', 'Output a JSON envelope instead of raw markdown', false)
-    .action((skill: string, skillPath: string | undefined, opts) => {
-      let result: ReturnType<typeof readWebcmdSkill>;
-      try {
-        result = readWebcmdSkill(skill, skillPath ?? '');
-      } catch (err) {
-        console.error(`Error: ${getErrorMessage(err)}`);
-        if (err instanceof CliError && err.hint) console.error(`Hint: ${err.hint}`);
-        process.exitCode = err instanceof CliError ? err.exitCode : EXIT_CODES.GENERIC_ERROR;
-        return;
-      }
-      if (opts.json) {
-        console.log(JSON.stringify(result, null, 2));
-        return;
-      }
-      process.stdout.write(result.content);
-      if (!result.content.endsWith('\n')) process.stdout.write('\n');
+    .command('install')
+    .description('Install bundled Webcmd skills into an agent skills folder')
+    .option('-p, --provider <provider>', 'Agent provider: agents, codex, claude')
+    .option('-s, --scope <scope>', 'Install scope: user/global or project/local')
+    .option('--path <path>', 'Custom agent skills directory')
+    .option('--json', 'Output a JSON envelope', false)
+    .action(async (opts) => {
+      await handleSkillLinkCommand(async () => {
+        const resolved = await resolveSkillInstallOptions(opts);
+        if (resolved.provider === 'custom' && !resolved.path) {
+          throw new ArgumentError('Custom skill provider requires --path.', 'Pass --path <skills-dir> or run interactively.');
+        }
+        return installWebcmdSkill({
+          provider: resolved.provider,
+          scope: resolved.scope,
+          customPath: resolved.path,
+        });
+      }, opts.json, 'installed');
+    });
+
+  skillsCmd
+    .command('update')
+    .description('Refresh bundled Webcmd skill symlinks after updating the package')
+    .option('-p, --provider <provider>', 'Also repair provider link: agents, codex, claude')
+    .option('-s, --scope <scope>', 'Also repair scoped link: user/global or project/local')
+    .option('--path <path>', 'Also repair a custom agent skills directory')
+    .option('--json', 'Output a JSON envelope', false)
+    .action(async (opts) => {
+      await handleSkillLinkCommand(() => updateWebcmdSkill({
+        provider: opts.provider,
+        scope: opts.scope,
+        customPath: opts.path,
+      }), opts.json, 'updated');
     });
 
   const authCmd = registerAuthCommands(program);

--- a/src/skills.test.ts
+++ b/src/skills.test.ts
@@ -4,18 +4,18 @@ import * as path from 'node:path';
 import yaml from 'js-yaml';
 import { describe, expect, it } from 'vitest';
 import { ArgumentError } from './errors.js';
-import { listWebcmdSkills, readWebcmdSkill } from './skills.js';
+import { installWebcmdSkill, listWebcmdSkills, updateWebcmdSkill } from './skills.js';
 
-function makePackageRoot(): string {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-skills-'));
-  fs.mkdirSync(path.join(root, 'skills', 'webcmd-browser', 'references'), { recursive: true });
+function makePackageRoot(label = 'current'): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `webcmd-skills-${label}-`));
+  fs.mkdirSync(path.join(root, 'skills', 'webcmd-browser'), { recursive: true });
   fs.mkdirSync(path.join(root, 'skills', 'webcmd-autofix'), { recursive: true });
   fs.mkdirSync(path.join(root, 'skills', 'smart-search'), { recursive: true });
   fs.writeFileSync(path.join(root, 'package.json'), '{"name":"@agentrhq/webcmd"}\n');
   fs.writeFileSync(path.join(root, 'skills', 'webcmd-browser', 'SKILL.md'), [
     '---',
     'name: webcmd-browser',
-    'description: Browser control skill',
+    `description: Browser control skill ${label}`,
     'version: 1.2.3',
     '---',
     '',
@@ -24,7 +24,6 @@ function makePackageRoot(): string {
     'Body.',
     '',
   ].join('\n'));
-  fs.writeFileSync(path.join(root, 'skills', 'webcmd-browser', 'references', 'targets.md'), '# Targets\n');
   fs.writeFileSync(path.join(root, 'skills', 'webcmd-autofix', 'SKILL.md'), [
     '---',
     'name: webcmd-autofix',
@@ -42,11 +41,15 @@ function makePackageRoot(): string {
   return root;
 }
 
+function real(filePath: string): string {
+  return fs.realpathSync(filePath);
+}
+
 describe('webcmd skills content', () => {
   it('keeps bundled skill frontmatter valid yaml', () => {
     const skillsRoot = path.join(process.cwd(), 'skills');
     const skillNames = fs.readdirSync(skillsRoot, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory() && entry.name.startsWith('webcmd-'))
+      .filter((entry) => entry.isDirectory())
       .map((entry) => entry.name);
 
     for (const name of skillNames) {
@@ -57,10 +60,11 @@ describe('webcmd skills content', () => {
     }
   });
 
-  it('lists only webcmd-prefixed skills', () => {
+  it('lists bundled skills', () => {
     const root = makePackageRoot();
 
     expect(listWebcmdSkills(root).map((skill) => skill.name)).toEqual([
+      'smart-search',
       'webcmd-autofix',
       'webcmd-browser',
     ]);
@@ -68,26 +72,75 @@ describe('webcmd skills content', () => {
       .toBe('Fix adapters: keep scope narrow');
   });
 
-  it('reads a skill SKILL.md and reference file', () => {
-    const root = makePackageRoot();
+  it('keeps the expected installable skill set', () => {
+    const skills = fs.readdirSync(path.join(process.cwd(), 'skills'), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
 
-    expect(readWebcmdSkill('webcmd-browser', '', root)).toMatchObject({
-      skill: 'webcmd-browser',
-      path: 'SKILL.md',
-    });
-    expect(readWebcmdSkill('webcmd-browser/references/targets.md', '', root)).toMatchObject({
-      skill: 'webcmd-browser',
-      path: 'references/targets.md',
-      content: '# Targets\n',
-    });
-    expect(readWebcmdSkill('webcmd-browser', 'references/targets.md', root).content).toBe('# Targets\n');
+    expect(skills).toEqual([
+      'smart-search',
+      'webcmd-adapter-author',
+      'webcmd-autofix',
+      'webcmd-browser',
+      'webcmd-browser-sitemap',
+      'webcmd-sitemap-author',
+      'webcmd-usage',
+    ]);
   });
 
-  it('rejects non-webcmd skills and path traversal', () => {
-    const root = makePackageRoot();
+  it('installs bundled skills once and refreshes them after package updates', () => {
+    const firstRoot = makePackageRoot('first');
+    const secondRoot = makePackageRoot('second');
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-home-'));
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-project-'));
 
-    expect(() => readWebcmdSkill('smart-search', '', root)).toThrow(ArgumentError);
-    expect(() => readWebcmdSkill('webcmd-browser/../smart-search/SKILL.md', '', root)).toThrow(ArgumentError);
-    expect(() => readWebcmdSkill('webcmd-browser', '../../package.json', root)).toThrow(ArgumentError);
+    const installed = installWebcmdSkill({ packageRoot: firstRoot, homeDir, cwd, provider: 'codex', scope: 'project' });
+
+    expect(installed).toMatchObject({
+      provider: 'codex',
+      scope: 'project',
+    });
+    expect(installed.skills.map((skill) => skill.name)).toEqual(['smart-search', 'webcmd-autofix', 'webcmd-browser']);
+    for (const skill of installed.skills) {
+      expect(skill.source).toBe(path.join(firstRoot, 'skills', skill.name));
+      expect(skill.stableLink).toBe(path.join(homeDir, '.webcmd', 'skills', skill.name));
+      expect(skill.destination).toBe(path.join(cwd, '.codex', 'skills', skill.name));
+      expect(real(skill.destination!)).toBe(real(skill.source));
+    }
+
+    const updated = updateWebcmdSkill({ packageRoot: secondRoot, homeDir });
+
+    expect(updated.skills.every((skill) => skill.destination === undefined)).toBe(true);
+    for (const skill of installed.skills) {
+      expect(real(skill.destination!)).toBe(real(path.join(secondRoot, 'skills', skill.name)));
+    }
+  });
+
+  it('installs bundled skills into a custom skills directory', () => {
+    const packageRoot = makePackageRoot();
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-home-'));
+    const customPath = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-custom-skills-'));
+
+    const installed = installWebcmdSkill({ packageRoot, homeDir, customPath });
+
+    expect(installed.provider).toBeUndefined();
+    expect(installed.skills.map((skill) => skill.destination)).toEqual([
+      path.join(customPath, 'smart-search'),
+      path.join(customPath, 'webcmd-autofix'),
+      path.join(customPath, 'webcmd-browser'),
+    ]);
+    for (const skill of installed.skills) {
+      expect(real(skill.destination!)).toBe(real(skill.source));
+    }
+  });
+
+  it('refuses to replace real files or directories', () => {
+    const packageRoot = makePackageRoot();
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-home-'));
+    const stablePath = path.join(homeDir, '.webcmd', 'skills', 'smart-search');
+    fs.mkdirSync(stablePath, { recursive: true });
+
+    expect(() => updateWebcmdSkill({ packageRoot, homeDir })).toThrow(ArgumentError);
   });
 });

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import yaml from 'js-yaml';
@@ -14,10 +15,26 @@ export interface WebcmdSkillInfo {
   path: string;
 }
 
-export interface WebcmdSkillReadResult {
-  skill: string;
-  path: string;
-  content: string;
+export interface WebcmdSkillInstallOptions {
+  provider?: string;
+  scope?: string;
+  customPath?: string;
+  packageRoot?: string;
+  homeDir?: string;
+  cwd?: string;
+}
+
+export interface WebcmdSkillLink {
+  name: string;
+  source: string;
+  stableLink: string;
+  destination?: string;
+}
+
+export interface WebcmdSkillInstallResult {
+  provider?: SkillProvider;
+  scope?: SkillScope;
+  skills: WebcmdSkillLink[];
 }
 
 interface SkillFrontmatter {
@@ -25,6 +42,9 @@ interface SkillFrontmatter {
   description?: unknown;
   version?: unknown;
 }
+
+type SkillProvider = 'agents' | 'codex' | 'claude';
+type SkillScope = 'user' | 'project';
 
 export function getSkillsRoot(packageRoot: string = findPackageRoot(MODULE_FILE)): string {
   return path.join(packageRoot, 'skills');
@@ -35,39 +55,103 @@ export function listWebcmdSkills(packageRoot?: string): WebcmdSkillInfo[] {
   if (!fs.existsSync(skillsRoot)) return [];
 
   return fs.readdirSync(skillsRoot, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory() && entry.name.startsWith('webcmd-'))
+    .filter((entry) => entry.isDirectory())
     .map((entry) => readSkillInfo(skillsRoot, entry.name))
     .filter((entry): entry is WebcmdSkillInfo => entry !== null)
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export function readWebcmdSkill(target: string, relpath = '', packageRoot?: string): WebcmdSkillReadResult {
-  const { name, pathInSkill } = parseSkillTarget(target, relpath);
-  if (!name.startsWith('webcmd-')) {
-    throw new ArgumentError(`Unknown Webcmd skill: ${name}`, 'Run "webcmd skills list" to see available Webcmd skills.');
-  }
+export function installWebcmdSkill(options: WebcmdSkillInstallOptions = {}): WebcmdSkillInstallResult {
+  const provider = options.customPath === undefined ? normalizeProvider(options.provider) : undefined;
+  const scope = normalizeScope(options.scope);
+  const skills = updateStableSkillLinks(options)
+    .map((skill) => {
+      const destination = destinationFor(skill.name, provider, scope, options);
+      replaceDirectorySymlink(skill.stableLink, destination);
+      return { ...skill, destination };
+    });
+  return { provider, scope, skills };
+}
 
-  const skillsRoot = getSkillsRoot(packageRoot);
-  const skillRoot = path.join(skillsRoot, name);
-  if (!isDirectory(skillRoot) || !fs.existsSync(path.join(skillRoot, 'SKILL.md'))) {
-    throw new ArgumentError(`Unknown Webcmd skill: ${name}`, 'Run "webcmd skills list" to see available Webcmd skills.');
-  }
+export function updateWebcmdSkill(options: WebcmdSkillInstallOptions = {}): WebcmdSkillInstallResult {
+  const skills = updateStableSkillLinks(options);
+  if (options.provider === undefined && options.scope === undefined && options.customPath === undefined) return { skills };
 
-  const relativePath = normalizeSkillPath(pathInSkill || 'SKILL.md');
-  const absolutePath = path.resolve(skillRoot, relativePath);
-  const relativeToRoot = path.relative(skillRoot, absolutePath);
-  if (relativeToRoot.startsWith('..') || path.isAbsolute(relativeToRoot)) {
-    throw new ArgumentError(`Invalid skill path: ${relativePath}`, 'Skill paths must stay inside the selected Webcmd skill.');
-  }
-  if (!fs.existsSync(absolutePath) || !fs.statSync(absolutePath).isFile()) {
-    throw new ArgumentError(`Skill file not found: ${name}/${relativePath}`, 'Run "webcmd skills list <skill>" is not supported yet; read SKILL.md or a known references/... file.');
-  }
-
+  const provider = options.customPath === undefined ? normalizeProvider(options.provider) : undefined;
+  const scope = normalizeScope(options.scope);
   return {
-    skill: name,
-    path: relativePath,
-    content: fs.readFileSync(absolutePath, 'utf8'),
+    provider,
+    scope,
+    skills: skills.map((skill) => {
+      const destination = destinationFor(skill.name, provider, scope, options);
+      replaceDirectorySymlink(skill.stableLink, destination);
+      return { ...skill, destination };
+    }),
   };
+}
+
+function updateStableSkillLinks(options: WebcmdSkillInstallOptions): WebcmdSkillLink[] {
+  const skillsRoot = getSkillsRoot(options.packageRoot);
+  const skills = listWebcmdSkills(options.packageRoot);
+  if (skills.length === 0) {
+    throw new ArgumentError(`No Webcmd skills found: ${skillsRoot}`, 'Install a package that includes skills/*/SKILL.md.');
+  }
+
+  return skills.map((skill) => {
+    const source = path.join(skillsRoot, skill.name);
+    const stableLink = path.join(options.homeDir ?? os.homedir(), '.webcmd', 'skills', skill.name);
+    replaceDirectorySymlink(source, stableLink);
+    return { name: skill.name, source, stableLink };
+  });
+}
+
+function destinationFor(name: string, provider: SkillProvider | undefined, scope: SkillScope, options: WebcmdSkillInstallOptions): string {
+  if (options.customPath !== undefined) return path.join(expandHomePath(options.customPath), name);
+  const base = scope === 'project' ? options.cwd ?? process.cwd() : options.homeDir ?? os.homedir();
+  const agentDir = provider === 'claude' ? '.claude' : provider === 'codex' ? '.codex' : '.agents';
+  return path.join(base, agentDir, 'skills', name);
+}
+
+function expandHomePath(raw: string): string {
+  const value = raw.trim();
+  if (!value) throw new ArgumentError('Custom skills path must be non-empty.');
+  return path.resolve(value === '~' ? os.homedir() : value.startsWith('~/') ? path.join(os.homedir(), value.slice(2)) : value);
+}
+
+function normalizeProvider(raw = 'agents'): SkillProvider {
+  const value = raw.trim().toLowerCase();
+  if (value === 'agents' || value === 'codex') return value;
+  if (value === 'claude' || value === 'claude-code' || value === 'claude_code') return 'claude';
+  throw new ArgumentError(`Unsupported skill provider: ${raw}`, 'Use one of: agents, codex, claude.');
+}
+
+function normalizeScope(raw = 'user'): SkillScope {
+  const value = raw.trim().toLowerCase();
+  if (value === 'user' || value === 'global') return 'user';
+  if (value === 'project' || value === 'local') return 'project';
+  throw new ArgumentError(`Unsupported skill scope: ${raw}`, 'Use one of: user, global, project, local.');
+}
+
+function replaceDirectorySymlink(target: string, linkPath: string): void {
+  const current = safeLstat(linkPath);
+  if (current) {
+    if (!current.isSymbolicLink()) {
+      throw new ArgumentError(`Refusing to replace non-symlink path: ${linkPath}`, 'Remove it manually or choose a different scope/provider.');
+    }
+    fs.unlinkSync(linkPath);
+  }
+
+  fs.mkdirSync(path.dirname(linkPath), { recursive: true });
+  fs.symlinkSync(target, linkPath, process.platform === 'win32' ? 'junction' : 'dir');
+}
+
+function safeLstat(filePath: string): fs.Stats | null {
+  try {
+    return fs.lstatSync(filePath);
+  } catch (err) {
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') return null;
+    throw err;
+  }
 }
 
 function readSkillInfo(skillsRoot: string, name: string): WebcmdSkillInfo | null {
@@ -81,32 +165,6 @@ function readSkillInfo(skillsRoot: string, name: string): WebcmdSkillInfo | null
     version: typeof fm.version === 'string' || typeof fm.version === 'number' ? String(fm.version) : '',
     path: `${name}/SKILL.md`,
   };
-}
-
-function parseSkillTarget(target: string, relpath: string): { name: string; pathInSkill: string } {
-  const normalizedTarget = normalizeSkillPath(target);
-  if (relpath) {
-    return { name: normalizedTarget, pathInSkill: relpath };
-  }
-  const slash = normalizedTarget.indexOf('/');
-  if (slash === -1) {
-    return { name: normalizedTarget, pathInSkill: '' };
-  }
-  return {
-    name: normalizedTarget.slice(0, slash),
-    pathInSkill: normalizedTarget.slice(slash + 1),
-  };
-}
-
-function normalizeSkillPath(raw: string): string {
-  const normalized = raw.trim().replace(/\\/g, '/');
-  if (!normalized || normalized.includes('\0')) {
-    throw new ArgumentError('Skill path must be non-empty.');
-  }
-  if (normalized.startsWith('/') || normalized.split('/').some((part) => part === '..')) {
-    throw new ArgumentError(`Invalid skill path: ${raw}`, 'Use a path relative to a Webcmd skill directory.');
-  }
-  return path.posix.normalize(normalized);
 }
 
 function parseFrontmatter(content: string): SkillFrontmatter {


### PR DESCRIPTION
## Summary
- Ships all seven Webcmd agent skills as installable bundled skills under `skills/` and includes them in the npm package via `skills/**`.
- Adds `webcmd skills install` as the main user-facing installer. In an interactive terminal it now asks for:
  - global vs local project install
  - agent target: `agents`, `codex`, `claude`, or a custom skills path
- Keeps automation/script usage non-interactive with `--scope`, `--provider`, `--path`, and `--json`.
- Installs through a stable symlink chain so package updates can be repaired without reinstalling every skill manually:

```text
agent skills dir/<skill> -> ~/.webcmd/skills/<skill> -> current package skills/<skill>
```

- Maps provider destinations explicitly:
  - `agents` -> `.agents/skills/<skill>`
  - `codex` -> `.codex/skills/<skill>`
  - `claude` -> `.claude/skills/<skill>`
  - custom path -> `<custom-path>/<skill>`
- Adds `webcmd skills update` to refresh stable Webcmd-managed symlinks and optionally repair provider/custom-path links.
- Updates docs to point users at `webcmd skills install` instead of manual skill copying.
- Adds focused coverage for bundled skill listing, YAML frontmatter validation, install/update symlink behavior, Codex destination paths, custom paths, and overwrite protection.

## Reasoning
The goal is to make Webcmd skills easy to install without asking users to approve seven separate skill installs. A single `webcmd skills install` command gives users an `npx skills add`-style flow while still leaving each workflow skill as a normal standalone agent skill.

The stable `~/.webcmd/skills/<skill>` middle link keeps updates boring: after the package changes, `webcmd skills update` can repoint Webcmd-managed links to the current package location. The installer refuses to replace real files or directories and only replaces symlinks, so it does not silently destroy user-owned skill folders.

No prompt dependency was added; Node's built-in readline is enough for this small flow. Scripts keep the old predictable behavior by using flags or `--json`, so CI and automation do not hang waiting for input.

## Testing
- `npm test -- src/cli.test.ts src/skills.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...origin/single-discovery-skill`
- TTY smoke: `webcmd skills install` -> Global -> Codex installs to `.codex/skills/*`
- TTY smoke: `webcmd skills install` -> Global -> Custom path installs to `<custom-path>/*`
- Non-TTY smoke: `webcmd skills install` keeps default non-interactive install behavior
- JSON smoke: `webcmd skills install --path <tmp> --json` emits custom-path destinations