### PR TITLE
Polish major release notes

### DIFF
--- a/scripts/generate-release-notes.ts
+++ b/scripts/generate-release-notes.ts
@@ -245,7 +245,7 @@ export async function runGenerateReleaseNotes(
     const model = env.GEMINI_RELEASE_NOTES_MODEL || DEFAULT_MODEL;
     const prompt = buildReleaseNotesPrompt(context);
     const raw = await (deps.generateText ?? generateText)(prompt, model, apiKey);
-    const normalized = normalizeReleaseNotes(raw);
+    const normalized = normalizeReleaseNotes(raw, { context });
     if (normalized) {
       io.writeStdout(`${normalized}\n`);
     }

--- a/src/generate-release-notes-cli.test.ts
+++ b/src/generate-release-notes-cli.test.ts
@@ -85,6 +85,11 @@ describe('runGenerateReleaseNotes', () => {
         '## Highlights',
         '- Better summaries.',
         '',
+        '## Contributors',
+        '<a href="https://github.com/alice" title="@alice"><img src="https://github.com/alice.png?size=64" width="64" height="64" alt="@alice" /></a>',
+        '',
+        '[@alice](https://github.com/alice)',
+        '',
       ].join('\n'),
       stderr: '',
     });

--- a/src/release-notes.test.ts
+++ b/src/release-notes.test.ts
@@ -4,7 +4,9 @@ import {
   buildReleaseNotesPrompt,
   extractPullRequestNumber,
   filterReleasePullRequests,
+  isMajorRelease,
   normalizeReleaseNotes,
+  releaseContributorHandles,
   replaceChangelogReleaseNotes,
   type ReleaseContext,
 } from './release-notes.js';
@@ -27,6 +29,25 @@ describe('release notes helpers', () => {
     ];
 
     expect(filterReleasePullRequests(prs).map((pr) => pr.number)).toEqual([1]);
+  });
+
+  it('detects major releases from semver tag ranges', () => {
+    expect(isMajorRelease({ tag: 'webcmd-v2.0.0', previousTag: 'webcmd-v1.9.9' })).toBe(true);
+    expect(isMajorRelease({ tag: 'v3.1.0', previousTag: 'v2.9.9' })).toBe(true);
+    expect(isMajorRelease({ tag: 'webcmd-v2.1.0', previousTag: 'webcmd-v2.0.0' })).toBe(false);
+    expect(isMajorRelease({ tag: 'webcmd-v0.3.0', previousTag: 'webcmd-v0.2.5' })).toBe(false);
+  });
+
+  it('deduplicates PR author contributors and excludes service accounts', () => {
+    const prs = [
+      { number: 1, title: 'feat: browser polish', author: { login: 'alice' }, labels: [], files: [], url: 'https://example.com/1' },
+      { number: 2, title: 'feat: docs polish', author: { login: '@alice' }, labels: [], files: [], url: 'https://example.com/2' },
+      { number: 3, title: 'chore: release', author: { login: 'github-actions[bot]' }, labels: [], files: [], url: 'https://example.com/3' },
+      { number: 4, title: 'feat: adapter polish', author: { login: 'bob' }, labels: [], files: [], url: 'https://example.com/4' },
+      { number: 5, title: 'chore: release notes', author: { login: 'release-please' }, labels: [], files: [], url: 'https://example.com/5' },
+    ];
+
+    expect(releaseContributorHandles(prs)).toEqual(['alice', 'bob']);
   });
 
   it('normalizes only sections with real release-note content', () => {
@@ -66,6 +87,92 @@ describe('release notes helpers', () => {
     expect(normalized).not.toContain('None.');
   });
 
+  it('adds an elegant major release title and visual contributor credits', () => {
+    const context: ReleaseContext = {
+      tag: 'webcmd-v2.0.0',
+      previousTag: 'webcmd-v1.9.9',
+      currentRef: 'webcmd-v2.0.0',
+      pullRequests: [
+        {
+          number: 42,
+          title: 'feat: expand browser adapter coverage',
+          author: { login: 'alice' },
+          labels: [{ name: 'feature' }],
+          files: [{ path: 'clis/github/auth.js' }],
+          url: 'https://github.com/agentrhq/webcmd/pull/42',
+        },
+        {
+          number: 43,
+          title: 'chore: release automation',
+          author: { login: 'github-actions[bot]' },
+          labels: [],
+          files: [{ path: '.github/workflows/release.yml' }],
+          url: 'https://github.com/agentrhq/webcmd/pull/43',
+        },
+      ],
+    };
+    const raw = [
+      '# webcmd v2.0.0: The Command Surface Opens',
+      '',
+      '## Highlights',
+      '- Broader adapter authoring workflows.',
+    ].join('\n');
+
+    const normalized = normalizeReleaseNotes(raw, { context });
+
+    expect(normalized).toContain('# webcmd v2.0.0: The Command Surface Opens');
+    expect(normalized).toContain('## Contributors');
+    expect(normalized).toContain('<img src="https://github.com/alice.png?size=64" width="64" height="64" alt="@alice" />');
+    expect(normalized).toContain('[@alice](https://github.com/alice)');
+    expect(normalized).not.toContain('github-actions');
+  });
+
+  it('uses a deterministic major release title fallback when the model omits one', () => {
+    const context: ReleaseContext = {
+      tag: 'webcmd-v2.0.0',
+      previousTag: 'webcmd-v1.9.9',
+      currentRef: 'webcmd-v2.0.0',
+      pullRequests: [
+        {
+          number: 42,
+          title: 'feat: add github adapter',
+          author: { login: 'alice' },
+          labels: [{ name: 'feature' }],
+          files: [{ path: 'clis/github/auth.js' }],
+          url: 'https://github.com/agentrhq/webcmd/pull/42',
+        },
+      ],
+    };
+
+    const normalized = normalizeReleaseNotes('## Highlights\n- Added a GitHub adapter.', { context });
+
+    expect(normalized).toContain('# webcmd v2.0.0: The Command Surface Expands');
+  });
+
+  it('does not add major release title treatment to minor releases', () => {
+    const context: ReleaseContext = {
+      tag: 'webcmd-v2.1.0',
+      previousTag: 'webcmd-v2.0.0',
+      currentRef: 'webcmd-v2.1.0',
+      pullRequests: [
+        {
+          number: 42,
+          title: 'feat: improve release notes',
+          author: { login: 'alice' },
+          labels: [{ name: 'feature' }],
+          files: [{ path: 'src/release-notes.ts' }],
+          url: 'https://github.com/agentrhq/webcmd/pull/42',
+        },
+      ],
+    };
+
+    const normalized = normalizeReleaseNotes('# The Polished Edition\n\n## Highlights\n- Better notes.', { context });
+
+    expect(normalized).not.toContain('# webcmd v2.1.0');
+    expect(normalized).toContain('## Highlights\n- Better notes.');
+    expect(normalized).toContain('## Contributors');
+  });
+
   it('replaces a matching changelog release entry with generated notes', () => {
     const changelog = [
       '# Changelog',
@@ -85,18 +192,28 @@ describe('release notes helpers', () => {
       '',
     ].join('\n');
     const notes = [
+      '# webcmd v2.0.0: The Command Surface Expands',
+      '',
       '## Highlights',
       '- Better release notes.',
       '',
       '## Adapters',
       '- Improved district checkout.',
+      '',
+      '## Contributors',
+      '<a href="https://github.com/alice" title="@alice"><img src="https://github.com/alice.png?size=64" width="64" height="64" alt="@alice" /></a>',
+      '',
+      '[@alice](https://github.com/alice)',
     ].join('\n');
 
     const updated = replaceChangelogReleaseNotes(changelog, 'webcmd-v0.2.3', notes);
 
     expect(updated).toContain('## [0.2.3]');
+    expect(updated).toContain('_webcmd v2.0.0: The Command Surface Expands_');
     expect(updated).toContain('### Highlights\n- Better release notes.');
     expect(updated).toContain('### Adapters\n- Improved district checkout.');
+    expect(updated).toContain('### Contributors\n[@alice](https://github.com/alice)');
+    expect(updated).not.toContain('<img');
     expect(updated).not.toContain('release-please generated note');
     expect(updated).toContain('## [0.2.2]');
     expect(updated).toContain('* older note');
@@ -128,11 +245,38 @@ describe('release notes helpers', () => {
     expect(prompt).toContain('## Highlights');
     expect(prompt).toContain('## Adapters');
     expect(prompt).not.toContain('## Contributors');
+    expect(prompt).toContain('Do not include a top-level release title');
     expect(prompt).toContain('Omit empty sections entirely');
     expect(prompt).toContain('Do not include a Contributors section');
     expect(prompt).toContain('CLI commands and adapters are the same thing');
     expect(prompt).toContain('files under clis/** as an adapter change');
     expect(prompt).toContain('Put new site adapters/CLIs, adapter promotions, adapter hardening');
     expect(prompt).toContain('## Reverts');
+  });
+
+  it('asks for a tasteful H1 title only when building major release notes', () => {
+    const context: ReleaseContext = {
+      tag: 'webcmd-v2.0.0',
+      previousTag: 'webcmd-v1.9.9',
+      currentRef: 'webcmd-v2.0.0',
+      pullRequests: [
+        {
+          number: 42,
+          title: 'feat: expand adapter authoring',
+          body: 'Adds richer authoring workflows.',
+          author: { login: 'alice' },
+          labels: [{ name: 'feature' }],
+          files: [{ path: 'skills/webcmd-adapter-author/SKILL.md' }],
+          diff: 'diff --git a/skills/webcmd-adapter-author/SKILL.md b/skills/webcmd-adapter-author/SKILL.md',
+          url: 'https://github.com/agentrhq/webcmd/pull/42',
+        },
+      ],
+    };
+
+    const prompt = buildReleaseNotesPrompt(context);
+
+    expect(prompt).toContain('This is a major release');
+    expect(prompt).toContain('# webcmd v2.0.0: <Elegant Release Title>');
+    expect(prompt).toContain('grand enough to feel memorable, but polished rather than loud');
   });
 });

--- a/src/release-notes.ts
+++ b/src/release-notes.ts
@@ -8,6 +8,10 @@ export const RELEASE_NOTE_SECTIONS = [
 
 export type ReleaseNoteSection = typeof RELEASE_NOTE_SECTIONS[number];
 
+export interface NormalizeReleaseNotesOptions {
+  context?: ReleaseContext;
+}
+
 export interface PullRequestLabel {
   name: string;
 }
@@ -50,6 +54,32 @@ export type GitRunner = (args: readonly string[]) => Promise<string>;
 const SQUASH_MERGE_PR_NUMBER_PATTERN = /\(#(?<number>\d+)\)\s*$/;
 const MERGE_COMMIT_PR_NUMBER_PATTERN = /^Merge pull request #(?<number>\d+) /;
 const RELEASE_PLEASE_TITLE_PATTERN = /^chore(?:\([^)]+\))?: release(?:\s|$)/;
+const SERVICE_ACCOUNT_HANDLES = new Set([
+  'allcontributors',
+  'copilot-pull-request-reviewer',
+  'dependabot',
+  'github-actions',
+  'release-please',
+  'renovate',
+  'semantic-release-bot',
+  'snyk-bot',
+  'web-flow',
+]);
+
+interface ReleaseSemver {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+function normalizeHandle(handle: string): string {
+  const trimmed = handle.trim();
+  return trimmed.startsWith('@') ? trimmed.slice(1) : trimmed;
+}
+
+function uniqueSortedHandles(handles: string[]): string[] {
+  return [...new Set(handles.map(normalizeHandle).filter(Boolean))].sort((left, right) => left.localeCompare(right));
+}
 
 function isNoChangeContent(content: string): boolean {
   const lines = content
@@ -83,7 +113,12 @@ function formatReleaseNotesForChangelog(notes: string): string {
   const trimmed = notes.trim();
   if (!trimmed) return '';
 
-  return trimmed.replace(/^##\s+/gm, '### ');
+  const lines = trimmed.split(/\r?\n/);
+  if (lines[0]?.startsWith('# ')) {
+    lines[0] = `_${lines[0].replace(/^#\s+/, '').trim()}_`;
+  }
+
+  return stripContributorAvatarLines(lines.join('\n')).replace(/^##\s+/gm, '### ');
 }
 
 export function releaseVersionFromTag(tag: string): string {
@@ -92,6 +127,166 @@ export function releaseVersionFromTag(tag: string): string {
   if (value.startsWith('v')) return value.slice(1);
 
   return value;
+}
+
+function releaseDisplayVersionFromTag(tag: string): string {
+  const version = releaseVersionFromTag(tag);
+  return version.startsWith('v') ? version : `v${version}`;
+}
+
+function parseReleaseSemver(tag: string): ReleaseSemver | null {
+  const match = releaseVersionFromTag(tag).match(/^v?(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:[-+].*)?$/);
+  if (!match?.groups) return null;
+
+  return {
+    major: Number(match.groups.major),
+    minor: Number(match.groups.minor),
+    patch: Number(match.groups.patch),
+  };
+}
+
+export function isMajorRelease(context: Pick<ReleaseContext, 'tag' | 'previousTag'>): boolean {
+  const current = parseReleaseSemver(context.tag);
+  if (!current || current.major === 0) return false;
+
+  const previous = parseReleaseSemver(context.previousTag);
+  if (!previous) return current.minor === 0 && current.patch === 0;
+
+  return current.major > previous.major;
+}
+
+function isServiceAccount(handle: string): boolean {
+  const normalized = normalizeHandle(handle).toLowerCase();
+  return SERVICE_ACCOUNT_HANDLES.has(normalized)
+    || normalized.endsWith('[bot]')
+    || normalized.endsWith('-bot');
+}
+
+export function releaseContributorHandles(pullRequests: PullRequestDetails[]): string[] {
+  return uniqueSortedHandles(
+    pullRequests.flatMap((pr) => (pr.author?.login ? [pr.author.login] : [])),
+  ).filter((handle) => !isServiceAccount(handle));
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => {
+    switch (character) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case "'":
+        return '&#39;';
+      default:
+        return character;
+    }
+  });
+}
+
+function githubHandleUrl(handle: string): string {
+  return `https://github.com/${encodeURIComponent(handle)}`;
+}
+
+function formatContributorAvatar(handle: string): string {
+  const escapedHandle = escapeHtml(handle);
+  const encodedHandle = encodeURIComponent(handle);
+
+  return `<a href="${githubHandleUrl(handle)}" title="@${escapedHandle}"><img src="https://github.com/${encodedHandle}.png?size=64" width="64" height="64" alt="@${escapedHandle}" /></a>`;
+}
+
+function formatContributorLink(handle: string): string {
+  return `[@${handle}](${githubHandleUrl(handle)})`;
+}
+
+function formatContributorsSection(handles: string[]): string | null {
+  if (handles.length === 0) return null;
+
+  return [
+    '## Contributors',
+    handles.map(formatContributorAvatar).join('\n'),
+    '',
+    handles.map(formatContributorLink).join(' | '),
+  ].join('\n');
+}
+
+function stripContributorAvatarLines(notes: string): string {
+  return notes
+    .split(/\r?\n/)
+    .filter((line) => !(/<img\b/i.test(line) && /https:\/\/github\.com\/[^"'\s>]+\.png\?size=64/.test(line)))
+    .join('\n')
+    .replace(/(^|\n)(## Contributors)\n\n/g, '$1$2\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function parseMajorReleaseTitle(raw: string): string | null {
+  for (const line of raw.split(/\r?\n/)) {
+    const titleMatch = line.match(/^#\s+(.+?)\s*$/);
+    if (titleMatch) return titleMatch[1];
+    if (/^##\s+/.test(line)) return null;
+  }
+
+  return null;
+}
+
+function fallbackMajorReleaseTitle(context: ReleaseContext): string {
+  const releaseText = context.pullRequests.map((pr) => [
+    pr.title,
+    ...pr.labels.map((label) => label.name),
+    ...pr.files.map((file) => file.path),
+  ].join('\n')).join('\n').toLowerCase();
+
+  if (/\bclis\//.test(releaseText) || /\badapter\b/.test(releaseText) || /\bcli\b/.test(releaseText)) {
+    return 'The Command Surface Expands';
+  }
+  if (/\bbrowser\b|\bcloak\b|\bdaemon\b/.test(releaseText)) {
+    return 'The Browser Runtime Matures';
+  }
+  if (/\bskills?\b/.test(releaseText)) {
+    return 'The Agent Authoring Edition';
+  }
+  if (/\bdocs?\b|\breadme\b/.test(releaseText)) {
+    return 'The Documentation Edition';
+  }
+  if (/\bplugins?\b/.test(releaseText)) {
+    return 'The Plugin System Opens Up';
+  }
+
+  return 'A New Command Surface';
+}
+
+function normalizeMajorReleaseTitle(rawTitle: string | null, context: ReleaseContext): string {
+  const title = (rawTitle ?? '')
+    .replace(/^webcmd[-\s]+v?\d+\.\d+\.\d+(?:[-+][^:\s]+)?\s*:\s*/i, '')
+    .replace(/^webcmd\s*:\s*/i, '')
+    .replace(/[`*_]/g, '')
+    .replace(/\s+/g, ' ')
+    .replace(/^[#:\-\s]+/, '')
+    .replace(/[.!]+$/, '')
+    .trim();
+  const lowerTitle = title.toLowerCase();
+
+  if (
+    !title
+    || title.length > 80
+    || lowerTitle === 'none'
+    || lowerTitle === 'n/a'
+    || lowerTitle === 'release notes'
+    || lowerTitle === 'webcmd'
+    || lowerTitle === 'webcmd release'
+  ) {
+    return fallbackMajorReleaseTitle(context);
+  }
+
+  return title;
+}
+
+function formatMajorReleaseHeading(raw: string, context: ReleaseContext): string {
+  return `# webcmd ${releaseDisplayVersionFromTag(context.tag)}: ${normalizeMajorReleaseTitle(parseMajorReleaseTitle(raw), context)}`;
 }
 
 export function replaceChangelogReleaseNotes(changelog: string, tag: string, notes: string): string {
@@ -163,13 +358,27 @@ function parseReleaseNoteSections(raw: string): Partial<Record<ReleaseNoteSectio
   return sections;
 }
 
-export function normalizeReleaseNotes(raw: string): string {
+export function normalizeReleaseNotes(raw: string, options: NormalizeReleaseNotesOptions = {}): string {
   const sections = parseReleaseNoteSections(raw);
-
-  return RELEASE_NOTE_SECTIONS.flatMap((section) => {
+  const sectionBlocks = RELEASE_NOTE_SECTIONS.flatMap((section) => {
     const content = normalizeSectionContent(sections[section]?.join('\n'));
     return content ? [`## ${section}\n${content}`] : [];
-  }).join('\n\n');
+  });
+
+  if (sectionBlocks.length === 0) return '';
+
+  const blocks: string[] = [];
+  if (options.context && isMajorRelease(options.context)) {
+    blocks.push(formatMajorReleaseHeading(raw, options.context));
+  }
+
+  blocks.push(...sectionBlocks);
+
+  const contributors = options.context ? releaseContributorHandles(options.context.pullRequests) : [];
+  const contributorsSection = formatContributorsSection(contributors);
+  if (contributorsSection) blocks.push(contributorsSection);
+
+  return blocks.join('\n\n');
 }
 
 function formatPullRequest(pr: PullRequestDetails): string {
@@ -191,12 +400,21 @@ function formatPullRequest(pr: PullRequestDetails): string {
 
 export function buildReleaseNotesPrompt(context: ReleaseContext): string {
   const prSummaries = context.pullRequests.map(formatPullRequest).join('\n\n');
+  const majorReleaseInstructions = isMajorRelease(context)
+    ? [
+      `This is a major release. Start with exactly one H1: # webcmd ${releaseDisplayVersionFromTag(context.tag)}: <Elegant Release Title>.`,
+      'Make the title grand enough to feel memorable, but polished rather than loud. Keep it short, specific to the supplied PRs, and avoid hype words.',
+    ]
+    : [
+      'Do not include a top-level release title.',
+    ];
 
   return [
     `Write user-facing release notes for ${context.tag}.`,
     `Release range: ${context.previousTag}...${context.currentRef}.`,
     'Use only the supplied pull requests below. Do not invent changes or pull in information from elsewhere.',
     `Allowed sections: ${RELEASE_NOTE_SECTIONS.map((section) => `## ${section}`).join(', ')}.`,
+    ...majorReleaseInstructions,
     'Include only sections that have user-visible changes. Omit empty sections entirely; do not write "None", "N/A", or similar placeholder text.',
     'Do not include a Contributors section.',
     'In this project, CLI commands and adapters are the same thing. Treat any PR that adds, removes, or changes files under clis/** as an adapter change, even if the PR title says "CLI" instead of "adapter".',


### PR DESCRIPTION
## Summary
- add major-release detection and prompt guidance for tasteful H1 release titles
- render deterministic contributor credits from PR authors with linked GitHub avatars and accessible handle links
- keep generated changelog entries readable by converting release-page titles and stripping generated avatar HTML there

Closes #77.

## Tests
- `npx vitest run --project unit src/release-notes.test.ts src/generate-release-notes-cli.test.ts`
- `npm run typecheck`
- `npm test`
