### PR TITLE
fix: reconcile district checkout selection with the requested seats

### DIFF
--- a/clis/district/checkout.js
+++ b/clis/district/checkout.js
@@ -94,6 +94,63 @@ async function selectRequestedSeats(page, requestedSeats, timeout) {
   return selected;
 }
 
+async function readSelectedSeats(page) {
+  const seats = await page.evaluate(`
+    (() => {
+      return [...document.querySelectorAll('#selected-seat span,[aria-label^="selected class"]')].map((el) => {
+        const aria = el.getAttribute('aria-label') || '';
+        const row = ((aria.match(/row\\s+([^,\\s]+)/i) || [])[1] || '').trim().toUpperCase();
+        const number = (el.querySelector('label')?.innerText || el.innerText || '').replace(/\\s+/g, '').trim();
+        return row && number ? row + number : '';
+      }).filter(Boolean);
+    })()
+  `);
+  return Array.isArray(seats) ? seats : [];
+}
+
+async function toggleSeat(page, seat) {
+  const result = await page.evaluate(`
+    (() => {
+      const wanted = ${JSON.stringify(seat)};
+      const candidates = [...document.querySelectorAll('#available-seat,[id="selected-seat"] span,[aria-label*="seat"]')];
+      const parse = (el) => {
+        const aria = el.getAttribute('aria-label') || '';
+        const row = ((aria.match(/row\\s+([^,\\s]+)/i) || [])[1] || '').trim().toUpperCase();
+        const number = (el.querySelector('label')?.innerText || el.innerText || '').replace(/\\s+/g, '').trim();
+        return row && number ? row + number : '';
+      };
+      const target = candidates.find((el) => parse(el) === wanted);
+      if (!target) return { ok: false, message: wanted + ' was not found in the seat map' };
+      target.click();
+      return { ok: true };
+    })()
+  `);
+  if (!result?.ok) throw new CommandExecutionError(result?.message || `Could not toggle ${seat}`);
+}
+
+/**
+ * District remembers the last ticket quantity per profile and auto-selects
+ * that many adjacent seats on the first click, so the selection can contain
+ * seats nobody asked for. Deselect extras, reselect anything knocked out,
+ * and refuse to proceed until the selection matches the request exactly.
+ */
+async function reconcileSelection(page, requestedSeats, timeout) {
+  const wanted = new Set(requestedSeats);
+  const deadline = Date.now() + timeout * 1000;
+  let selected = await readSelectedSeats(page);
+  while (Date.now() < deadline) {
+    const extras = selected.filter((seat) => !wanted.has(seat));
+    const missing = requestedSeats.filter((seat) => !selected.includes(seat));
+    if (!extras.length && !missing.length) return;
+    for (const seat of [...extras, ...missing]) await toggleSeat(page, seat);
+    await page.wait(0.5);
+    selected = await readSelectedSeats(page);
+  }
+  throw new CommandExecutionError(
+    `District kept the selection at ${selected.join(', ') || 'no seats'} while ${requestedSeats.join(', ')} was requested; a pending booking or sticky ticket count may be interfering — open the browser tab to inspect`,
+  );
+}
+
 async function clickProceed(page, timeout) {
   const result = await page.evaluate(`
     (() => {
@@ -272,7 +329,20 @@ cli({
 
     await dismissSeatDrawer(page);
     const selected = await selectRequestedSeats(page, seats, timeout);
+    await reconcileSelection(page, seats, timeout);
     await clickProceed(page, timeout);
-    return extractReview(page, target, selected, timeout);
+    const review = await extractReview(page, target, selected, timeout);
+
+    // Final contract check: the review page is the last stop before money
+    // moves, so a resumed pending order or re-expanded selection must fail
+    // loudly here rather than hand the user the wrong tickets to pay for.
+    const reviewSeats = String(review.seats || '').split(/\s*,\s*/).filter(Boolean).sort().join(',');
+    const requested = [...seats].sort().join(',');
+    if (reviewSeats && reviewSeats !== requested) {
+      throw new CommandExecutionError(
+        `District review shows seats ${review.seats} but ${seats.join(', ')} was requested; open the browser tab and correct the order before paying`,
+      );
+    }
+    return review;
   },
 });


### PR DESCRIPTION
## Summary

Found while testing the released 0.2.2: District remembers the last ticket quantity per browser profile and **auto-selects that many adjacent seats on the first seat click**. A `--seats H10,H11` checkout therefore selected H10–H12 and proceeded to the payment page with 3 tickets (₹1175.76 instead of ₹783.84). The adapter verified that each *requested* seat was selected and never noticed the extra one — a wrong-success, the worst failure mode for a write command.

## Fix

Two guards in `clis/district/checkout.js`:

1. **`reconcileSelection`** — after selecting the requested seats, read the actual selected set, click off any extra seats, re-add anything knocked out, and refuse to click Proceed until the selection matches the request exactly (bounded by the command timeout, with an actionable error naming both sets).
2. **Review-page assertion** — the order-review page is the last stop before money moves, so the order's seats are compared against the request there too; a mismatch (e.g. a resumed pending order with different seats) fails loudly instead of handing the user the wrong tickets to pay for.

## Testing

Reproduced live against district.in with a profile that had previously booked 3 seats: before the fix, `--seats H10,H11` reached the payment page with H10–H12 / 3 tickets; after the fix, the identical request reached it with exactly H10, H11 / 2 tickets (₹783.84). `cli-manifest.json` is unchanged (no registration metadata changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)