### PR TITLE
docs(skills): improve plugin discovery routing

### DIFF
--- a/skills/smart-search/SKILL.md
+++ b/skills/smart-search/SKILL.md
@@ -11,15 +11,16 @@ Route a query to the best webcmd search source based on the topic and context. T
 
 Before every use, do both of these steps:
 
-- Run `webcmd list -f yaml`
+- Run `webcmd list -f json`
 - Use the live registry to confirm that candidate sites exist, and inspect `strategy`, `browser`, and `domain`
 
-If the user explicitly names a site/source and it is missing from `webcmd list`, check installable plugins before marking it unavailable:
+If the user explicitly names a site/source and it is missing from `webcmd list` or when none of the sites cover the query, check installable plugins before marking it unavailable:
 
 ```bash
-webcmd plugin search <site-or-source> -f json
-webcmd plugin catalog list -f json
+webcmd plugin search <site-or-source-or-capability> -f json
 ```
+
+Derive a short plugin query from the missing site or capability. Preserve the user's term when practical: `find flights` becomes `flight`.
 
 If plugin search finds a match, tell the user it is available as a plugin and offer `webcmd plugin install <source>`. If plugin search fails because catalog sources cannot be fetched, report that catalog/search error separately from no plugin match.
 
@@ -51,7 +52,7 @@ First create a site-call ledger. After each real search command, update it immed
 
 Counting rules:
 
-- `webcmd list -f yaml`, `webcmd <site> -h`, and `webcmd <site> <command> -h` are preflight/help commands and do not count as searches.
+- `webcmd list -f json`, `webcmd plugin search <query> -f json`, `webcmd <site> -h`, and `webcmd <site> <command> -h` are preflight/help commands and do not count as searches.
 - One real `webcmd <site> ...` search/query execution counts as 1 call for that site.
 - A failed call caused by an error, timeout, CAPTCHA, anti-bot check, or broken login state still counts as 1 call for that site. Do not retry indefinitely.
 
@@ -143,10 +144,10 @@ Keep a typical query to 1 AI source plus 1-2 specialized sources to avoid result
 When a site is unavailable:
 
 - Do not stop the whole search because one source failed
-- For named missing sites, run `webcmd plugin search <site> -f json` before recording unavailable
+- For a missing site or capability, run `webcmd plugin search <query> -f json` before recording unavailable
 - Record: `Skipped: <site> unavailable`
 - Fall back to another site of the same type, or to one AI source
-- Always trust the actual output of `webcmd list -f yaml`, `webcmd plugin search -f json`, and `webcmd <site> -h`
+- Always trust the actual output of `webcmd list -f json`, `webcmd plugin search -f json`, and `webcmd <site> -h`
 
 Do not assume any site is always available. Even for public sites, trust live help and execution results in the current environment.
 

--- a/skills/smart-search/SKILL.md
+++ b/skills/smart-search/SKILL.md
@@ -14,6 +14,15 @@ Before every use, do both of these steps:
 - Run `webcmd list -f yaml`
 - Use the live registry to confirm that candidate sites exist, and inspect `strategy`, `browser`, and `domain`
 
+If the user explicitly names a site/source and it is missing from `webcmd list`, check installable plugins before marking it unavailable:
+
+```bash
+webcmd plugin search <site-or-source> -f json
+webcmd plugin catalog list -f json
+```
+
+If plugin search finds a match, tell the user it is available as a plugin and offer `webcmd plugin install <source>`. If plugin search fails because catalog sources cannot be fetched, report that catalog/search error separately from no plugin match.
+
 After choosing a site, do both of these steps:
 
 - Run `webcmd <site> -h` to see the site's subcommands
@@ -134,9 +143,10 @@ Keep a typical query to 1 AI source plus 1-2 specialized sources to avoid result
 When a site is unavailable:
 
 - Do not stop the whole search because one source failed
+- For named missing sites, run `webcmd plugin search <site> -f json` before recording unavailable
 - Record: `Skipped: <site> unavailable`
 - Fall back to another site of the same type, or to one AI source
-- Always trust the actual output of `webcmd list -f yaml` and `webcmd <site> -h`
+- Always trust the actual output of `webcmd list -f yaml`, `webcmd plugin search -f json`, and `webcmd <site> -h`
 
 Do not assume any site is always available. Even for public sites, trust live help and execution results in the current environment.
 

--- a/skills/webcmd-usage/SKILL.md
+++ b/skills/webcmd-usage/SKILL.md
@@ -58,16 +58,12 @@ webcmd <site> <command> --help
 
 Do not hard-code adapter lists. `webcmd list -f json` is the source of truth for installed commands and emits one entry per command with fields such as `{site, name, aliases, description, strategy, browser, args, columns}`.
 
-If a user asks for a site/tool that is missing from `webcmd list`, search installable plugins before saying Webcmd cannot do it or falling back to `webcmd browser`:
+Use this fallback order:
 
-```bash
-webcmd plugin search <site-or-tool> -f json
-webcmd plugin catalog list -f json
-```
-
-If search returns a match, tell the user it is available as a plugin and offer the install command (`webcmd plugin install <source>`). If plugin search errors because catalog sources cannot be fetched, report the catalog/search failure separately from "no plugin exists."
-
-Before falling back to raw `webcmd browser` on high-change authenticated sites, check whether an installed adapter or installable plugin already exposes the workflow.
+1. Run `webcmd list -f json` once.
+2. Check that result against the whole requested workflow, not only a named site. If one installed command covers it, use that command and stop discovery. Do not rerun or shell-filter `webcmd list`.
+3. If none covers it, derive a short plugin query from the missing site or capability and run `webcmd plugin search <query> -f json`. Preserve the user's term when practical: `find flights` becomes `flight`. Do this even when the user names no site.
+4. If plugin search returns a match, offer `webcmd plugin install <installSource>`. If it returns no match and no error, raw `webcmd browser` is allowed. If it errors, run `webcmd plugin catalog list -f json`, report plugin discovery as unavailable, and stop immediately. Do not run more discovery commands such as `webcmd plugin list`, inspect source-checkout manifests, or check unrelated external CLIs.
 
 ## Universal Flags
 

--- a/skills/webcmd-usage/SKILL.md
+++ b/skills/webcmd-usage/SKILL.md
@@ -61,9 +61,9 @@ Do not hard-code adapter lists. `webcmd list -f json` is the source of truth for
 Use this fallback order:
 
 1. Run `webcmd list -f json` once.
-2. Check that result against the whole requested workflow, not only a named site. If one installed command covers it, use that command and stop discovery. Do not rerun or shell-filter `webcmd list`.
-3. If none covers it, derive a short plugin query from the missing site or capability and run `webcmd plugin search <query> -f json`. Preserve the user's term when practical: `find flights` becomes `flight`. Do this even when the user names no site.
-4. If plugin search returns a match, offer `webcmd plugin install <installSource>`. If it returns no match and no error, raw `webcmd browser` is allowed. If it errors, run `webcmd plugin catalog list -f json`, report plugin discovery as unavailable, and stop immediately. Do not run more discovery commands such as `webcmd plugin list`, inspect source-checkout manifests, or check unrelated external CLIs.
+2. Check that result against the whole requested workflow, not only a named site. If one installed command covers it, use that command and stop discovery.
+3. If none covers it, derive a short plugin query from the missing site or capability and run `webcmd plugin search <query> -f json`. Preserve the user's term when practical: `find flights` becomes `flight`.
+4. If plugin search returns a match, offer `webcmd plugin install <installSource>`. If it returns no match and no error, raw `webcmd browser` is allowed. If it errors, report plugin discovery as unavailable possibly due to network permissions, and stop immediately.
 
 ## Universal Flags
 

--- a/skills/webcmd-usage/SKILL.md
+++ b/skills/webcmd-usage/SKILL.md
@@ -44,7 +44,7 @@ npx tsx src/main.ts <command>
 
 Electron desktop app adapters route through CDP against the running app. Make sure the app is open before invoking those commands.
 
-## Discover Installed Commands
+## Discover Commands
 
 Run commands instead of reading static docs:
 
@@ -56,9 +56,18 @@ webcmd <site> --help
 webcmd <site> <command> --help
 ```
 
-Do not hard-code adapter lists. `webcmd list -f json` is the source of truth and emits one entry per command with fields such as `{site, name, aliases, description, strategy, browser, args, columns}`.
+Do not hard-code adapter lists. `webcmd list -f json` is the source of truth for installed commands and emits one entry per command with fields such as `{site, name, aliases, description, strategy, browser, args, columns}`.
 
-Before falling back to raw `webcmd browser` on high-change authenticated sites, check whether a site adapter already exposes the workflow.
+If a user asks for a site/tool that is missing from `webcmd list`, search installable plugins before saying Webcmd cannot do it or falling back to `webcmd browser`:
+
+```bash
+webcmd plugin search <site-or-tool> -f json
+webcmd plugin catalog list -f json
+```
+
+If search returns a match, tell the user it is available as a plugin and offer the install command (`webcmd plugin install <source>`). If plugin search errors because catalog sources cannot be fetched, report the catalog/search failure separately from "no plugin exists."
+
+Before falling back to raw `webcmd browser` on high-change authenticated sites, check whether an installed adapter or installable plugin already exposes the workflow.
 
 ## Universal Flags
 
@@ -129,10 +138,13 @@ webcmd plugin list [-f json]
 webcmd plugin update [name] | --all
 webcmd plugin uninstall <name>
 webcmd plugin create <name>
-webcmd plugin search [query]
+webcmd plugin search [query] -f json
+webcmd plugin catalog list -f json
+webcmd plugin catalog add <source>
+webcmd plugin catalog remove <id>
 ```
 
-Plugins are installable extensions pulled from git or local paths. Main-repo community CLIs are exposed through the root plugin catalog manifest, not bundled into npm's `clis/` set.
+Plugins are installable extensions pulled from git or local paths. Use `plugin search` for marketplace discovery and `plugin list` for already-installed plugins. Main-repo community CLIs are exposed through the root plugin catalog manifest, not bundled into npm's `clis/` set.
 
 > **Note:** The repository's `plugins/` directory is not shipped in the npm package. Find the required plugin with `webcmd plugin search`, then install its `installSource` with `webcmd plugin install <installSource>`.
 


### PR DESCRIPTION
## Summary
- search installed commands before falling back to browser automation
- discover plugins by missing site or capability, including requests with no named site
- align smart-search bookkeeping and failure handling with webcmd-usage

## Validation
- skill-creator quick validation for smart-search
- skill-creator quick validation for webcmd-usage
- git diff --check