### PR TITLE
feat: added plugin marketplace catalog commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "clis/",
     "skills/**",
     "cli-manifest.json",
+    "plugin-catalog.json",
     "scripts/",
     "README.md",
     "LICENSE",

--- a/plugin-catalog.json
+++ b/plugin-catalog.json
@@ -2,7 +2,7 @@
   "version": 1,
   "sources": [
     {
-      "id": "webcmd-official",
+      "id": "agentrhq/webcmd",
       "source": "github:agentrhq/webcmd",
       "manifestUrl": "https://raw.githubusercontent.com/agentrhq/webcmd/main/webcmd-plugin.json"
     }

--- a/plugin-catalog.json
+++ b/plugin-catalog.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "sources": [
+    {
+      "id": "webcmd-official",
+      "source": "github:agentrhq/webcmd",
+      "manifestUrl": "https://raw.githubusercontent.com/agentrhq/webcmd/main/webcmd-plugin.json"
+    }
+  ]
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -68,7 +68,7 @@ describe('createProgram root help descriptions', () => {
     expect(descriptionFor(program, 'browser')).toContain('verify');
     expect(descriptionFor(program, 'browser')).not.toContain('Browser control');
     expect(descriptionFor(program, 'auth')).toBe('refresh, status');
-    expect(descriptionFor(program, 'plugin')).toBe('create, install, list, uninstall, update');
+    expect(descriptionFor(program, 'plugin')).toBe('catalog, create, install, list, search, uninstall, update');
     expect(descriptionFor(program, 'adapter')).toBe('eject, reset, status');
     expect(descriptionFor(program, 'profile')).toBe('list, rename, use');
     expect(descriptionFor(program, 'daemon')).toBe('restart, status, stop');
@@ -693,7 +693,7 @@ name: 'search',
         description: 'Manage webcmd plugins',
         namespace_options: [],
       });
-      expect(data.commands.map((cmd: any) => cmd.name)).toEqual(['create', 'install', 'list', 'uninstall', 'update']);
+      expect(data.commands.map((cmd: any) => cmd.name)).toEqual(['catalog add', 'catalog list', 'catalog remove', 'create', 'install', 'list', 'search', 'uninstall', 'update']);
       const update = data.commands.find((cmd: any) => cmd.name === 'update');
       expect(update).toMatchObject({
         usage: 'webcmd plugin update [name] [options]',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3272,6 +3272,103 @@ cli({
       console.log();
     });
 
+
+  const catalogCmd = pluginCmd
+    .command('catalog')
+    .description('Manage plugin marketplace sources');
+
+  catalogCmd
+    .command('list')
+    .description('List configured plugin marketplace sources')
+    .option('-f, --format <fmt>', 'Output format: table, json', 'table')
+    .action(async (opts: { format?: string }) => {
+      const { readCatalog } = await import('./plugin-catalog.js');
+      try {
+        const catalog = readCatalog();
+        if (opts.format === 'json') {
+          renderOutput(catalog, { fmt: 'json' });
+          return;
+        }
+        renderOutput(catalog.sources, {
+          fmt: opts.format,
+          columns: ['id', 'source', 'manifestUrl'],
+          title: `${CLI_COMMAND}/plugin-catalog`,
+          source: `${CLI_COMMAND} plugin catalog list`,
+        });
+      } catch (err) {
+        console.error(`Error: ${getErrorMessage(err)}`);
+        process.exitCode = EXIT_CODES.GENERIC_ERROR;
+      }
+    });
+
+  catalogCmd
+    .command('add')
+    .description('Add a plugin marketplace source')
+    .argument('<source>', 'Marketplace source, e.g. github:owner/repo')
+    .option('-f, --format <fmt>', 'Output format: table, json', 'table')
+    .action(async (source: string, opts: { format?: string }) => {
+      const { addCatalogSource } = await import('./plugin-catalog.js');
+      try {
+        const added = await addCatalogSource(source);
+        renderOutput(opts.format === 'json' ? added : [added], {
+          fmt: opts.format,
+          columns: ['id', 'source', 'manifestUrl'],
+          title: `${CLI_COMMAND}/plugin-catalog`,
+          source: `${CLI_COMMAND} plugin catalog add`,
+        });
+      } catch (err) {
+        console.error(`Error: ${getErrorMessage(err)}`);
+        process.exitCode = EXIT_CODES.GENERIC_ERROR;
+      }
+    });
+
+  catalogCmd
+    .command('remove')
+    .description('Remove a plugin marketplace source')
+    .argument('<id>', 'Catalog source id')
+    .action(async (id: string) => {
+      const { removeCatalogSource } = await import('./plugin-catalog.js');
+      try {
+        removeCatalogSource(id);
+        console.log(`✅ Catalog source "${id}" removed.`);
+      } catch (err) {
+        console.error(`Error: ${getErrorMessage(err)}`);
+        process.exitCode = EXIT_CODES.GENERIC_ERROR;
+      }
+    });
+
+  pluginCmd
+    .command('search')
+    .description('Search installable marketplace plugins')
+    .argument('[query]', 'Search query matched against plugin name and description')
+    .option('-f, --format <fmt>', 'Output format: table, json', 'table')
+    .action(async (query: string | undefined, opts: { format?: string }) => {
+      const { readCatalog, searchCatalogPlugins } = await import('./plugin-catalog.js');
+      try {
+        const catalog = readCatalog();
+        const result = await searchCatalogPlugins(catalog, { query });
+        if (opts.format === 'json') {
+          renderOutput(result, { fmt: 'json' });
+        } else {
+          for (const err of result.errors) {
+            console.error(`Warning: ${err.sourceId}: ${err.message}`);
+          }
+          renderOutput(result.plugins, {
+            fmt: opts.format,
+            columns: ['name', 'description', 'version', 'sourceId', 'installSource', 'webcmd'],
+            title: `${CLI_COMMAND}/plugin-search`,
+            source: `${CLI_COMMAND} plugin search`,
+          });
+        }
+        if (catalog.sources.length > 0 && result.errors.length === catalog.sources.length) {
+          process.exitCode = EXIT_CODES.GENERIC_ERROR;
+        }
+      } catch (err) {
+        console.error(`Error: ${getErrorMessage(err)}`);
+        process.exitCode = EXIT_CODES.GENERIC_ERROR;
+      }
+    });
+
   pluginCmd
     .command('create')
     .description('Create a new plugin scaffold')

--- a/src/plugin-catalog.test.ts
+++ b/src/plugin-catalog.test.ts
@@ -27,7 +27,7 @@ describe('plugin catalog', () => {
     fs.writeFileSync(path.join(packageRoot, 'plugin-catalog.json'), JSON.stringify({
       version: 1,
       sources: [{
-        id: 'webcmd-official',
+        id: 'agentrhq/webcmd',
         source: 'github:agentrhq/webcmd',
         manifestUrl: 'https://raw.githubusercontent.com/agentrhq/webcmd/main/webcmd-plugin.json',
       }],
@@ -41,31 +41,45 @@ describe('plugin catalog', () => {
   it('seeds the user catalog from the packaged default', () => {
     const catalog = readCatalog({ packageRoot, homeDir });
 
-    expect(catalog.sources).toEqual([{ id: 'webcmd-official', source: 'github:agentrhq/webcmd', manifestUrl: 'https://raw.githubusercontent.com/agentrhq/webcmd/main/webcmd-plugin.json' }]);
+    expect(catalog.sources).toEqual([{ id: 'agentrhq/webcmd', source: 'github:agentrhq/webcmd', manifestUrl: 'https://raw.githubusercontent.com/agentrhq/webcmd/main/webcmd-plugin.json' }]);
     expect(fs.existsSync(getUserPluginCatalogPath(homeDir))).toBe(true);
   });
 
   it('derives catalog metadata from github shorthand', () => {
     expect(deriveGithubCatalogSource('github:other-org/webcmd-travel-plugins')).toEqual({
-      id: 'other-org-webcmd-travel-plugins',
+      id: 'other-org/webcmd-travel-plugins',
       source: 'github:other-org/webcmd-travel-plugins',
       manifestUrl: 'https://raw.githubusercontent.com/other-org/webcmd-travel-plugins/main/webcmd-plugin.json',
     });
+  });
+
+  it('normalizes legacy github slug ids when reading catalogs', () => {
+    fs.mkdirSync(path.dirname(getUserPluginCatalogPath(homeDir)), { recursive: true });
+    fs.writeFileSync(getUserPluginCatalogPath(homeDir), JSON.stringify({
+      version: 1,
+      sources: [{
+        id: 'rishabhraj36-webcmd-plugin-nasa-images.json',
+        source: 'github:rishabhraj36/webcmd-plugin-nasa-images',
+        manifestUrl: 'https://raw.githubusercontent.com/rishabhraj36/webcmd-plugin-nasa-images/main/webcmd-plugin.json',
+      }],
+    }));
+
+    expect(readCatalog({ packageRoot, homeDir }).sources[0].id).toBe('rishabhraj36/webcmd-plugin-nasa-images');
   });
 
   it('adds and removes catalog sources in the user catalog', async () => {
     const fetchJson = async () => ({ name: 'travel', description: 'Travel tools' });
 
     const added = await addCatalogSource('github:other-org/webcmd-travel-plugins', { packageRoot, homeDir, fetchJson });
-    expect(added.id).toBe('other-org-webcmd-travel-plugins');
+    expect(added.id).toBe('other-org/webcmd-travel-plugins');
 
     expect(readCatalog({ packageRoot, homeDir }).sources.map((source) => source.id)).toEqual([
-      'webcmd-official',
-      'other-org-webcmd-travel-plugins',
+      'agentrhq/webcmd',
+      'other-org/webcmd-travel-plugins',
     ]);
 
-    removeCatalogSource('other-org-webcmd-travel-plugins', { packageRoot, homeDir });
-    expect(readCatalog({ packageRoot, homeDir }).sources.map((source) => source.id)).toEqual(['webcmd-official']);
+    removeCatalogSource('other-org/webcmd-travel-plugins', { packageRoot, homeDir });
+    expect(readCatalog({ packageRoot, homeDir }).sources.map((source) => source.id)).toEqual(['agentrhq/webcmd']);
   });
 
   it('rejects duplicate catalog sources', async () => {
@@ -77,7 +91,7 @@ describe('plugin catalog', () => {
 
   it('flattens monorepo manifests into installable rows', () => {
     const rows = flattenPluginManifest({
-      id: 'webcmd-official',
+      id: 'agentrhq/webcmd',
       source: 'github:agentrhq/webcmd',
       manifestUrl: 'https://example.com/webcmd-plugin.json',
     }, {
@@ -88,7 +102,7 @@ describe('plugin catalog', () => {
       },
     });
 
-    expect(rows).toEqual([{ name: 'skyscanner', description: 'Flights', version: '0.1.0', sourceId: 'webcmd-official', installSource: 'github:agentrhq/webcmd/skyscanner', webcmd: '>=0.2.1' }]);
+    expect(rows).toEqual([{ name: 'skyscanner', description: 'Flights', version: '0.1.0', sourceId: 'agentrhq/webcmd', installSource: 'github:agentrhq/webcmd/skyscanner', webcmd: '>=0.2.1' }]);
   });
 
   it('flattens single-plugin manifests into installable rows', () => {

--- a/src/plugin-catalog.test.ts
+++ b/src/plugin-catalog.test.ts
@@ -53,20 +53,6 @@ describe('plugin catalog', () => {
     });
   });
 
-  it('normalizes legacy github slug ids when reading catalogs', () => {
-    fs.mkdirSync(path.dirname(getUserPluginCatalogPath(homeDir)), { recursive: true });
-    fs.writeFileSync(getUserPluginCatalogPath(homeDir), JSON.stringify({
-      version: 1,
-      sources: [{
-        id: 'rishabhraj36-webcmd-plugin-nasa-images.json',
-        source: 'github:rishabhraj36/webcmd-plugin-nasa-images',
-        manifestUrl: 'https://raw.githubusercontent.com/rishabhraj36/webcmd-plugin-nasa-images/main/webcmd-plugin.json',
-      }],
-    }));
-
-    expect(readCatalog({ packageRoot, homeDir }).sources[0].id).toBe('rishabhraj36/webcmd-plugin-nasa-images');
-  });
-
   it('adds and removes catalog sources in the user catalog', async () => {
     const fetchJson = async () => ({ name: 'travel', description: 'Travel tools' });
 

--- a/src/plugin-catalog.test.ts
+++ b/src/plugin-catalog.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  addCatalogSource,
+  deriveGithubCatalogSource,
+  flattenPluginManifest,
+  getUserPluginCatalogPath,
+  readCatalog,
+  removeCatalogSource,
+  searchCatalogPlugins,
+  type PluginCatalog,
+} from './plugin-catalog.js';
+
+describe('plugin catalog', () => {
+  let tmpDir: string;
+  let packageRoot: string;
+  let homeDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-plugin-catalog-'));
+    packageRoot = path.join(tmpDir, 'package');
+    homeDir = path.join(tmpDir, 'home');
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.mkdirSync(homeDir, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, 'plugin-catalog.json'), JSON.stringify({
+      version: 1,
+      sources: [{
+        id: 'webcmd-official',
+        source: 'github:agentrhq/webcmd',
+        manifestUrl: 'https://raw.githubusercontent.com/agentrhq/webcmd/main/webcmd-plugin.json',
+      }],
+    }));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('seeds the user catalog from the packaged default', () => {
+    const catalog = readCatalog({ packageRoot, homeDir });
+
+    expect(catalog.sources).toEqual([{ id: 'webcmd-official', source: 'github:agentrhq/webcmd', manifestUrl: 'https://raw.githubusercontent.com/agentrhq/webcmd/main/webcmd-plugin.json' }]);
+    expect(fs.existsSync(getUserPluginCatalogPath(homeDir))).toBe(true);
+  });
+
+  it('derives catalog metadata from github shorthand', () => {
+    expect(deriveGithubCatalogSource('github:other-org/webcmd-travel-plugins')).toEqual({
+      id: 'other-org-webcmd-travel-plugins',
+      source: 'github:other-org/webcmd-travel-plugins',
+      manifestUrl: 'https://raw.githubusercontent.com/other-org/webcmd-travel-plugins/main/webcmd-plugin.json',
+    });
+  });
+
+  it('adds and removes catalog sources in the user catalog', async () => {
+    const fetchJson = async () => ({ name: 'travel', description: 'Travel tools' });
+
+    const added = await addCatalogSource('github:other-org/webcmd-travel-plugins', { packageRoot, homeDir, fetchJson });
+    expect(added.id).toBe('other-org-webcmd-travel-plugins');
+
+    expect(readCatalog({ packageRoot, homeDir }).sources.map((source) => source.id)).toEqual([
+      'webcmd-official',
+      'other-org-webcmd-travel-plugins',
+    ]);
+
+    removeCatalogSource('other-org-webcmd-travel-plugins', { packageRoot, homeDir });
+    expect(readCatalog({ packageRoot, homeDir }).sources.map((source) => source.id)).toEqual(['webcmd-official']);
+  });
+
+  it('rejects duplicate catalog sources', async () => {
+    const fetchJson = async () => ({ name: 'travel', description: 'Travel tools' });
+    await addCatalogSource('github:other-org/webcmd-travel-plugins', { packageRoot, homeDir, fetchJson });
+
+    await expect(addCatalogSource('github:other-org/webcmd-travel-plugins', { packageRoot, homeDir, fetchJson })).rejects.toThrow('already exists');
+  });
+
+  it('flattens monorepo manifests into installable rows', () => {
+    const rows = flattenPluginManifest({
+      id: 'webcmd-official',
+      source: 'github:agentrhq/webcmd',
+      manifestUrl: 'https://example.com/webcmd-plugin.json',
+    }, {
+      webcmd: '>=0.2.0',
+      plugins: {
+        skyscanner: { path: 'plugins/skyscanner', version: '0.1.0', description: 'Flights', webcmd: '>=0.2.1' },
+        disabled: { path: 'plugins/disabled', disabled: true },
+      },
+    });
+
+    expect(rows).toEqual([{ name: 'skyscanner', description: 'Flights', version: '0.1.0', sourceId: 'webcmd-official', installSource: 'github:agentrhq/webcmd/skyscanner', webcmd: '>=0.2.1' }]);
+  });
+
+  it('flattens single-plugin manifests into installable rows', () => {
+    const rows = flattenPluginManifest({
+      id: 'research-tools',
+      source: 'github:someone/research-tools',
+      manifestUrl: 'https://example.com/webcmd-plugin.json',
+    }, { name: 'research-tools', version: '0.1.0', description: 'Research helpers', webcmd: '>=0.2.0' });
+
+    expect(rows).toEqual([{ name: 'research-tools', description: 'Research helpers', version: '0.1.0', sourceId: 'research-tools', installSource: 'github:someone/research-tools', webcmd: '>=0.2.0' }]);
+  });
+
+  it('fetches manifests live and preserves remote errors in search output', async () => {
+    const catalog: PluginCatalog = {
+      version: 1,
+      sources: [
+        { id: 'ok', source: 'github:ok/repo', manifestUrl: 'https://ok.test/webcmd-plugin.json' },
+        { id: 'bad', source: 'github:bad/repo', manifestUrl: 'https://bad.test/webcmd-plugin.json' },
+      ],
+    };
+    const fetchJson = async (url: string) => {
+      if (url.includes('bad')) throw new Error('network failed');
+      return { plugins: { flights: { path: 'plugins/flights', description: 'Flight search' } } };
+    };
+
+    const result = await searchCatalogPlugins(catalog, { query: 'flight', fetchJson });
+
+    expect(result.plugins.map((plugin) => plugin.name)).toEqual(['flights']);
+    expect(result.errors).toEqual([{ sourceId: 'bad', manifestUrl: 'https://bad.test/webcmd-plugin.json', message: 'network failed' }]);
+  });
+});

--- a/src/plugin-catalog.ts
+++ b/src/plugin-catalog.ts
@@ -1,0 +1,217 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getEnabledPlugins, isMonorepo, type PluginManifest } from './plugin-manifest.js';
+import { findPackageRoot } from './package-paths.js';
+
+const MODULE_FILE = fileURLToPath(import.meta.url);
+const CATALOG_FILENAME = 'plugin-catalog.json';
+
+export interface PluginCatalogSource {
+  id: string;
+  source: string;
+  manifestUrl: string;
+}
+
+export interface PluginCatalog {
+  version: 1;
+  sources: PluginCatalogSource[];
+}
+
+export interface PluginSearchRow {
+  name: string;
+  description?: string;
+  version?: string;
+  sourceId: string;
+  installSource: string;
+  webcmd?: string;
+}
+
+export interface PluginSearchError {
+  sourceId: string;
+  manifestUrl: string;
+  message: string;
+}
+
+export interface PluginSearchResult {
+  plugins: PluginSearchRow[];
+  errors: PluginSearchError[];
+}
+
+type FetchJson = (url: string) => Promise<unknown>;
+
+interface CatalogOptions {
+  packageRoot?: string;
+  homeDir?: string;
+  fetchJson?: FetchJson;
+}
+
+export function getUserPluginCatalogPath(homeDir: string = os.homedir()): string {
+  return path.join(homeDir, '.webcmd', CATALOG_FILENAME);
+}
+
+export function getPackagedPluginCatalogPath(packageRoot: string = findPackageRoot(MODULE_FILE)): string {
+  return path.join(packageRoot, CATALOG_FILENAME);
+}
+
+export function readCatalog(options: CatalogOptions = {}): PluginCatalog {
+  const homeDir = options.homeDir ?? os.homedir();
+  const userPath = getUserPluginCatalogPath(homeDir);
+  if (!fs.existsSync(userPath)) seedUserCatalog(options.packageRoot, homeDir);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(userPath, 'utf-8'));
+  } catch (err) {
+    throw new Error(`Malformed plugin catalog at ${userPath}: ${errorMessage(err)}`);
+  }
+  return normalizeCatalog(parsed, userPath);
+}
+
+export function writeCatalog(catalog: PluginCatalog, options: CatalogOptions = {}): void {
+  const userPath = getUserPluginCatalogPath(options.homeDir ?? os.homedir());
+  fs.mkdirSync(path.dirname(userPath), { recursive: true });
+  fs.writeFileSync(userPath, `${JSON.stringify(catalog, null, 2)}\n`);
+}
+
+export function deriveGithubCatalogSource(source: string): PluginCatalogSource {
+  const match = /^github:([\w.-]+)\/([\w.-]+)$/.exec(source);
+  if (!match) throw new Error(`Unsupported catalog source "${source}". Use github:owner/repo.`);
+  const [, owner, repo] = match;
+  return {
+    id: `${owner}-${repo}`,
+    source,
+    manifestUrl: `https://raw.githubusercontent.com/${owner}/${repo}/main/webcmd-plugin.json`,
+  };
+}
+
+export async function addCatalogSource(source: string, options: CatalogOptions = {}): Promise<PluginCatalogSource> {
+  const entry = deriveGithubCatalogSource(source);
+  const catalog = readCatalog(options);
+  const duplicate = catalog.sources.find((existing) => (
+    existing.id === entry.id || existing.source === entry.source || existing.manifestUrl === entry.manifestUrl
+  ));
+  if (duplicate) throw new Error(`Catalog source already exists: ${duplicate.id}`);
+
+  const manifest = await fetchManifest(entry, options.fetchJson);
+  validateMarketplaceManifest(manifest, entry.manifestUrl);
+
+  catalog.sources.push(entry);
+  writeCatalog(catalog, options);
+  return entry;
+}
+
+export function removeCatalogSource(id: string, options: CatalogOptions = {}): PluginCatalogSource {
+  const catalog = readCatalog(options);
+  const index = catalog.sources.findIndex((source) => source.id === id);
+  if (index < 0) throw new Error(`Catalog source not found: ${id}`);
+  const [removed] = catalog.sources.splice(index, 1);
+  writeCatalog(catalog, options);
+  return removed;
+}
+
+export function flattenPluginManifest(source: PluginCatalogSource, manifest: PluginManifest): PluginSearchRow[] {
+  if (isMonorepo(manifest)) {
+    return getEnabledPlugins(manifest).map(({ name, entry }) => ({
+      name,
+      description: entry.description,
+      version: entry.version,
+      sourceId: source.id,
+      installSource: `${source.source}/${name}`,
+      webcmd: entry.webcmd ?? manifest.webcmd,
+    }));
+  }
+  if (!manifest.name) return [];
+  return [{
+    name: manifest.name,
+    description: manifest.description,
+    version: manifest.version,
+    sourceId: source.id,
+    installSource: source.source,
+    webcmd: manifest.webcmd,
+  }];
+}
+
+export async function searchCatalogPlugins(
+  catalog: PluginCatalog,
+  options: { query?: string; fetchJson?: FetchJson } = {},
+): Promise<PluginSearchResult> {
+  const plugins: PluginSearchRow[] = [];
+  const errors: PluginSearchError[] = [];
+
+  await Promise.all(catalog.sources.map(async (source) => {
+    try {
+      const manifest = await fetchManifest(source, options.fetchJson);
+      validateMarketplaceManifest(manifest, source.manifestUrl);
+      plugins.push(...flattenPluginManifest(source, manifest));
+    } catch (err) {
+      errors.push({ sourceId: source.id, manifestUrl: source.manifestUrl, message: errorMessage(err) });
+    }
+  }));
+
+  const query = options.query?.trim().toLowerCase();
+  const filtered = query
+    ? plugins.filter((plugin) => `${plugin.name} ${plugin.description ?? ''}`.toLowerCase().includes(query))
+    : plugins;
+
+  filtered.sort((a, b) => a.name.localeCompare(b.name));
+  errors.sort((a, b) => a.sourceId.localeCompare(b.sourceId));
+  return { plugins: filtered, errors };
+}
+
+function seedUserCatalog(packageRoot: string | undefined, homeDir: string): void {
+  const packagedPath = getPackagedPluginCatalogPath(packageRoot);
+  const userPath = getUserPluginCatalogPath(homeDir);
+  if (!fs.existsSync(packagedPath)) throw new Error(`Packaged plugin catalog not found: ${packagedPath}`);
+  fs.mkdirSync(path.dirname(userPath), { recursive: true });
+  fs.copyFileSync(packagedPath, userPath);
+}
+
+function normalizeCatalog(value: unknown, filePath: string): PluginCatalog {
+  if (!isRecord(value)) throw new Error(`Malformed plugin catalog at ${filePath}: expected object`);
+  if (value.version !== 1) throw new Error(`Malformed plugin catalog at ${filePath}: expected version 1`);
+  if (!Array.isArray(value.sources)) throw new Error(`Malformed plugin catalog at ${filePath}: expected sources array`);
+  return {
+    version: 1,
+    sources: value.sources.map((source, index) => normalizeCatalogSource(source, `${filePath} sources[${index}]`)),
+  };
+}
+
+function normalizeCatalogSource(value: unknown, label: string): PluginCatalogSource {
+  if (!isRecord(value)) throw new Error(`Malformed plugin catalog at ${label}: expected object`);
+  if (typeof value.id !== 'string' || !value.id) throw new Error(`Malformed plugin catalog at ${label}: expected id`);
+  if (typeof value.source !== 'string' || !value.source) throw new Error(`Malformed plugin catalog at ${label}: expected source`);
+  if (typeof value.manifestUrl !== 'string' || !value.manifestUrl) throw new Error(`Malformed plugin catalog at ${label}: expected manifestUrl`);
+  return { id: value.id, source: value.source, manifestUrl: value.manifestUrl };
+}
+
+async function fetchManifest(source: PluginCatalogSource, fetchJson: FetchJson = defaultFetchJson): Promise<PluginManifest> {
+  const value = await fetchJson(source.manifestUrl);
+  if (!isRecord(value)) throw new Error(`Invalid plugin manifest at ${source.manifestUrl}: expected object`);
+  return value as PluginManifest;
+}
+
+function validateMarketplaceManifest(manifest: PluginManifest, manifestUrl: string): void {
+  if (isMonorepo(manifest)) {
+    if (getEnabledPlugins(manifest).length === 0) {
+      throw new Error(`Invalid plugin manifest at ${manifestUrl}: no enabled plugins`);
+    }
+    return;
+  }
+  if (!manifest.name) throw new Error(`Invalid plugin manifest at ${manifestUrl}: missing name or plugins`);
+}
+
+async function defaultFetchJson(url: string): Promise<unknown> {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`HTTP ${response.status} ${response.statusText}`.trim());
+  return response.json();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/plugin-catalog.ts
+++ b/src/plugin-catalog.ts
@@ -76,11 +76,11 @@ export function writeCatalog(catalog: PluginCatalog, options: CatalogOptions = {
 }
 
 export function deriveGithubCatalogSource(source: string): PluginCatalogSource {
-  const match = /^github:([\w.-]+)\/([\w.-]+)$/.exec(source);
-  if (!match) throw new Error(`Unsupported catalog source "${source}". Use github:owner/repo.`);
-  const [, owner, repo] = match;
+  const parsed = parseGithubSource(source);
+  if (!parsed) throw new Error(`Unsupported catalog source "${source}". Use github:owner/repo.`);
+  const { owner, repo } = parsed;
   return {
-    id: `${owner}-${repo}`,
+    id: `${owner}/${repo}`,
     source,
     manifestUrl: `https://raw.githubusercontent.com/${owner}/${repo}/main/webcmd-plugin.json`,
   };
@@ -183,7 +183,18 @@ function normalizeCatalogSource(value: unknown, label: string): PluginCatalogSou
   if (typeof value.id !== 'string' || !value.id) throw new Error(`Malformed plugin catalog at ${label}: expected id`);
   if (typeof value.source !== 'string' || !value.source) throw new Error(`Malformed plugin catalog at ${label}: expected source`);
   if (typeof value.manifestUrl !== 'string' || !value.manifestUrl) throw new Error(`Malformed plugin catalog at ${label}: expected manifestUrl`);
-  return { id: value.id, source: value.source, manifestUrl: value.manifestUrl };
+  const github = parseGithubSource(value.source);
+  return {
+    id: github ? `${github.owner}/${github.repo}` : value.id,
+    source: value.source,
+    manifestUrl: value.manifestUrl,
+  };
+}
+
+function parseGithubSource(source: string): { owner: string; repo: string } | null {
+  const match = /^github:([\w.-]+)\/([\w.-]+)$/.exec(source);
+  if (!match) return null;
+  return { owner: match[1], repo: match[2] };
 }
 
 async function fetchManifest(source: PluginCatalogSource, fetchJson: FetchJson = defaultFetchJson): Promise<PluginManifest> {


### PR DESCRIPTION
## Description

Adds plugin marketplace catalog support so Webcmd can discover installable plugin packs from configured marketplace manifests.

This includes:
- a packaged `plugin-catalog.json` seed
- `webcmd plugin catalog list`
- `webcmd plugin catalog add <source>`
- `webcmd plugin catalog remove <id>`
- `webcmd plugin search [query]`
- live fetching and flattening of `webcmd-plugin.json` manifests
- unit coverage for catalog behavior and CLI help updates

Related issue:

## Type of Change

- [ ] 🐛 Bug fix
- [ x ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [ x ] I ran the checks relevant to this PR
- [ x ] I updated tests or docs if needed
- [ x ] I included output or screenshots when useful

### Adapter Notes

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

<!-- If applicable, paste CLI output or screenshots here. -->
