### PR TITLE
Fix adapter CliError envelope rendering

### DIFF
--- a/src/commanderAdapter.test.ts
+++ b/src/commanderAdapter.test.ts
@@ -388,6 +388,33 @@ describe('commanderAdapter error envelope output', () => {
     stderrSpy.mockRestore();
   });
 
+  it('preserves CliError-like adapter error code and exitCode across module boundaries', async () => {
+    const program = new Command();
+    const siteCmd = program.command('github');
+    registerCommandToProgram(siteCmd, cmd);
+
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const err = new Error('Practo /logged_in_user rejected the current browser session') as Error & {
+      code: string;
+      hint: string;
+      exitCode: number;
+    };
+    err.code = 'AUTH_REQUIRED';
+    err.hint = 'Please open Chrome or Chromium and log in to https://www.practo.com';
+    err.exitCode = 77;
+    mockExecuteCommand.mockRejectedValueOnce(err);
+
+    await program.parseAsync(['node', 'webcmd', 'github', 'issue', '12345']);
+
+    const output = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+    expect(output).toContain('code: AUTH_REQUIRED');
+    expect(output).toContain('exitCode: 77');
+    expect(output).not.toContain('AutoFix: re-run');
+    expect(process.exitCode).toBe(77);
+
+    stderrSpy.mockRestore();
+  });
+
   it('does not add an AutoFix rerun hint when trace is already enabled', async () => {
     const program = new Command();
     const siteCmd = program.command('github');

--- a/src/commanderAdapter.ts
+++ b/src/commanderAdapter.ts
@@ -28,8 +28,8 @@ import {
   siteHelpData,
 } from './help.js';
 import {
-  CliError,
   EXIT_CODES,
+  isCliErrorLike,
   toEnvelope,
 } from './errors.js';
 
@@ -153,7 +153,7 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
 // ── Exit code resolution ─────────────────────────────────────────────────────
 
 function resolveExitCode(err: unknown): number {
-  if (err instanceof CliError) return err.exitCode;
+  if (isCliErrorLike(err)) return err.exitCode;
   return EXIT_CODES.GENERIC_ERROR;
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -77,6 +77,16 @@ export function getTraceReceipt(err: unknown): ObservationTraceReceipt | undefin
   return (err as Record<PropertyKey, unknown>)[TRACE_RECEIPT_SYMBOL] as ObservationTraceReceipt | undefined;
 }
 
+export function isCliErrorLike(err: unknown): err is CliError {
+  if (err instanceof CliError) return true;
+  if (!err || (typeof err !== 'object' && typeof err !== 'function')) return false;
+  const value = err as Record<string, unknown>;
+  return typeof value.code === 'string'
+    && value.code.length > 0
+    && typeof value.message === 'string'
+    && Number.isInteger(value.exitCode);
+}
+
 // ── Typed subclasses ─────────────────────────────────────────────────────────
 
 export type BrowserConnectKind = 'daemon-not-running' | 'runtime-not-ready' | 'extension-not-connected' | 'profile-required' | 'profile-disconnected' | 'command-failed' | 'unknown';
@@ -246,13 +256,13 @@ export function toEnvelope(err: unknown): ErrorEnvelope {
     receiptPath: traceReceipt.receiptPath,
     status: traceReceipt.status,
   } : undefined;
-  if (err instanceof CliError) {
+  if (isCliErrorLike(err)) {
     return {
       ok: false,
       error: {
         code: err.code,
         message: err.message,
-        ...(err.hint ? { help: err.hint } : {}),
+        ...(typeof err.hint === 'string' && err.hint ? { help: err.hint } : {}),
         exitCode: err.exitCode,
         ...(cause ? { cause } : {}),
       },


### PR DESCRIPTION
## Summary

- preserve typed adapter error envelopes even when `instanceof CliError` fails across module boundaries
- use the same CliError-like guard for process exit code resolution
- add regression coverage for auth-style adapter errors rendering as `AUTH_REQUIRED` instead of `UNKNOWN`

Fixes #47.

## Verification

- `npm test -- src/errors.test.ts src/commanderAdapter.test.ts`
- `npm run typecheck`
- `npm test`
