### PR TITLE
Add Practo adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -16115,6 +16115,417 @@
     "siteSession": "persistent"
   },
   {
+    "site": "practo",
+    "name": "appointment",
+    "description": "Show logged-in Practo Drive appointment details",
+    "access": "read",
+    "domain": "drive.practo.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "appointment_id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Appointment id from `practo appointments`"
+      }
+    ],
+    "columns": [
+      "appointment_id",
+      "status",
+      "summary"
+    ],
+    "type": "js",
+    "modulePath": "practo/appointment.js",
+    "sourceFile": "practo/appointment.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "practo",
+    "name": "appointments",
+    "description": "List logged-in Practo Drive appointments",
+    "access": "read",
+    "domain": "drive.practo.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "appointment_id",
+      "doctor",
+      "practice",
+      "time",
+      "status"
+    ],
+    "type": "js",
+    "modulePath": "practo/appointments.js",
+    "sourceFile": "practo/appointments.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "practo",
+    "name": "book-confirm",
+    "description": "Confirm a Practo clinic visit booking after explicit confirmation",
+    "access": "write",
+    "domain": "www.practo.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "practice_doctor_id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Practo practice_doctor_id"
+      },
+      {
+        "name": "time",
+        "type": "str",
+        "required": true,
+        "help": "Slot time YYYY-MM-DD HH:mm:ss"
+      },
+      {
+        "name": "profile-url",
+        "type": "str",
+        "required": false,
+        "help": "Doctor profile_url from `practo search`, used to build a canonical booking URL"
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Required. Set --confirm true to create the appointment."
+      }
+    ],
+    "columns": [
+      "status",
+      "practice_doctor_id",
+      "time",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "practo/book-confirm.js",
+    "sourceFile": "practo/book-confirm.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "practo",
+    "name": "book-preview",
+    "description": "Preview Practo booking details for a selected slot without confirming",
+    "access": "read",
+    "domain": "www.practo.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "practice_doctor_id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Practo practice_doctor_id"
+      },
+      {
+        "name": "time",
+        "type": "str",
+        "required": true,
+        "help": "Slot time YYYY-MM-DD HH:mm:ss"
+      },
+      {
+        "name": "profile-url",
+        "type": "str",
+        "required": false,
+        "help": "Doctor profile_url from `practo search`, used to build a canonical booking URL"
+      }
+    ],
+    "columns": [
+      "practice_doctor_id",
+      "time",
+      "amount",
+      "prepaid",
+      "payment_mode",
+      "requires_payment",
+      "confirm_button",
+      "booking_url"
+    ],
+    "type": "js",
+    "modulePath": "practo/book-preview.js",
+    "sourceFile": "practo/book-preview.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "practo",
+    "name": "booking-link",
+    "description": "Build a Practo booking URL for a selected slot without confirming it",
+    "access": "read",
+    "domain": "www.practo.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "practice_doctor_id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Practo practice_doctor_id"
+      },
+      {
+        "name": "time",
+        "type": "str",
+        "required": true,
+        "help": "Slot time YYYY-MM-DD HH:mm:ss"
+      },
+      {
+        "name": "profile-url",
+        "type": "str",
+        "required": false,
+        "help": "Doctor profile_url from `practo search`, used to build a canonical booking URL"
+      }
+    ],
+    "columns": [
+      "practice_doctor_id",
+      "time",
+      "booking_url"
+    ],
+    "type": "js",
+    "modulePath": "practo/booking-link.js",
+    "sourceFile": "practo/booking-link.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "practo",
+    "name": "cancel",
+    "description": "Cancel a logged-in Practo Drive appointment after explicit confirmation",
+    "access": "write",
+    "domain": "drive.practo.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "appointment_id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Appointment id from `practo appointments`"
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Required. Set --confirm true to cancel the appointment."
+      }
+    ],
+    "columns": [
+      "status",
+      "appointment_id"
+    ],
+    "type": "js",
+    "modulePath": "practo/cancel.js",
+    "sourceFile": "practo/cancel.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "practo",
+    "name": "contact",
+    "description": "Get Practo virtual contact number for a practice_doctor_id",
+    "access": "read",
+    "domain": "www.practo.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "practice_doctor_id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Practo practice_doctor_id from search results"
+      }
+    ],
+    "columns": [
+      "practice_doctor_id",
+      "phone",
+      "raw"
+    ],
+    "type": "js",
+    "modulePath": "practo/contact.js",
+    "sourceFile": "practo/contact.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "practo",
+    "name": "login",
+    "description": "Open Practo login for manual sign-in",
+    "access": "write",
+    "domain": "www.practo.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "status",
+      "site",
+      "message"
+    ],
+    "type": "js",
+    "modulePath": "practo/login.js",
+    "sourceFile": "practo/login.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "practo",
+    "name": "profile",
+    "description": "Read public details from a Practo doctor profile URL",
+    "access": "read",
+    "domain": "www.practo.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "url",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Practo doctor profile URL"
+      }
+    ],
+    "columns": [
+      "name",
+      "specialty",
+      "experience",
+      "fee",
+      "profile_url"
+    ],
+    "type": "js",
+    "modulePath": "practo/profile.js",
+    "sourceFile": "practo/profile.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "practo",
+    "name": "search",
+    "description": "Search Practo doctors by specialty, city, and optional locality",
+    "access": "read",
+    "domain": "www.practo.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "specialty",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Doctor specialty, e.g. orthopedist or dermatologist"
+      },
+      {
+        "name": "city",
+        "type": "str",
+        "default": "bangalore",
+        "required": false,
+        "help": "City, e.g. bangalore"
+      },
+      {
+        "name": "locality",
+        "type": "str",
+        "required": false,
+        "help": "Optional locality, e.g. indiranagar"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Max doctors to return (1-25)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "practice_doctor_id",
+      "doctor_id",
+      "practice_id",
+      "name",
+      "specialty",
+      "experience_years",
+      "locality",
+      "clinic",
+      "fee",
+      "next_available",
+      "profile_url"
+    ],
+    "type": "js",
+    "modulePath": "practo/search.js",
+    "sourceFile": "practo/search.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "practo",
+    "name": "slots",
+    "description": "List available Practo appointment slots for a practice_doctor_id",
+    "access": "read",
+    "domain": "www.practo.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "practice_doctor_id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Practo practice_doctor_id from search results"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max slots to return (1-25)"
+      }
+    ],
+    "columns": [
+      "practice_doctor_id",
+      "time",
+      "available",
+      "amount",
+      "prepaid",
+      "appointment_token"
+    ],
+    "type": "js",
+    "modulePath": "practo/slots.js",
+    "sourceFile": "practo/slots.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "practo",
+    "name": "whoami",
+    "aliases": [
+      "auth-status"
+    ],
+    "description": "Show whether the current browser session is logged into Practo",
+    "access": "read",
+    "domain": "www.practo.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "practo/whoami.js",
+    "sourceFile": "practo/whoami.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
     "site": "producthunt",
     "name": "browse",
     "description": "Best products in a Product Hunt category",

--- a/clis/practo/appointment.js
+++ b/clis/practo/appointment.js
@@ -1,0 +1,21 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { driveJson, normalizeAppointmentId } from './utils.js';
+
+cli({
+  site: 'practo',
+  name: 'appointment',
+  access: 'read',
+  description: 'Show logged-in Practo Drive appointment details',
+  domain: 'drive.practo.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  siteSession: 'persistent',
+  args: [{ name: 'appointment_id', positional: true, required: true, help: 'Appointment id from `practo appointments`' }],
+  columns: ['appointment_id', 'status', 'summary'],
+  func: async (page, kwargs) => {
+    const id = normalizeAppointmentId(kwargs.appointment_id);
+    const data = await driveJson(page, `/api/record/v2/appointment/${encodeURIComponent(id)}`);
+    return [{ appointment_id: id, status: data?.status || data?.data?.status || '', summary: JSON.stringify(data?.data ?? data).slice(0, 1000) }];
+  },
+});

--- a/clis/practo/appointments.js
+++ b/clis/practo/appointments.js
@@ -1,0 +1,27 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { driveJson } from './utils.js';
+
+cli({
+  site: 'practo',
+  name: 'appointments',
+  access: 'read',
+  description: 'List logged-in Practo Drive appointments',
+  domain: 'drive.practo.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  siteSession: 'persistent',
+  args: [],
+  columns: ['appointment_id', 'doctor', 'practice', 'time', 'status'],
+  func: async (page) => {
+    const data = await driveJson(page, '/api/record/v2/appointments');
+    const list = Array.isArray(data?.data) ? data.data : [];
+    return list.map((item) => ({
+      appointment_id: String(item.id || item.appointment_id || item.object_identifier || ''),
+      doctor: item.doctor_name || item.provider_name || item.doctor?.name || '',
+      practice: item.practice_name || item.establishment_name || item.practice?.name || '',
+      time: item.appointment_time || item.scheduled_at || item.from_time || '',
+      status: item.status || item.state || '',
+    }));
+  },
+});

--- a/clis/practo/book-confirm.js
+++ b/clis/practo/book-confirm.js
@@ -1,0 +1,35 @@
+import { ArgumentError, CommandExecutionError } from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { bookingPreviewFromPageData, normalizeConfirm, prepareBookingPage, submitBookingPage } from './utils.js';
+
+cli({
+  site: 'practo',
+  name: 'book-confirm',
+  access: 'write',
+  description: 'Confirm a Practo clinic visit booking after explicit confirmation',
+  domain: 'www.practo.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  defaultWindowMode: 'foreground',
+  siteSession: 'persistent',
+  args: [
+    { name: 'practice_doctor_id', positional: true, required: true, help: 'Practo practice_doctor_id' },
+    { name: 'time', required: true, help: 'Slot time YYYY-MM-DD HH:mm:ss' },
+    { name: 'profile-url', required: false, help: 'Doctor profile_url from `practo search`, used to build a canonical booking URL' },
+    { name: 'confirm', type: 'boolean', default: false, help: 'Required. Set --confirm true to create the appointment.' },
+  ],
+  columns: ['status', 'practice_doctor_id', 'time', 'url'],
+  func: async (page, kwargs) => {
+    if (!normalizeConfirm(kwargs.confirm)) {
+      throw new ArgumentError('Refusing to book appointment without --confirm true', 'Example: webcmd practo book-confirm 859054 --time "2026-07-10 10:30:00" --confirm true');
+    }
+    const prepared = await prepareBookingPage(page, kwargs);
+    const preview = bookingPreviewFromPageData(prepared.data, prepared.context)[0];
+    if (preview.requires_payment) {
+      throw new CommandExecutionError('This Practo slot appears to require online payment; stopping before payment.');
+    }
+    const result = await submitBookingPage(page);
+    return [{ status: 'submitted', practice_doctor_id: prepared.context.practiceDoctorId, time: prepared.context.slotTime, url: result.url || prepared.context.url }];
+  },
+});

--- a/clis/practo/book-preview.js
+++ b/clis/practo/book-preview.js
@@ -1,0 +1,24 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { bookingPreviewFromPageData, prepareBookingPage } from './utils.js';
+
+cli({
+  site: 'practo',
+  name: 'book-preview',
+  access: 'read',
+  description: 'Preview Practo booking details for a selected slot without confirming',
+  domain: 'www.practo.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  siteSession: 'persistent',
+  args: [
+    { name: 'practice_doctor_id', positional: true, required: true, help: 'Practo practice_doctor_id' },
+    { name: 'time', required: true, help: 'Slot time YYYY-MM-DD HH:mm:ss' },
+    { name: 'profile-url', required: false, help: 'Doctor profile_url from `practo search`, used to build a canonical booking URL' },
+  ],
+  columns: ['practice_doctor_id', 'time', 'amount', 'prepaid', 'payment_mode', 'requires_payment', 'confirm_button', 'booking_url'],
+  func: async (page, kwargs) => {
+    const prepared = await prepareBookingPage(page, kwargs);
+    return bookingPreviewFromPageData(prepared.data, prepared.context);
+  },
+});

--- a/clis/practo/booking-link.js
+++ b/clis/practo/booking-link.js
@@ -1,0 +1,24 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { buildBookingUrl, findSlot, normalizePracticeDoctorId, rowsForSlots } from './utils.js';
+
+cli({
+  site: 'practo',
+  name: 'booking-link',
+  access: 'read',
+  description: 'Build a Practo booking URL for a selected slot without confirming it',
+  domain: 'www.practo.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  args: [
+    { name: 'practice_doctor_id', positional: true, required: true, help: 'Practo practice_doctor_id' },
+    { name: 'time', required: true, help: 'Slot time YYYY-MM-DD HH:mm:ss' },
+    { name: 'profile-url', required: false, help: 'Doctor profile_url from `practo search`, used to build a canonical booking URL' },
+  ],
+  columns: ['practice_doctor_id', 'time', 'booking_url'],
+  func: async (page, kwargs) => {
+    const practiceDoctorId = normalizePracticeDoctorId(kwargs.practice_doctor_id);
+    const slot = findSlot(await rowsForSlots(page, practiceDoctorId), kwargs.time);
+    return [{ practice_doctor_id: practiceDoctorId, time: slot.time, booking_url: buildBookingUrl({ practiceDoctorId, slotTime: slot.time, appointmentToken: slot.appointment_token, amount: slot.amount, prepaid: slot.prepaid, profileUrl: kwargs['profile-url'] }) }];
+  },
+});

--- a/clis/practo/cancel.js
+++ b/clis/practo/cancel.js
@@ -1,0 +1,29 @@
+import { ArgumentError } from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { cancelAppointment, normalizeAppointmentId, normalizeConfirm } from './utils.js';
+
+cli({
+  site: 'practo',
+  name: 'cancel',
+  access: 'write',
+  description: 'Cancel a logged-in Practo Drive appointment after explicit confirmation',
+  domain: 'drive.practo.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  defaultWindowMode: 'foreground',
+  siteSession: 'persistent',
+  args: [
+    { name: 'appointment_id', positional: true, required: true, help: 'Appointment id from `practo appointments`' },
+    { name: 'confirm', type: 'boolean', default: false, help: 'Required. Set --confirm true to cancel the appointment.' },
+  ],
+  columns: ['status', 'appointment_id'],
+  func: async (page, kwargs) => {
+    const id = normalizeAppointmentId(kwargs.appointment_id);
+    if (!normalizeConfirm(kwargs.confirm)) {
+      throw new ArgumentError('Refusing to cancel appointment without --confirm true', 'Example: webcmd practo cancel <appointment_id> --confirm true');
+    }
+    await cancelAppointment(page, id);
+    return [{ status: 'cancelled', appointment_id: id }];
+  },
+});

--- a/clis/practo/contact.js
+++ b/clis/practo/contact.js
@@ -1,0 +1,21 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { normalizePracticeDoctorId, practoJson } from './utils.js';
+
+cli({
+  site: 'practo',
+  name: 'contact',
+  access: 'read',
+  description: 'Get Practo virtual contact number for a practice_doctor_id',
+  domain: 'www.practo.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  args: [{ name: 'practice_doctor_id', positional: true, required: true, help: 'Practo practice_doctor_id from search results' }],
+  columns: ['practice_doctor_id', 'phone', 'raw'],
+  func: async (page, kwargs) => {
+    const id = normalizePracticeDoctorId(kwargs.practice_doctor_id);
+    const data = await practoJson(page, `/health/api/vn/vnpractice?practice_doctor_id=${id}`);
+    const phone = data?.phone_number || data?.phone || data?.number || data?.data?.phone_number || '';
+    return [{ practice_doctor_id: id, phone, raw: phone ? '' : JSON.stringify(data).slice(0, 500) }];
+  },
+});

--- a/clis/practo/login.js
+++ b/clis/practo/login.js
@@ -1,0 +1,21 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { PRACTO } from './utils.js';
+
+cli({
+  site: 'practo',
+  name: 'login',
+  access: 'write',
+  description: 'Open Practo login for manual sign-in',
+  domain: 'www.practo.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  defaultWindowMode: 'foreground',
+  siteSession: 'persistent',
+  args: [],
+  columns: ['status', 'site', 'message'],
+  func: async (page) => {
+    await page.goto(`${PRACTO}/login`);
+    return [{ status: 'opened', site: 'practo', message: 'Finish login in the browser, then run `webcmd practo whoami`.' }];
+  },
+});

--- a/clis/practo/practo.test.js
+++ b/clis/practo/practo.test.js
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import { ArgumentError } from '@agentrhq/webcmd/errors';
+import { getRegistry } from '@agentrhq/webcmd/registry';
+import './appointment.js';
+import './appointments.js';
+import './book-confirm.js';
+import './book-preview.js';
+import './booking-link.js';
+import './cancel.js';
+import './contact.js';
+import './login.js';
+import './profile.js';
+import './search.js';
+import './slots.js';
+import './whoami.js';
+import { __test__ } from './utils.js';
+
+const {
+  buildSearchUrl,
+  buildBookingUrl,
+  normalizeConfirm,
+  normalizeLimit,
+  normalizePracticeDoctorId,
+  normalizeSlotTime,
+  rowsFromSearchState,
+  rowsFromSlotsPayload,
+} = __test__;
+
+describe('practo helpers', () => {
+  it('builds city/specialty search URLs', () => {
+    expect(buildSearchUrl({ city: 'Bangalore', specialty: 'Orthopedist' })).toBe('https://www.practo.com/bangalore/orthopedist');
+    expect(buildSearchUrl({ city: 'New Delhi', specialty: 'Dentist', locality: 'South Extension' })).toBe('https://www.practo.com/new-delhi/dentist/south-extension');
+  });
+
+  it('validates identity, limits, slot times, and confirmations', () => {
+    expect(normalizePracticeDoctorId('859054')).toBe('859054');
+    expect(normalizeLimit('3')).toBe(3);
+    expect(normalizeSlotTime('2026-07-10 10:30:00')).toBe('2026-07-10 10:30:00');
+    expect(normalizeConfirm(true)).toBe(true);
+    expect(normalizeConfirm('true')).toBe(true);
+    expect(() => normalizePracticeDoctorId('abc')).toThrow(ArgumentError);
+    expect(() => normalizeLimit(0)).toThrow(ArgumentError);
+    expect(() => normalizeSlotTime('tomorrow')).toThrow(ArgumentError);
+  });
+
+  it('maps listing redux doctors into stable search rows', () => {
+    const rows = rowsFromSearchState({
+      listingV2: {
+        doctors: {
+          entities: {
+            1: {
+              id: 859054,
+              doctor_id: 1056089,
+              practice_id: 776696,
+              doctor_name: 'Dr. Nithin Patel',
+              specialization: 'Orthopedist',
+              experience_years: 12,
+              locality: 'Koramangala',
+              city: 'Bangalore',
+              practice: { name: 'Practo Clinic' },
+              consultation_fees: 1000,
+              profile_url: '/bangalore/doctor/dr-nithin-patel-orthopedist',
+              next_available_timestamp: '2026-07-10T10:30:00+05:30',
+            },
+          },
+        },
+      },
+    }, 1);
+    expect(rows).toEqual([{
+      rank: 1,
+      practice_doctor_id: '859054',
+      doctor_id: '1056089',
+      practice_id: '776696',
+      name: 'Dr. Nithin Patel',
+      specialty: 'Orthopedist',
+      experience_years: 12,
+      locality: 'Koramangala',
+      city: 'Bangalore',
+      clinic: 'Practo Clinic',
+      fee: 1000,
+      next_available: '2026-07-10T10:30:00+05:30',
+      profile_url: 'https://www.practo.com/bangalore/doctor/dr-nithin-patel-orthopedist',
+    }]);
+  });
+
+  it('maps slot payloads into rows and booking URLs', () => {
+    const rows = rowsFromSlotsPayload({
+      practice_doctor_id: 859054,
+      amount: 1000,
+      prepaid: false,
+      appointment_token: 'abc',
+      slots: [{
+        datestamp: '2026-07-10',
+        slots: [{ time: '10:00', timeslots: [{ ts: '2026-07-10 10:30:00', available: true }] }],
+      }],
+    });
+    expect(rows).toEqual([{
+      practice_doctor_id: '859054',
+      time: '2026-07-10 10:30:00',
+      available: true,
+      amount: 1000,
+      prepaid: false,
+      appointment_token: 'abc',
+    }]);
+    expect(buildBookingUrl({ practiceDoctorId: '859054', slotTime: rows[0].time, appointmentToken: 'abc', amount: 1000, prepaid: false }))
+      .toContain('/appointment/doctor/859054/book?');
+  });
+});
+
+describe('practo command registry', () => {
+  it('registers the approved command surface', () => {
+    for (const name of ['whoami', 'login', 'search', 'profile', 'slots', 'contact', 'booking-link', 'appointments', 'appointment', 'book-preview', 'book-confirm', 'cancel']) {
+      expect(getRegistry().get(`practo/${name}`)).toBeDefined();
+    }
+    expect(getRegistry().get('practo/auth-status')).toBe(getRegistry().get('practo/whoami'));
+  });
+
+  it('marks writes as explicit confirm commands', () => {
+    const book = getRegistry().get('practo/book-confirm');
+    const cancel = getRegistry().get('practo/cancel');
+    expect(book.access).toBe('write');
+    expect(cancel.access).toBe('write');
+    expect(book.args.find((arg) => arg.name === 'confirm')?.type).toBe('boolean');
+    expect(cancel.args.find((arg) => arg.name === 'confirm')?.type).toBe('boolean');
+  });
+
+  it('refuses real booking without --confirm true', async () => {
+    const book = getRegistry().get('practo/book-confirm');
+    await expect(book.func({}, { practice_doctor_id: '859054', time: '2026-07-10 10:30:00' })).rejects.toThrow(ArgumentError);
+  });
+
+  it('refuses cancellation without --confirm true', async () => {
+    const cancel = getRegistry().get('practo/cancel');
+    await expect(cancel.func({}, { appointment_id: 'abc' })).rejects.toThrow(ArgumentError);
+  });
+});

--- a/clis/practo/profile.js
+++ b/clis/practo/profile.js
@@ -1,0 +1,31 @@
+import { EmptyResultError } from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { PRACTO, unwrapBrowserResult } from './utils.js';
+
+cli({
+  site: 'practo',
+  name: 'profile',
+  access: 'read',
+  description: 'Read public details from a Practo doctor profile URL',
+  domain: 'www.practo.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  args: [{ name: 'url', positional: true, required: true, help: 'Practo doctor profile URL' }],
+  columns: ['name', 'specialty', 'experience', 'fee', 'profile_url'],
+  func: async (page, kwargs) => {
+    const url = new URL(String(kwargs.url), PRACTO).toString();
+    await page.goto(url);
+    await page.wait(2);
+    const row = unwrapBrowserResult(await page.evaluate(`(() => {
+      const text = document.body?.innerText || '';
+      const title = document.querySelector('h1')?.textContent?.trim() || document.title.replace(/ - Practo.*/, '').trim();
+      const specialty = (text.match(/(Orthopedist|Dentist|Dermatologist|Gynecologist|Pediatrician|General Physician|Cardiologist)/i) || [,''])[1];
+      const experience = (text.match(/(\\d+\\s+Years? Experience)/i) || [,''])[1];
+      const fee = (text.match(/(?:₹|Rs\\.?\\s*)([0-9,]+)/i) || [,''])[1];
+      return { name: title, specialty, experience, fee: fee ? Number(fee.replace(/,/g, '')) : '', profile_url: location.href };
+    })()`));
+    if (!row?.name) throw new EmptyResultError('practo profile');
+    return [row];
+  },
+});

--- a/clis/practo/search.js
+++ b/clis/practo/search.js
@@ -1,0 +1,30 @@
+import { EmptyResultError } from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { buildSearchUrl, normalizeLimit, rowsFromSearchState, unwrapBrowserResult } from './utils.js';
+
+cli({
+  site: 'practo',
+  name: 'search',
+  access: 'read',
+  description: 'Search Practo doctors by specialty, city, and optional locality',
+  domain: 'www.practo.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  args: [
+    { name: 'specialty', positional: true, required: true, help: 'Doctor specialty, e.g. orthopedist or dermatologist' },
+    { name: 'city', default: 'bangalore', help: 'City, e.g. bangalore' },
+    { name: 'locality', help: 'Optional locality, e.g. indiranagar' },
+    { name: 'limit', type: 'int', default: 10, help: 'Max doctors to return (1-25)' },
+  ],
+  columns: ['rank', 'practice_doctor_id', 'doctor_id', 'practice_id', 'name', 'specialty', 'experience_years', 'locality', 'clinic', 'fee', 'next_available', 'profile_url'],
+  func: async (page, kwargs) => {
+    const limit = normalizeLimit(kwargs.limit);
+    await page.goto(buildSearchUrl(kwargs));
+    await page.wait(2);
+    const state = unwrapBrowserResult(await page.evaluate(`(() => window.__REDUX_STATE__ || window.__PRELOADED_STATE__ || null)()`));
+    const rows = rowsFromSearchState(state, limit);
+    if (rows.length === 0) throw new EmptyResultError('practo search', 'No doctor cards were found in Practo page state.');
+    return rows;
+  },
+});

--- a/clis/practo/slots.js
+++ b/clis/practo/slots.js
@@ -1,0 +1,19 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { normalizeLimit, rowsForSlots } from './utils.js';
+
+cli({
+  site: 'practo',
+  name: 'slots',
+  access: 'read',
+  description: 'List available Practo appointment slots for a practice_doctor_id',
+  domain: 'www.practo.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  args: [
+    { name: 'practice_doctor_id', positional: true, required: true, help: 'Practo practice_doctor_id from search results' },
+    { name: 'limit', type: 'int', default: 20, help: 'Max slots to return (1-25)' },
+  ],
+  columns: ['practice_doctor_id', 'time', 'available', 'amount', 'prepaid', 'appointment_token'],
+  func: async (page, kwargs) => (await rowsForSlots(page, kwargs.practice_doctor_id)).filter((row) => row.available).slice(0, normalizeLimit(kwargs.limit, 20)),
+});

--- a/clis/practo/utils.js
+++ b/clis/practo/utils.js
@@ -1,0 +1,374 @@
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+
+const SLOT_TIME_RE = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
+export const PRACTO = 'https://www.practo.com';
+export const DRIVE = 'https://drive.practo.com';
+
+export function slugifyPathPart(value, label) {
+  const out = String(value ?? '').trim().toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  if (!out) throw new ArgumentError(`${label} is required`);
+  return out;
+}
+
+export function normalizeLimit(value, defaultValue = 10, max = 25) {
+  const n = Number(value ?? defaultValue);
+  if (!Number.isInteger(n) || n < 1 || n > max) {
+    throw new ArgumentError(`limit must be an integer from 1 to ${max}`);
+  }
+  return n;
+}
+
+export function normalizePracticeDoctorId(value) {
+  const id = String(value ?? '').trim();
+  if (!/^\d+$/.test(id)) {
+    throw new ArgumentError('practice_doctor_id must be numeric', 'Use `webcmd practo search ...` or `webcmd practo slots <practice_doctor_id>` first.');
+  }
+  return id;
+}
+
+export function normalizeAppointmentId(value) {
+  const id = String(value ?? '').trim();
+  if (!id) throw new ArgumentError('appointment_id is required');
+  return id;
+}
+
+export function normalizeSlotTime(value) {
+  const raw = String(value ?? '').trim();
+  if (!SLOT_TIME_RE.test(raw)) {
+    throw new ArgumentError('time must be YYYY-MM-DD HH:mm:ss', 'Example: --time "2026-07-10 10:30:00"');
+  }
+  return raw;
+}
+
+export function normalizeConfirm(value) {
+  return value === true || value === 'true';
+}
+
+export function unwrapBrowserResult(value) {
+  if (value && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, 'data') && Object.prototype.hasOwnProperty.call(value, 'session')) {
+    return value.data;
+  }
+  return value;
+}
+
+export async function evalJson(page, url, init = {}) {
+  const result = unwrapBrowserResult(await page.evaluate(`(async () => {
+    try {
+      const res = await fetch(${JSON.stringify(url)}, {
+        credentials: 'include',
+        method: ${JSON.stringify(init.method || 'GET')},
+        headers: ${JSON.stringify(init.headers || { Accept: 'application/json' })},
+        body: ${init.body == null ? 'undefined' : JSON.stringify(init.body)}
+      });
+      const text = await res.text();
+      let data = null;
+      try { data = text ? JSON.parse(text) : null; } catch { data = { text }; }
+      if (!res.ok) return { __error: 'HTTP ' + res.status, status: res.status, data };
+      return data;
+    } catch (e) {
+      return { __error: String(e && e.message || e) };
+    }
+  })()`));
+  return assertJsonOk(result, url);
+}
+
+export async function practoJson(page, pathOrUrl) {
+  await page.goto(PRACTO);
+  return evalJson(page, pathOrUrl.startsWith('http') ? pathOrUrl : `${PRACTO}${pathOrUrl}`);
+}
+
+export async function driveJson(page, path, init = {}) {
+  await page.goto(`${DRIVE}/appointments`);
+  return evalJson(page, `${DRIVE}${path}`, init);
+}
+
+function displayName(user) {
+  return String(user?.name || user?.user?.name || user?.profile?.name || user?.logged_in_user?.name || '').trim();
+}
+
+export async function probeIdentity(page) {
+  let user;
+  try {
+    user = await practoJson(page, '/logged_in_user');
+  } catch (error) {
+    if (/HTTP 401|HTTP 403/.test(error?.message || '')) {
+      throw new AuthRequiredError('www.practo.com', 'Practo /logged_in_user rejected the current browser session');
+    }
+    throw error;
+  }
+  if (!user || user.__error) throw new AuthRequiredError('www.practo.com');
+  return [{ logged_in: true, site: 'practo', name: displayName(user) }];
+}
+
+export function buildSearchUrl({ city, specialty, locality }) {
+  const parts = [
+    'https://www.practo.com',
+    slugifyPathPart(city, 'city'),
+    slugifyPathPart(specialty, 'specialty'),
+  ];
+  if (String(locality ?? '').trim()) parts.push(slugifyPathPart(locality, 'locality'));
+  return parts.join('/');
+}
+
+export function buildSlotsUrl(practiceDoctorId) {
+  return `https://www.practo.com/health/api/practicedoctors/${normalizePracticeDoctorId(practiceDoctorId)}/slots?mobile=true&group_by_hour=true&logged_in_api=false&first_available=true&`;
+}
+
+export async function rowsForSlots(page, practiceDoctorId) {
+  const payload = await practoJson(page, buildSlotsUrl(practiceDoctorId));
+  const rows = rowsFromSlotsPayload(payload);
+  if (rows.length === 0) throw new EmptyResultError('practo slots', 'No available slots were returned for that practice_doctor_id.');
+  return rows;
+}
+
+function slugFromProfileUrl(profileUrl) {
+  const raw = text(profileUrl);
+  if (!raw) return 'doctor';
+  try {
+    const url = new URL(raw, 'https://www.practo.com');
+    const parts = url.pathname.split('/').filter(Boolean);
+    const doctorIndex = parts.indexOf('doctor');
+    return doctorIndex >= 0 && parts[doctorIndex + 1] ? parts[doctorIndex + 1] : 'doctor';
+  } catch {
+    return 'doctor';
+  }
+}
+
+export function buildBookingUrl({ practiceDoctorId, slotTime, appointmentToken = '', amount = '', prepaid = false, profileUrl = '' }) {
+  const params = new URLSearchParams();
+  params.set('type', 'abs');
+  params.set('doctor_id', normalizePracticeDoctorId(practiceDoctorId));
+  params.set('appointment_time', normalizeSlotTime(slotTime));
+  if (appointmentToken) params.set('appointment_token', String(appointmentToken));
+  params.set('prepaid', String(Boolean(prepaid)));
+  if (amount !== '' && amount != null) params.set('amount', String(amount));
+  return `https://www.practo.com/appointment/${slugFromProfileUrl(profileUrl)}/${practiceDoctorId}/book?${params.toString()}`;
+}
+
+export function bookingPreviewFromPageData(data, context) {
+  const text = String(data?.text || '');
+  const confirmText = data?.confirmText || '';
+  const paymentMode = context.paymentMode || data?.paymentMode || (/pay at clinic/i.test(text) ? 'Pay At Clinic' : '');
+  return [{
+    practice_doctor_id: context.practiceDoctorId,
+    time: context.slotTime,
+    amount: context.amount,
+    prepaid: context.prepaid,
+    payment_mode: paymentMode,
+    requires_payment: Boolean(paymentMode && !/pay at clinic/i.test(paymentMode)),
+    confirm_button: confirmText,
+    booking_url: context.url,
+  }];
+}
+
+export async function prepareBookingPage(page, kwargs) {
+  const practiceDoctorId = normalizePracticeDoctorId(kwargs.practice_doctor_id ?? kwargs.practiceDoctorId);
+  const slotTime = normalizeSlotTime(kwargs.time);
+  const slots = await rowsForSlots(page, practiceDoctorId);
+  const slot = findSlot(slots, slotTime);
+  let paymentMode = '';
+  try {
+    const summary = await practoJson(page, `/health/api/appointment/payment/summary?appointment_type=abs&platform=web&practice_doctor_id=${practiceDoctorId}`);
+    const modes = summary?.payment_mode_details || summary?.data?.payment_mode_details || [];
+    paymentMode = String(modes?.[0]?.mode || modes?.[0]?.payment_mode || '').trim();
+  } catch {
+    paymentMode = '';
+  }
+  const url = buildBookingUrl({
+    practiceDoctorId,
+    slotTime,
+    appointmentToken: slot.appointment_token,
+    amount: slot.amount,
+    prepaid: slot.prepaid,
+    profileUrl: kwargs['profile-url'] ?? kwargs.profile_url ?? kwargs.profileUrl,
+  });
+  await page.goto(url);
+  let ready = false;
+  for (let i = 0; i < 60; i++) {
+    const readyNow = unwrapBrowserResult(await page.evaluate(`(() => /Confirm Clinic Visit|Enter your mobile number|sign in|login/i.test(document.body?.innerText || ''))()`));
+    if (readyNow) {
+      ready = true;
+      break;
+    }
+    await page.wait(0.5);
+  }
+  const data = unwrapBrowserResult(await page.evaluate(`(() => {
+    const text = document.body?.innerText || '';
+    const buttons = Array.from(document.querySelectorAll('button, [role="button"], input[type="submit"]'))
+      .map((el) => (el.innerText || el.value || el.textContent || '').replace(/\\s+/g, ' ').trim())
+      .filter(Boolean);
+    return {
+      url: location.href,
+      text,
+      buttons,
+      confirmText: buttons.find((label) => /confirm clinic visit|confirm/i.test(label)) || '',
+      paymentMode: (/pay at clinic/i.test(text) && 'Pay At Clinic') || (/pay online/i.test(text) && 'Pay Online') || ''
+    };
+  })()`));
+  if (/enter your mobile number|login|sign in/i.test(String(data?.text || ''))) {
+    throw new AuthRequiredError('www.practo.com', 'Booking page requires a logged-in Practo session');
+  }
+  if (!ready || !data?.confirmText) {
+    throw new CommandExecutionError(
+      `Practo booking page did not expose a confirm button at ${data?.url || 'unknown URL'}`,
+      'Pass --profile-url from `webcmd practo search ...` so the adapter can build Practo\'s canonical booking URL.',
+    );
+  }
+  return { slot, data, context: { practiceDoctorId, slotTime, amount: slot.amount, prepaid: slot.prepaid, paymentMode, url } };
+}
+
+export async function submitBookingPage(page) {
+  const result = unwrapBrowserResult(await page.evaluate(`(async () => {
+    const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+    const buttons = Array.from(document.querySelectorAll('button, [role="button"], input[type="submit"]'));
+    const button = buttons.find((el) => /confirm clinic visit|confirm/i.test(el.innerText || el.value || el.textContent || ''));
+    if (!button) return { ok: false, message: 'Confirm Clinic Visit button not found' };
+    button.click();
+    await sleep(3000);
+    return { ok: true, url: location.href, text: document.body?.innerText || '' };
+  })()`));
+  if (!result?.ok) throw new CommandExecutionError(result?.message || 'Failed to click Practo confirmation button');
+  return result;
+}
+
+export async function cancelAppointment(page, appointmentId) {
+  await page.goto(`${DRIVE}/appointments`);
+  const result = unwrapBrowserResult(await page.evaluate(`(async () => {
+    const token = decodeURIComponent((document.cookie.split('; ').find((c) => c.startsWith('X-Genesis-Token=')) || '').split('=')[1] || '');
+    if (!token) return { ok: false, message: 'X-Genesis-Token cookie missing' };
+    const res = await fetch(${JSON.stringify(`${DRIVE}/api/record/v2/cancel_appointment/${appointmentId}`)}, {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'X-Genesis-Token': token }
+    });
+    const text = await res.text();
+    return { ok: res.ok, status: res.status, text };
+  })()`));
+  if (!result?.ok) {
+    if (result?.status === 401 || result?.status === 403) throw new AuthRequiredError('drive.practo.com', `Practo Drive cancel returned HTTP ${result.status}`);
+    throw new CommandExecutionError(`Practo cancel failed: ${result?.message || result?.status || 'unknown'}`);
+  }
+}
+
+function text(value) {
+  if (value == null) return '';
+  if (typeof value === 'object') {
+    return text(firstDefined(value.name, value.practice_name, value.establishment_name, value.clinic_name, value.locality));
+  }
+  return String(value).replace(/\s+/g, ' ').trim();
+}
+
+function firstDefined(...values) {
+  return values.find((value) => value !== undefined && value !== null && value !== '');
+}
+
+function asAbsPractoUrl(value) {
+  const raw = text(value);
+  if (!raw) return '';
+  try {
+    return new URL(raw, 'https://www.practo.com').toString();
+  } catch {
+    return raw;
+  }
+}
+
+function doctorsFromState(state) {
+  const doctors = state?.listingV2?.doctors?.entities ?? state?.doctors?.entities ?? state?.doctors;
+  if (Array.isArray(doctors)) return doctors;
+  if (doctors && typeof doctors === 'object') return Object.values(doctors);
+  return [];
+}
+
+export function rowsFromSearchState(state, limit = 10) {
+  return doctorsFromState(state).slice(0, limit).map((doctor, i) => {
+    const practiceDoctorId = firstDefined(doctor.practice_doctor_id, doctor.relation_id, doctor.id);
+    const name = firstDefined(doctor.doctor_name, doctor.name, doctor.display_name);
+    if (!practiceDoctorId || !name) return null;
+    return {
+      rank: i + 1,
+      practice_doctor_id: String(practiceDoctorId),
+      doctor_id: text(firstDefined(doctor.doctor_id, doctor.provider_id)),
+      practice_id: text(firstDefined(doctor.practice_id, doctor.establishment_id)),
+      name: text(name),
+      specialty: text(firstDefined(doctor.specialization, doctor.speciality, doctor.specialty)),
+      experience_years: firstDefined(doctor.experience_years, doctor.experience),
+      locality: text(firstDefined(doctor.locality, doctor.locality_name)),
+      city: text(doctor.city),
+      clinic: text(firstDefined(doctor.practice, doctor.practice_name, doctor.clinic_name)),
+      fee: firstDefined(doctor.consultation_fees, doctor.fees, doctor.fee),
+      next_available: text(firstDefined(doctor.next_available_timestamp, doctor.next_available, doctor.first_available_day_slots?.[0]?.time)),
+      profile_url: asAbsPractoUrl(firstDefined(doctor.profile_url, doctor.url, doctor.translated_new_slug)),
+    };
+  }).filter(Boolean);
+}
+
+function flattenSlots(value, out = []) {
+  if (!value) return out;
+  if (Array.isArray(value)) {
+    for (const item of value) flattenSlots(item, out);
+    return out;
+  }
+  if (typeof value !== 'object') return out;
+  const time = firstDefined(value.ts, value.start_time, value.appointment_time, value.slot_time);
+  if (time) out.push(value);
+  else if (value.time && !value.timeslots && !value.slots) out.push(value);
+  for (const key of ['timeslots', 'slots', 'items', 'available_slots', 'hour_slots']) {
+    if (value[key]) flattenSlots(value[key], out);
+  }
+  return out;
+}
+
+export function rowsFromSlotsPayload(payload) {
+  const data = payload?.data ?? payload;
+  const practiceDoctorId = text(firstDefined(data?.practice_doctor_id, data?.practiceDoctorId));
+  const amount = firstDefined(data?.amount, data?.appointment_payment_details?.amount, data?.fee);
+  const prepaid = Boolean(firstDefined(data?.prepaid, data?.appointment_payment_details?.prepaid, false));
+  const appointmentToken = text(firstDefined(data?.appointment_token, data?.appointmentToken));
+  return flattenSlots(data?.slots ?? data).map((slot) => ({
+    practice_doctor_id: text(firstDefined(slot.practice_doctor_id, practiceDoctorId)),
+    time: text(firstDefined(slot.ts, slot.time, slot.start_time, slot.appointment_time, slot.slot_time)),
+    available: firstDefined(slot.available, slot.is_available, true) !== false,
+    amount: firstDefined(slot.amount, amount),
+    prepaid: Boolean(firstDefined(slot.prepaid, prepaid)),
+    appointment_token: text(firstDefined(slot.appointment_token, appointmentToken)),
+  })).filter((row) => row.practice_doctor_id && row.time);
+}
+
+export function findSlot(slots, slotTime) {
+  const wanted = normalizeSlotTime(slotTime);
+  const slot = slots.find((row) => row.time === wanted);
+  if (!slot) {
+    throw new EmptyResultError('practo slots', `No Practo slot matched ${wanted}. Run \`webcmd practo slots <practice_doctor_id>\` first.`);
+  }
+  if (slot.available === false) {
+    throw new EmptyResultError('practo slots', `Practo slot ${wanted} is not available.`);
+  }
+  return slot;
+}
+
+export function assertJsonOk(result, label) {
+  if (!result || typeof result !== 'object') {
+    throw new CommandExecutionError(`${label} returned no data`);
+  }
+  if (result.__error) {
+    throw new CommandExecutionError(`${label} failed: ${result.__error}`);
+  }
+  return result;
+}
+
+export const __test__ = {
+  buildSearchUrl,
+  buildSlotsUrl,
+  buildBookingUrl,
+  normalizeConfirm,
+  normalizeLimit,
+  normalizePracticeDoctorId,
+  normalizeAppointmentId,
+  normalizeSlotTime,
+  rowsFromSearchState,
+  rowsFromSlotsPayload,
+  findSlot,
+};

--- a/clis/practo/whoami.js
+++ b/clis/practo/whoami.js
@@ -1,0 +1,28 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { probeIdentity } from './utils.js';
+
+cli({
+  site: 'practo',
+  name: 'whoami',
+  aliases: ['auth-status'],
+  access: 'read',
+  description: 'Show whether the current browser session is logged into Practo',
+  domain: 'www.practo.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  siteSession: 'persistent',
+  args: [],
+  columns: ['logged_in', 'site', 'name'],
+  authStatus: {
+    quickCheck: async (page) => {
+      try {
+        const rows = await probeIdentity(page);
+        return { logged_in: true, name: rows[0].name };
+      } catch {
+        return { logged_in: false };
+      }
+    },
+  },
+  func: probeIdentity,
+});


### PR DESCRIPTION
## Summary

- add a browser-backed Practo adapter for doctor discovery, slot lookup, contact lookup, booking preview, appointment listing/details, booking confirmation, and cancellation
- split safe logged-out commands from logged-in appointment management commands
- require explicit `--confirm true` for real booking and cancellation writes
- regenerate `cli-manifest.json`

## Commands

Public / logged-out capable:

- `practo search`
- `practo profile`
- `practo slots`
- `practo contact`
- `practo booking-link`

Logged-in / session-backed:

- `practo whoami` / `practo auth-status`
- `practo login`
- `practo appointments`
- `practo appointment`
- `practo book-preview`
- `practo book-confirm --confirm true`
- `practo cancel --confirm true`

## Safety

- `book-preview` opens the booking page and reports payment/confirmation state without clicking the final button.
- `book-confirm` refuses to run without `--confirm true` and stops before online-payment flows.
- `cancel` refuses to run without `--confirm true`.

## Verification

- `npm run build-manifest`
- `npm run test:adapter -- clis/practo/practo.test.js`
- `npm test`
- `npm run typecheck`

Live safe checks were also run earlier for `doctor`, `practo whoami`, `practo search`, `practo slots`, `practo booking-link`, `practo appointments`, and `practo book-preview`. No appointment was created.
