### PR TITLE
docs: clarify adapter discovery

### DIFF
--- a/skills/webcmd-usage/SKILL.md
+++ b/skills/webcmd-usage/SKILL.md
@@ -49,14 +49,13 @@ Electron desktop app adapters route through CDP against the running app. Make su
 Run commands instead of reading static docs:
 
 ```bash
-webcmd list
+webcmd
 webcmd list -f json
-webcmd list | grep -i github
 webcmd <site> --help
 webcmd <site> <command> --help
 ```
 
-Do not hard-code adapter lists. `webcmd list -f json` is the source of truth and emits one entry per command with fields such as `{site, name, aliases, description, strategy, browser, args, columns}`.
+Run `webcmd` with no arguments to see all installed app and site adapters. Do not hard-code adapter lists: `webcmd list -f json` is the source of truth and emits one entry per command with fields such as `{site, name, aliases, description, strategy, browser, args, columns}`.
 
 Before falling back to raw `webcmd browser` on high-change authenticated sites, check whether a site adapter already exposes the workflow.
 

--- a/skills/webcmd-usage/SKILL.md
+++ b/skills/webcmd-usage/SKILL.md
@@ -55,7 +55,7 @@ webcmd <site> --help
 webcmd <site> <command> --help
 ```
 
-Run `webcmd` with no arguments to see all available functions and installed site adapters. Do not hard-code adapter lists: `webcmd list -f json` is the source of truth and emits one entry per command with fields such as `{site, name, aliases, description, strategy, browser, args, columns}`.
+Run `webcmd` with no arguments to see all available functions and installed site adapters. Do not hard-code adapter lists: `webcmd list -f json` is the source of truth for installed commands and emits one entry per command with fields such as `{site, name, aliases, description, strategy, browser, args, columns}`.
 
 Use this fallback order:
 

--- a/skills/webcmd-usage/SKILL.md
+++ b/skills/webcmd-usage/SKILL.md
@@ -55,7 +55,7 @@ webcmd <site> --help
 webcmd <site> <command> --help
 ```
 
-Run `webcmd` with no arguments to see all installed app and site adapters. Do not hard-code adapter lists: `webcmd list -f json` is the source of truth and emits one entry per command with fields such as `{site, name, aliases, description, strategy, browser, args, columns}`.
+Run `webcmd` with no arguments to see all available functions and installed site adapters. Do not hard-code adapter lists: `webcmd list -f json` is the source of truth and emits one entry per command with fields such as `{site, name, aliases, description, strategy, browser, args, columns}`.
 
 Before falling back to raw `webcmd browser` on high-change authenticated sites, check whether a site adapter already exposes the workflow.
 


### PR DESCRIPTION
## Summary

- document that bare webcmd shows installed app and site adapters
- keep webcmd list -f json as the command-schema source for agents
- remove the redundant human-facing webcmd list and grep examples

## Testing

- skill validator passed
- focused skill tests: 6 passed
- full test suite: 365 files passed, 4,130 tests passed, 1 skipped