### PR TITLE
Fix Practo login wait flow

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -16873,16 +16873,25 @@
   {
     "site": "practo",
     "name": "login",
-    "description": "Open Practo login for manual sign-in",
+    "description": "Open Practo login and wait until the browser session is authenticated",
     "access": "write",
     "domain": "www.practo.com",
     "strategy": "cookie",
     "browser": true,
-    "args": [],
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
     "columns": [
       "status",
+      "logged_in",
       "site",
-      "message"
+      "name"
     ],
     "type": "js",
     "modulePath": "practo/login.js",

--- a/clis/practo/login.js
+++ b/clis/practo/login.js
@@ -1,21 +1,48 @@
+import { AuthRequiredError, TimeoutError } from '@agentrhq/webcmd/errors';
 import { cli, Strategy } from '@agentrhq/webcmd/registry';
-import { PRACTO } from './utils.js';
+import { PRACTO, probeIdentity } from './utils.js';
+
+const DEFAULT_TIMEOUT_SECONDS = 300;
+
+function isAuthRequired(error) {
+  return error instanceof AuthRequiredError;
+}
 
 cli({
   site: 'practo',
   name: 'login',
   access: 'write',
-  description: 'Open Practo login for manual sign-in',
+  description: 'Open Practo login and wait until the browser session is authenticated',
   domain: 'www.practo.com',
   strategy: Strategy.COOKIE,
   browser: true,
   navigateBefore: false,
   defaultWindowMode: 'foreground',
   siteSession: 'persistent',
-  args: [],
-  columns: ['status', 'site', 'message'],
-  func: async (page) => {
-    await page.goto(`${PRACTO}/login`);
-    return [{ status: 'opened', site: 'practo', message: 'Finish login in the browser, then run `webcmd practo whoami`.' }];
+  args: [
+    { name: 'timeout', type: 'int', default: DEFAULT_TIMEOUT_SECONDS, help: 'Maximum seconds to wait for the user to finish login' },
+  ],
+  columns: ['status', 'logged_in', 'site', 'name'],
+  func: async (page, kwargs) => {
+    try {
+      const rows = await probeIdentity(page);
+      return [{ status: 'already_logged_in', ...rows[0] }];
+    } catch (error) {
+      if (!isAuthRequired(error)) throw error;
+    }
+
+    await page.goto(`${PRACTO}/login`, { waitUntil: 'none', settleMs: 1500 });
+    const timeout = Number(kwargs.timeout ?? DEFAULT_TIMEOUT_SECONDS);
+    const deadline = Date.now() + timeout * 1000;
+    while (Date.now() < deadline) {
+      await page.wait(2);
+      try {
+        const rows = await probeIdentity(page);
+        return [{ status: 'login_complete', ...rows[0] }];
+      } catch (error) {
+        if (!isAuthRequired(error)) throw error;
+      }
+    }
+    throw new TimeoutError('practo login', timeout, 'Complete Practo login in the browser, then retry.');
   },
 });

--- a/clis/practo/practo.test.js
+++ b/clis/practo/practo.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ArgumentError } from '@agentrhq/webcmd/errors';
 import { getRegistry } from '@agentrhq/webcmd/registry';
 import './appointment.js';
@@ -122,6 +122,24 @@ describe('practo command registry', () => {
     expect(cancel.access).toBe('write');
     expect(book.args.find((arg) => arg.name === 'confirm')?.type).toBe('boolean');
     expect(cancel.args.find((arg) => arg.name === 'confirm')?.type).toBe('boolean');
+  });
+
+  it('waits for manual login to complete', async () => {
+    const login = getRegistry().get('practo/login');
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn()
+        .mockResolvedValueOnce({ __error: 'HTTP 401', status: 401 })
+        .mockResolvedValueOnce({ name: 'Ada' }),
+    };
+
+    await expect(login.func(page, { timeout: 1 })).resolves.toEqual([{
+      status: 'login_complete',
+      logged_in: true,
+      site: 'practo',
+      name: 'Ada',
+    }]);
   });
 
   it('refuses real booking without --confirm true', async () => {


### PR DESCRIPTION
## Summary
- update Practo login to wait for manual auth completion instead of returning immediately
- avoid Practo/accounts redirect churn by opening the login page with non-blocking navigation
- add regression coverage and refresh the CLI manifest

## Verification
- npm run test:adapter -- clis/practo/practo.test.js
- npm run typecheck

## Manual smoke
- webcmd practo login --timeout 2 now exits with a clean TIMEOUT/help message instead of UNKNOWN: execution context destroyed when login is not completed in time