### PR TITLE
Fix pre-1 minor release titles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,16 @@ jobs:
           set -euo pipefail
           npm --silent run generate-release-notes -- "${{ steps.release.outputs.tag_name }}" > "$RUNNER_TEMP/release-notes.md"
           if [ -s "$RUNNER_TEMP/release-notes.md" ]; then
-            if gh release edit "${{ steps.release.outputs.tag_name }}" --notes-file "$RUNNER_TEMP/release-notes.md"; then
+            release_title="$(sed -n 's/^# //p' "$RUNNER_TEMP/release-notes.md" | head -n 1)"
+            release_body_file="$RUNNER_TEMP/release-notes.md"
+            release_edit_args=()
+            if [ -n "$release_title" ]; then
+              release_body_file="$RUNNER_TEMP/release-body.md"
+              tail -n +2 "$RUNNER_TEMP/release-notes.md" | sed '1{/^$/d;}' > "$release_body_file"
+              release_edit_args+=(--title "$release_title")
+            fi
+            release_edit_args+=(--notes-file "$release_body_file")
+            if gh release edit "${{ steps.release.outputs.tag_name }}" "${release_edit_args[@]}"; then
               echo "Enhanced release notes were applied."
             else
               echo "::warning::Enhanced release notes could not be applied; keeping release-please notes."

--- a/src/generate-release-notes-cli.test.ts
+++ b/src/generate-release-notes-cli.test.ts
@@ -264,7 +264,12 @@ describe('runGenerateReleaseNotes', () => {
     expect(workflow.indexOf('- name: Publish to npm')).toBeLessThan(workflow.indexOf('- name: Update changelog with enhanced release notes'));
     expect(workflow).toContain('npm --silent run generate-release-notes -- --update-changelog');
     expect(workflow).toContain('git push origin "HEAD:${{ github.ref_name }}"');
-    expect(workflow).toMatch(/if gh release edit "\$\{\{ steps\.release\.outputs\.tag_name \}\}" --notes-file "\$RUNNER_TEMP\/release-notes\.md"; then/);
+    expect(workflow).toContain('release_title="$(sed -n');
+    expect(workflow).toContain('release_body_file="$RUNNER_TEMP/release-notes.md"');
+    expect(workflow).toContain('release_body_file="$RUNNER_TEMP/release-body.md"');
+    expect(workflow).toContain('release_edit_args+=(--title "$release_title")');
+    expect(workflow).toContain('release_edit_args+=(--notes-file "$release_body_file")');
+    expect(workflow).toContain('if gh release edit "${{ steps.release.outputs.tag_name }}" "${release_edit_args[@]}"; then');
     expect(workflow).toMatch(/Enhanced release notes could not be applied; keeping release-please notes\./);
   });
 });

--- a/src/release-notes.test.ts
+++ b/src/release-notes.test.ts
@@ -34,8 +34,11 @@ describe('release notes helpers', () => {
   it('detects major releases from semver tag ranges', () => {
     expect(isMajorRelease({ tag: 'webcmd-v2.0.0', previousTag: 'webcmd-v1.9.9' })).toBe(true);
     expect(isMajorRelease({ tag: 'v3.1.0', previousTag: 'v2.9.9' })).toBe(true);
+    expect(isMajorRelease({ tag: 'webcmd-v0.3.0', previousTag: 'webcmd-v0.2.5' })).toBe(true);
+    expect(isMajorRelease({ tag: 'webcmd-v0.1.0', previousTag: 'webcmd-v0.0.9' })).toBe(true);
     expect(isMajorRelease({ tag: 'webcmd-v2.1.0', previousTag: 'webcmd-v2.0.0' })).toBe(false);
-    expect(isMajorRelease({ tag: 'webcmd-v0.3.0', previousTag: 'webcmd-v0.2.5' })).toBe(false);
+    expect(isMajorRelease({ tag: 'webcmd-v0.3.1', previousTag: 'webcmd-v0.3.0' })).toBe(false);
+    expect(isMajorRelease({ tag: 'webcmd-v0.0.1', previousTag: 'webcmd-v0.0.0' })).toBe(false);
   });
 
   it('deduplicates PR author contributors and excludes service accounts', () => {
@@ -129,9 +132,9 @@ describe('release notes helpers', () => {
 
   it('uses a deterministic major release title fallback when the model omits one', () => {
     const context: ReleaseContext = {
-      tag: 'webcmd-v2.0.0',
-      previousTag: 'webcmd-v1.9.9',
-      currentRef: 'webcmd-v2.0.0',
+      tag: 'webcmd-v0.3.0',
+      previousTag: 'webcmd-v0.2.5',
+      currentRef: 'webcmd-v0.3.0',
       pullRequests: [
         {
           number: 42,
@@ -146,7 +149,7 @@ describe('release notes helpers', () => {
 
     const normalized = normalizeReleaseNotes('## Highlights\n- Added a GitHub adapter.', { context });
 
-    expect(normalized).toContain('# webcmd v2.0.0: The Command Surface Expands');
+    expect(normalized).toContain('# webcmd v0.3.0: The Command Surface Expands');
   });
 
   it('does not add major release title treatment to minor releases', () => {
@@ -221,8 +224,8 @@ describe('release notes helpers', () => {
 
   it('builds a prompt grounded in the exact release range and PR list', () => {
     const context: ReleaseContext = {
-      tag: 'v0.2.0',
-      previousTag: 'v0.1.1',
+      tag: 'v0.2.1',
+      previousTag: 'v0.2.0',
       currentRef: 'abc123',
       pullRequests: [
         {
@@ -239,7 +242,7 @@ describe('release notes helpers', () => {
     };
 
     const prompt = buildReleaseNotesPrompt(context);
-    expect(prompt).toContain('v0.1.1...abc123');
+    expect(prompt).toContain('v0.2.0...abc123');
     expect(prompt).toContain('PR #42: feat: add docs scaffold');
     expect(prompt).toContain('docs/docs.json');
     expect(prompt).toContain('## Highlights');
@@ -256,9 +259,9 @@ describe('release notes helpers', () => {
 
   it('asks for a tasteful H1 title only when building major release notes', () => {
     const context: ReleaseContext = {
-      tag: 'webcmd-v2.0.0',
-      previousTag: 'webcmd-v1.9.9',
-      currentRef: 'webcmd-v2.0.0',
+      tag: 'webcmd-v0.3.0',
+      previousTag: 'webcmd-v0.2.5',
+      currentRef: 'webcmd-v0.3.0',
       pullRequests: [
         {
           number: 42,
@@ -276,7 +279,7 @@ describe('release notes helpers', () => {
     const prompt = buildReleaseNotesPrompt(context);
 
     expect(prompt).toContain('This is a major release');
-    expect(prompt).toContain('# webcmd v2.0.0: <Elegant Release Title>');
+    expect(prompt).toContain('# webcmd v0.3.0: <Elegant Release Title>');
     expect(prompt).toContain('grand enough to feel memorable, but polished rather than loud');
   });
 });

--- a/src/release-notes.ts
+++ b/src/release-notes.ts
@@ -147,9 +147,16 @@ function parseReleaseSemver(tag: string): ReleaseSemver | null {
 
 export function isMajorRelease(context: Pick<ReleaseContext, 'tag' | 'previousTag'>): boolean {
   const current = parseReleaseSemver(context.tag);
-  if (!current || current.major === 0) return false;
+  if (!current) return false;
 
   const previous = parseReleaseSemver(context.previousTag);
+  if (current.major === 0) {
+    if (current.minor === 0 || current.patch !== 0) return false;
+    if (!previous) return true;
+
+    return previous.major === 0 && current.minor > previous.minor;
+  }
+
   if (!previous) return current.minor === 0 && current.patch === 0;
 
   return current.major > previous.major;


### PR DESCRIPTION
## Summary
- treat `0.x.0` releases as title-worthy major-style releases while webcmd is pre-1.0
- keep patch releases like `0.3.1` untitled
- pass the generated H1 into `gh release edit --title` so the GitHub release page title updates, not just the notes body
- strip that H1 from the release body before editing the GitHub release, so the page title does not duplicate above Highlights

Follow-up to #77 / #79 after `webcmd-v0.3.0` showed contributors working but no release title.

## Tests
- `npx vitest run --project unit src/release-notes.test.ts src/generate-release-notes-cli.test.ts`
- `npm run typecheck`
- `npm test`
