### PR TITLE
Fix plugin management e2e test: replace deleted GitHub repo

### DIFF
--- a/tests/e2e/plugin-management.test.ts
+++ b/tests/e2e/plugin-management.test.ts
@@ -1,6 +1,6 @@
 /**
  * E2E integration tests for plugin management commands.
- * Uses a real GitHub plugin (webcmd-plugin-hot-digest) to verify the full
+ * Uses a real GitHub plugin (webcmd-plugin-bookmyshow) to verify the full
  * install → list → update → uninstall lifecycle in an isolated HOME.
  */
 
@@ -13,8 +13,8 @@ import { runCli, parseJsonOutput } from './helpers.js';
 const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-plugin-e2e-'));
 const WEBCMD_HOME = path.join(TEST_HOME, '.webcmd');
 const PLUGINS_DIR = path.join(WEBCMD_HOME, 'plugins');
-const PLUGIN_SOURCE = 'github:ByteYue/webcmd-plugin-hot-digest';
-const PLUGIN_NAME = 'hot-digest';
+const PLUGIN_SOURCE = 'github:rishabhraj36/webcmd-plugin-bookmyshow';
+const PLUGIN_NAME = 'bookmyshow';
 const PLUGIN_DIR = path.join(PLUGINS_DIR, PLUGIN_NAME);
 const LOCK_FILE = path.join(WEBCMD_HOME, 'plugins.lock.json');
 
@@ -63,7 +63,7 @@ describe('plugin management E2E', () => {
     expect(lock[PLUGIN_NAME].source).toMatchObject({
       kind: 'git',
     });
-    expect(lock[PLUGIN_NAME].source.url).toContain('webcmd-plugin-hot-digest');
+    expect(lock[PLUGIN_NAME].source.url).toContain('webcmd-plugin-bookmyshow');
     expect(lock[PLUGIN_NAME].installedAt).toBeTruthy();
   }, 60_000);
 


### PR DESCRIPTION
## Summary
- The e2e test at `tests/e2e/plugin-management.test.ts` referenced `github:ByteYue/webcmd-plugin-hot-digest`, which has been deleted upstream ("Repository not found"). This broke `plugin install` and cascaded into 4 downstream tests that assumed the plugin was installed (`plugin list`, `plugin list -f json`, `plugin update`, `plugin uninstall`).
- Replaced it with `github:rishabhraj36/webcmd-plugin-bookmyshow`, a live repo with a valid `webcmd-plugin.json` manifest (name: `bookmyshow`) and top-level command files, so the full install → list → update → uninstall lifecycle can be exercised for real.

## Test plan
- [x] `npx vitest run tests/e2e/plugin-management.test.ts` — all 10 tests pass
- [x] `npx vitest run` (full suite) — 370 files / 4130 tests pass, 1 unrelated skip, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)