### PR TITLE
fix: honor background mode for Cloak tab targeting

### DIFF
--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -21,7 +21,7 @@ import {
   type DaemonHealth,
   type DaemonStatus,
 } from './daemon-transport.js';
-import type { BrowserRuntimeCommand, BrowserRuntimeResult } from './protocol.js';
+import type { BrowserRuntimeCommand, BrowserRuntimeResult, BrowserWindowMode } from './protocol.js';
 
 let _idCounter = 0;
 
@@ -250,6 +250,6 @@ export async function sendCommandFull(
   return { data: result.data, page: result.page };
 }
 
-export async function bindTab(session: string, opts: { contextId?: string; preferredContextId?: string; page?: string; index?: number } = {}): Promise<unknown> {
+export async function bindTab(session: string, opts: { contextId?: string; preferredContextId?: string; page?: string; index?: number; windowMode?: BrowserWindowMode } = {}): Promise<unknown> {
   return sendCommand('bind', { session, surface: 'browser', ...opts });
 }

--- a/src/browser/runtime/local-cloak/actions.ts
+++ b/src/browser/runtime/local-cloak/actions.ts
@@ -52,6 +52,7 @@ async function resolveLease(manager: CloakSessionManager, command: BrowserRuntim
     siteSession: command.siteSession,
     idleTimeout: command.idleTimeout,
     freshPage: command.freshPage,
+    windowMode: command.windowMode,
   });
 }
 
@@ -137,11 +138,12 @@ export async function dispatchCloakAction(manager: CloakSessionManager, command:
               siteSession: command.siteSession,
               idleTimeout: command.idleTimeout,
               url: command.url,
+              windowMode: command.windowMode,
             });
             return { id: command.id, ok: true, data: { title: await lease.page.title(), url: lease.page.url() }, page: lease.pageId };
           }
           case 'select': {
-            const lease = await manager.selectPage({ profileId: commandProfileId(manager, command), pageId: command.page, index: command.index });
+            const lease = await manager.selectPage({ profileId: commandProfileId(manager, command), pageId: command.page, index: command.index, windowMode: command.windowMode });
             if (!lease) return { id: command.id, ok: false, errorCode: 'runtime_command_failed', error: 'Tab not found' };
             return { id: command.id, ok: true, data: { selected: true, url: lease.page.url() }, page: lease.pageId };
           }
@@ -215,6 +217,7 @@ export async function dispatchCloakAction(manager: CloakSessionManager, command:
             surface: command.surface,
             siteSession: command.siteSession,
             idleTimeout: command.idleTimeout,
+            windowMode: command.windowMode,
             pageId: command.page,
             index: command.index,
           });

--- a/src/browser/runtime/local-cloak/provider.test.ts
+++ b/src/browser/runtime/local-cloak/provider.test.ts
@@ -277,6 +277,49 @@ describe('LocalCloakRuntimeProvider', () => {
     expect(pages[1].close).toHaveBeenCalled();
   });
 
+  it('does not bring selected tabs to front in background window mode', async () => {
+    const { provider, pages } = makeProviderWithFakePage();
+
+    const created = await provider.dispatch({ id: 'new', action: 'tabs', op: 'new', session: 'work', surface: 'browser', url: 'https://second.example/', profileId: 'default' });
+
+    await expect(provider.dispatch({
+      id: 'select',
+      action: 'tabs',
+      op: 'select',
+      session: 'work',
+      surface: 'browser',
+      page: created.page,
+      profileId: 'default',
+      windowMode: 'background',
+    })).resolves.toMatchObject({ id: 'select', ok: true });
+    expect(pages[1].bringToFront).not.toHaveBeenCalled();
+  });
+
+  it('does not bring bound tabs to front in background window mode', async () => {
+    const { provider, pages } = makeProviderWithFakePage();
+    const created = await provider.dispatch({ id: 'new', action: 'tabs', op: 'new', session: 'source', surface: 'browser', url: 'https://second.example/', profileId: 'default' });
+
+    await expect(provider.dispatch({
+      id: 'bind',
+      action: 'bind',
+      session: 'target',
+      surface: 'browser',
+      page: created.page,
+      profileId: 'default',
+      windowMode: 'background',
+    })).resolves.toMatchObject({ id: 'bind', ok: true });
+    expect(pages[1].bringToFront).not.toHaveBeenCalled();
+  });
+
+  it('brings bound tabs to front by default', async () => {
+    const { provider, pages } = makeProviderWithFakePage();
+    const created = await provider.dispatch({ id: 'new', action: 'tabs', op: 'new', session: 'source', surface: 'browser', url: 'https://second.example/', profileId: 'default' });
+
+    await expect(provider.dispatch({ id: 'bind', action: 'bind', session: 'target', surface: 'browser', page: created.page, profileId: 'default' }))
+      .resolves.toMatchObject({ id: 'bind', ok: true });
+    expect(pages[1].bringToFront).toHaveBeenCalledOnce();
+  });
+
   it('closes a window by page identity when command.page is provided', async () => {
     const { provider, pages } = makeProviderWithFakePage();
     const first = await provider.dispatch({ id: 'first', action: 'navigate', session: 'first', surface: 'browser', url: 'https://first.example/', profileId: 'default' });

--- a/src/browser/runtime/local-cloak/session-manager.ts
+++ b/src/browser/runtime/local-cloak/session-manager.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import { execFile } from 'node:child_process';
 import type { BrowserContext, Page as PlaywrightPage } from 'playwright-core';
 import { launchPersistentContext as cloakLaunchPersistentContext } from 'cloakbrowser';
-import type { BrowserSurface, SiteSessionMode } from '../../protocol.js';
+import type { BrowserSurface, BrowserWindowMode, SiteSessionMode } from '../../protocol.js';
 import { normalizeProfileId, resolveCloakProfileDir } from './profiles.js';
 import { CloakNetworkCapture } from './network.js';
 
@@ -15,6 +15,7 @@ export interface SessionKeyInput {
   surface?: BrowserSurface;
   siteSession?: SiteSessionMode;
   idleTimeout?: number;
+  windowMode?: BrowserWindowMode;
   /** Discard the existing leased page (if any) and create a new one under the same lease. */
   freshPage?: boolean;
 }
@@ -210,14 +211,14 @@ export class CloakSessionManager {
     return { profileId, leaseKey, context: runtime.context, page, pageId };
   }
 
-  async selectPage(input: Pick<SessionKeyInput, 'profileId'> & { pageId?: string; index?: number }): Promise<CloakPageLease | null> {
+  async selectPage(input: Pick<SessionKeyInput, 'profileId' | 'windowMode'> & { pageId?: string; index?: number }): Promise<CloakPageLease | null> {
     const profileId = normalizeProfileId(input.profileId);
     const runtime = this.profiles.get(profileId);
     if (!runtime) return null;
     const match = input.pageId ? this.findEntryByPageId(runtime, input.pageId) : this.openEntries(runtime)[input.index ?? -1];
     if (!match) return null;
     const [leaseKey, entry] = match;
-    await entry.page.bringToFront?.().catch(() => {});
+    if (input.windowMode !== 'background') await entry.page.bringToFront?.().catch(() => {});
     runtime.selectedPageId = entry.pageId;
     runtime.lastSeenAt = Date.now();
     return { profileId, leaseKey, context: runtime.context, page: entry.page, pageId: entry.pageId };
@@ -250,7 +251,7 @@ export class CloakSessionManager {
     entry.siteSession = input.siteSession;
     entry.idleTimeout = input.idleTimeout;
     runtime.pages.set(canonicalKey, entry);
-    await entry.page.bringToFront?.().catch(() => {});
+    if (input.windowMode !== 'background') await entry.page.bringToFront?.().catch(() => {});
     this.refreshIdleTimer(runtime, canonicalKey, entry);
     runtime.selectedPageId = entry.pageId;
     runtime.lastSeenAt = Date.now();

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1187,8 +1187,8 @@ describe('browser tab targeting commands', () => {
 
     await program.parseAsync(['node', 'webcmd', 'browser', '--session', 'test', 'bind', '--page', 'tab-2']);
 
-    expect(mockBrowserConnect).toHaveBeenCalledWith({ timeout: 45, session: 'test', surface: 'browser' });
-    expect(mockBindTab).toHaveBeenCalledWith('test', { page: 'tab-2' });
+    expect(mockBrowserConnect).toHaveBeenCalledWith({ timeout: 45, session: 'test', surface: 'browser', windowMode: 'foreground' });
+    expect(mockBindTab).toHaveBeenCalledWith('test', { page: 'tab-2', windowMode: 'foreground' });
     const out = lastJsonLog();
     expect(out.session).toBe('test');
     expect(out.url).toBe('https://user.example/inbox');
@@ -1199,10 +1199,19 @@ describe('browser tab targeting commands', () => {
 
     await program.parseAsync(['node', 'webcmd', 'browser', '--session', 'test', 'bind', '--index', '1']);
 
-    expect(mockBrowserConnect).toHaveBeenCalledWith({ timeout: 45, session: 'test', surface: 'browser' });
-    expect(mockBindTab).toHaveBeenCalledWith('test', { index: 1 });
+    expect(mockBrowserConnect).toHaveBeenCalledWith({ timeout: 45, session: 'test', surface: 'browser', windowMode: 'foreground' });
+    expect(mockBindTab).toHaveBeenCalledWith('test', { index: 1, windowMode: 'foreground' });
     const out = lastJsonLog();
     expect(out.session).toBe('test');
+  });
+
+  it('passes background window mode when binding a Cloak tab', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'webcmd', 'browser', '--session', 'test', '--window', 'background', 'bind', '--page', 'tab-2']);
+
+    expect(mockBrowserConnect).toHaveBeenCalledWith({ timeout: 45, session: 'test', surface: 'browser', windowMode: 'background' });
+    expect(mockBindTab).toHaveBeenCalledWith('test', { page: 'tab-2', windowMode: 'background' });
   });
 
   it('requires an explicit Cloak tab target for bind', async () => {
@@ -1353,7 +1362,7 @@ describe('browser tab targeting commands', () => {
 
     await program.parseAsync(['node', 'webcmd', 'browser', '--session', 'test', 'unbind']);
 
-    expect(mockBrowserConnect).toHaveBeenCalledWith({ timeout: 45, session: 'test', surface: 'browser' });
+    expect(mockBrowserConnect).toHaveBeenCalledWith({ timeout: 45, session: 'test', surface: 'browser', windowMode: 'foreground' });
     expect(mockSendCommand).toHaveBeenCalledWith('close-window', { session: 'test', surface: 'browser' });
     const out = lastJsonLog();
     expect(out).toEqual({ unbound: true, session: 'test' });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1148,6 +1148,7 @@ Examples:
     session: string;
     contextId?: string;
     routing: { contextId?: string; preferredContextId?: string };
+    windowMode: BrowserWindowMode;
   };
 
   function browserSessionCommandAction(fn: (ctx: BrowserSessionCommandContext, opts: Record<string, unknown>) => Promise<void>) {
@@ -1160,11 +1161,12 @@ Examples:
       const profileSelection = getBrowserProfileSelection(command);
       const contextId = profileSelection?.contextId;
       const routing = profileRouteParams(profileSelection);
+      const windowMode = getBrowserWindowMode(command, 'foreground');
       try {
         const { BrowserBridge } = await import('./browser/index.js');
         const bridge = new BrowserBridge();
-        await bridge.connect({ timeout: DEFAULT_BROWSER_CONNECT_TIMEOUT, session, surface: 'browser', ...routing });
-        await fn({ session, contextId, routing }, opts);
+        await bridge.connect({ timeout: DEFAULT_BROWSER_CONNECT_TIMEOUT, session, surface: 'browser', ...routing, windowMode });
+        await fn({ session, contextId, routing, windowMode }, opts);
       } catch (err) {
         if (err instanceof BrowserCommandError) {
           emitBrowserCommandErrorEnvelope(err);
@@ -1181,7 +1183,7 @@ Examples:
     .description('Bind an existing Cloak runtime tab to the browser session named by <session>')
     .option('--page <id>', 'Cloak tab page id from `webcmd browser <session> tab list`')
     .option('--index <n>', 'Cloak tab index from `webcmd browser <session> tab list`')
-    .action(browserSessionCommandAction(async ({ session, contextId, routing }, opts) => {
+    .action(browserSessionCommandAction(async ({ session, contextId, routing, windowMode }, opts) => {
       const page = typeof opts.page === 'string' && opts.page.trim() ? opts.page.trim() : undefined;
       const rawIndex = typeof opts.index === 'string' && opts.index.trim() ? opts.index.trim() : undefined;
       if ((page && rawIndex) || (!page && !rawIndex)) {
@@ -1195,7 +1197,7 @@ Examples:
         throw new BrowserCommandError('--index must be a non-negative integer.', 'invalid_request');
       }
       const index = rawIndex === undefined ? undefined : Number.parseInt(rawIndex, 10);
-      const data = await bindTab(session, { ...routing, ...(page && { page }), ...(index !== undefined && { index }) });
+      const data = await bindTab(session, { ...routing, ...(page && { page }), ...(index !== undefined && { index }), windowMode });
       saveBrowserTargetState(undefined, getBrowserScope(session, contextId));
       console.log(JSON.stringify({ session, ...((data && typeof data === 'object') ? data as Record<string, unknown> : { data }) }, null, 2));
     }));


### PR DESCRIPTION
## Description

Fix `--window background` propagation through the local Cloak runtime so browser tab selection and binding do not call `bringToFront()` and steal focus.

Related issue: none

### Root cause

The CLI parsed and transported `windowMode`, but the local Cloak tab-selection and bind paths did not consistently carry it into `CloakSessionManager`. Both paths therefore called Playwright's `bringToFront()` unconditionally.

The bind command had an additional seam: `webcmd browser <session> bind --window background` connected and called `bindTab()` without forwarding the resolved window mode.

### What changed

- Propagate `windowMode` through Cloak lease resolution, tab creation, selection, and binding.
- Skip `bringToFront()` for explicit background selection and binding.
- Preserve existing default/foreground behavior.
- Resolve and forward `--window` through the user-facing `browser bind` CLI path and daemon client.
- Add regressions for:
  - background tab selection;
  - background tab binding;
  - default/foreground binding;
  - CLI-to-daemon background bind propagation.

### Behavior after this change

| Command type | `--window background` | `--window foreground` |
| --- | --- | --- |
| Browser-backed commands | Uses headed Chromium without bringing selected/bound tabs forward | Preserves foreground/default focus behavior |
| API/local commands (`browser: false`) | Rejected as an unknown option | Rejected as an unknown option |

The reliable way to distinguish the two is `webcmd <site> <command> --help -f yaml` or `webcmd list -f json` and inspect `browser: true|false`. Strategy names alone are insufficient because some `public` commands are still browser-backed.

### Scope and limitations

- Background mode is **not headless mode**. Cloak still launches Chromium with `headless: false`.
- A first background command may launch a visible Chromium window behind the current application; this PR prevents tab selection/binding from stealing focus.
- Chromium does not need to be open before a background command can succeed.
- API-only commands do not create a browser session and remain unaffected. Passing the CLI flag continues to return `error: unknown option '--window'`; setting `WEBCMD_WINDOW` has no operational effect on them.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Verification

### Red/green regression

The background-selection regression was run against both revisions:

- Unfixed `main`: failed because `bringToFront()` was called once.
- Fixed branch: passed with no `bringToFront()` call.

The bind CLI regression was also observed failing before the propagation change and passing afterward.

### Live macOS checks

With Safari foreground:

- cold-start `twitter whoami --window background` launched headed Chromium and completed without requiring Chromium to be open first;
- repeated background adapter execution left Safari foreground;
- background tab selection left Safari foreground;
- `webcmd browser pr-bg-target bind --page <page-id> --window background` completed successfully and left Safari foreground.

### Automated checks

After rebasing onto current `origin/main`:

```text
Test Files  365 passed (365)
Tests       4134 passed | 1 skipped (4135)
```

Also completed successfully:

- `npm run build`
- `npm run typecheck`
- `git diff --check`
- focused CLI, daemon-client, and Cloak provider tests
- read-only code review with no remaining Critical or Important findings

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Adapter Notes

- [x] Not applicable: command discoverability did not change
- [x] Not applicable: no adapter argument surface changed
- [x] Not applicable: no adapter error handling changed

## Screenshots / Output

No screenshot is necessary. The macOS focus check recorded Safari as the frontmost application after background selection and binding.
