### PR TITLE
Fix auth commands to return result rows

### DIFF
--- a/clis/_shared/site-auth.js
+++ b/clis/_shared/site-auth.js
@@ -72,7 +72,7 @@ export function registerSiteAuthCommands(config) {
         ? { refresh: async (page, kwargs) => normalizeRefreshResult(await config.refresh(page, kwargs)) }
         : {}),
     },
-    func: async (page) => tryProbe(config, page, 'identity'),
+    func: async (page) => [await tryProbe(config, page, 'identity')],
   });
 
   cli({
@@ -92,7 +92,7 @@ export function registerSiteAuthCommands(config) {
     columns: ['status', ...commandColumns(config)],
     func: async (page, kwargs) => {
       try {
-        return { status: 'already_logged_in', ...await tryProbe(config, page, 'identity') };
+        return [{ status: 'already_logged_in', ...await tryProbe(config, page, 'identity') }];
       } catch (error) {
         if (!isAuthRequired(error)) throw error;
       }
@@ -106,7 +106,7 @@ export function registerSiteAuthCommands(config) {
         await page.wait(Math.min(POLL_INTERVAL_MS / 1000, Math.max(0.2, (deadline - Date.now()) / 1000)));
         try {
           const identity = await tryProbe(config, page, 'poll');
-          return { status: 'login_complete', ...identity };
+          return [{ status: 'login_complete', ...identity }];
         } catch (error) {
           if (!isAuthRequired(error)) throw error;
           lastAuthMessage = getErrorMessage(error);

--- a/clis/_shared/site-auth.test.js
+++ b/clis/_shared/site-auth.test.js
@@ -47,11 +47,11 @@ describe('site auth command helper', () => {
     const cmd = getRegistry().get('auth-helper-whoami/whoami');
     const page = pageMock();
 
-    await expect(cmd.func(page, {})).resolves.toEqual({
+    await expect(cmd.func(page, {})).resolves.toEqual([{
       logged_in: true,
       site: 'auth-helper-whoami',
       username: 'alice',
-    });
+    }]);
     expect(page.goto).not.toHaveBeenCalled();
   });
 
@@ -70,12 +70,12 @@ describe('site auth command helper', () => {
     const cmd = getRegistry().get('auth-helper-login/login');
     const page = pageMock();
 
-    await expect(cmd.func(page, { timeout: 1 })).resolves.toEqual({
+    await expect(cmd.func(page, { timeout: 1 })).resolves.toEqual([{
       status: 'login_complete',
       logged_in: true,
       site: 'auth-helper-login',
       username: 'alice',
-    });
+    }]);
     expect(page.goto).toHaveBeenCalledWith('https://example.com/login');
     expect(page.wait).toHaveBeenCalled();
     expect(poll).toHaveBeenCalledTimes(2);

--- a/clis/slock/whoami.test.js
+++ b/clis/slock/whoami.test.js
@@ -14,10 +14,10 @@ function makePage(authMe, status = 200) {
 describe('slock whoami', () => {
   const command = getRegistry().get('slock/whoami');
 
-  it('returns a normalized identity object from /auth/me on 200', async () => {
+  it('returns a normalized identity row from /auth/me on 200', async () => {
     const page = makePage({ id: 'u1', name: 'Alice', email: 'a@b.c' });
     const identity = await command.func(page, {});
-    expect(identity).toEqual({ logged_in: true, site: 'slock', id: 'u1', name: 'Alice', email: 'a@b.c' });
+    expect(identity).toEqual([{ logged_in: true, site: 'slock', id: 'u1', name: 'Alice', email: 'a@b.c' }]);
     expect(page.goto).toHaveBeenCalled();
   });
 });

--- a/src/commands/auth.test.ts
+++ b/src/commands/auth.test.ts
@@ -18,7 +18,7 @@ function registerWhoami(site: string, opts: {
   quick?: boolean;
   quickLoggedIn?: boolean;
   refresh?: 'touched' | 'refreshed';
-  identity?: Record<string, unknown>;
+  identity?: Record<string, unknown> | Record<string, unknown>[];
 } = {}): void {
   cli({
     site,
@@ -92,12 +92,12 @@ describe('auth status collection', () => {
 
   it('runs full whoami with --full and returns a safe identity summary', async () => {
     registerWhoami('gamma', {
-      identity: {
+      identity: [{
         logged_in: true,
         site: 'gamma',
         email: 'hidden@example.com',
         username: 'public-handle',
-      },
+      }],
     });
 
     const rows = await collectAuthStatus({ sites: 'gamma', full: true });

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -180,8 +180,9 @@ function safeIdentityValue(value: unknown): string {
 }
 
 function identitySummary(result: unknown): string {
-  if (!result || typeof result !== 'object' || Array.isArray(result)) return '';
-  const row = result as Record<string, unknown>;
+  const first = Array.isArray(result) ? result[0] : result;
+  if (!first || typeof first !== 'object' || Array.isArray(first)) return '';
+  const row = first as Record<string, unknown>;
   const blocked = /(?:email|phone|real.?name|first.?name|last.?name|cookie|token|session|secret|password|csrf|jwt|bearer|wt2)/i;
   for (const key of ['username', 'handle', 'user_id', 'id', 'name', 'nickname', 'user_type', 'url']) {
     if (blocked.test(key)) continue;


### PR DESCRIPTION
## Problem

`webcmd district whoami -f json` returned a bare JSON object instead of an array of result rows. Downstream agents consuming Webcmd command metadata and structured results therefore rejected a successful District auth response as `webcmd command returned invalid structured rows`. District `login` used the same result path and had the same incompatibility.

## Root cause

District registers `whoami` and `login` through the shared `registerSiteAuthCommands` helper. That helper returned bare objects, while Webcmd adapters and their declared `columns` use row-oriented results. Fixing only the District wrapper would leave the same issue in every sibling adapter using this helper.

## Changes

- return shared `whoami` and `login` command results as one-row arrays
- preserve safe identity extraction for `webcmd auth status --full`
- update shared and sibling regression tests for the row contract

## Verification

- live source `district whoami` returned one JSON row
- `npm test` — 4,130 passed, 1 skipped
- `npm run typecheck`
- `npm run check:silent-column-drop`
- `npm run check:typed-error-lint`