### PR TITLE
Shrink contributor avatars in release notes

### DIFF
--- a/src/generate-release-notes-cli.test.ts
+++ b/src/generate-release-notes-cli.test.ts
@@ -86,7 +86,7 @@ describe('runGenerateReleaseNotes', () => {
         '- Better summaries.',
         '',
         '## Contributors',
-        '<a href="https://github.com/alice" title="@alice"><img src="https://github.com/alice.png?size=64" width="64" height="64" alt="@alice" /></a>',
+        '<a href="https://github.com/alice" title="@alice"><img src="https://github.com/alice.png?size=40" width="40" height="40" alt="@alice" /></a>',
         '',
         '[@alice](https://github.com/alice)',
         '',

--- a/src/release-notes.test.ts
+++ b/src/release-notes.test.ts
@@ -106,11 +106,19 @@ describe('release notes helpers', () => {
         },
         {
           number: 43,
+          title: 'feat: improve release presentation',
+          author: { login: 'bob' },
+          labels: [{ name: 'feature' }],
+          files: [{ path: 'src/release-notes.ts' }],
+          url: 'https://github.com/agentrhq/webcmd/pull/43',
+        },
+        {
+          number: 44,
           title: 'chore: release automation',
           author: { login: 'github-actions[bot]' },
           labels: [],
           files: [{ path: '.github/workflows/release.yml' }],
-          url: 'https://github.com/agentrhq/webcmd/pull/43',
+          url: 'https://github.com/agentrhq/webcmd/pull/44',
         },
       ],
     };
@@ -125,8 +133,9 @@ describe('release notes helpers', () => {
 
     expect(normalized).toContain('# webcmd v2.0.0: The Command Surface Opens');
     expect(normalized).toContain('## Contributors');
-    expect(normalized).toContain('<img src="https://github.com/alice.png?size=64" width="64" height="64" alt="@alice" />');
+    expect(normalized).toContain('<img src="https://github.com/alice.png?size=40" width="40" height="40" alt="@alice" /></a> <a href="https://github.com/bob"');
     expect(normalized).toContain('[@alice](https://github.com/alice)');
+    expect(normalized).toContain('[@alice](https://github.com/alice) | [@bob](https://github.com/bob)');
     expect(normalized).not.toContain('github-actions');
   });
 
@@ -204,7 +213,7 @@ describe('release notes helpers', () => {
       '- Improved district checkout.',
       '',
       '## Contributors',
-      '<a href="https://github.com/alice" title="@alice"><img src="https://github.com/alice.png?size=64" width="64" height="64" alt="@alice" /></a>',
+      '<a href="https://github.com/alice" title="@alice"><img src="https://github.com/alice.png?size=40" width="40" height="40" alt="@alice" /></a>',
       '',
       '[@alice](https://github.com/alice)',
     ].join('\n');

--- a/src/release-notes.ts
+++ b/src/release-notes.ts
@@ -54,6 +54,7 @@ export type GitRunner = (args: readonly string[]) => Promise<string>;
 const SQUASH_MERGE_PR_NUMBER_PATTERN = /\(#(?<number>\d+)\)\s*$/;
 const MERGE_COMMIT_PR_NUMBER_PATTERN = /^Merge pull request #(?<number>\d+) /;
 const RELEASE_PLEASE_TITLE_PATTERN = /^chore(?:\([^)]+\))?: release(?:\s|$)/;
+const CONTRIBUTOR_AVATAR_SIZE = 40;
 const SERVICE_ACCOUNT_HANDLES = new Set([
   'allcontributors',
   'copilot-pull-request-reviewer',
@@ -202,7 +203,7 @@ function formatContributorAvatar(handle: string): string {
   const escapedHandle = escapeHtml(handle);
   const encodedHandle = encodeURIComponent(handle);
 
-  return `<a href="${githubHandleUrl(handle)}" title="@${escapedHandle}"><img src="https://github.com/${encodedHandle}.png?size=64" width="64" height="64" alt="@${escapedHandle}" /></a>`;
+  return `<a href="${githubHandleUrl(handle)}" title="@${escapedHandle}"><img src="https://github.com/${encodedHandle}.png?size=${CONTRIBUTOR_AVATAR_SIZE}" width="${CONTRIBUTOR_AVATAR_SIZE}" height="${CONTRIBUTOR_AVATAR_SIZE}" alt="@${escapedHandle}" /></a>`;
 }
 
 function formatContributorLink(handle: string): string {
@@ -214,7 +215,7 @@ function formatContributorsSection(handles: string[]): string | null {
 
   return [
     '## Contributors',
-    handles.map(formatContributorAvatar).join('\n'),
+    handles.map(formatContributorAvatar).join(' '),
     '',
     handles.map(formatContributorLink).join(' | '),
   ].join('\n');
@@ -223,7 +224,7 @@ function formatContributorsSection(handles: string[]): string | null {
 function stripContributorAvatarLines(notes: string): string {
   return notes
     .split(/\r?\n/)
-    .filter((line) => !(/<img\b/i.test(line) && /https:\/\/github\.com\/[^"'\s>]+\.png\?size=64/.test(line)))
+    .filter((line) => !(/<img\b/i.test(line) && /https:\/\/github\.com\/[^"'\s>]+\.png\?size=\d+/.test(line)))
     .join('\n')
     .replace(/(^|\n)(## Contributors)\n\n/g, '$1$2\n')
     .replace(/\n{3,}/g, '\n\n')


### PR DESCRIPTION
## Summary
- reduce generated contributor avatar dimensions from 64px to 40px
- emit contributor avatars as one inline row so GitHub Releases renders them horizontally
- keep changelog avatar stripping tolerant of generated GitHub avatar sizes
- update release-note generator tests for the smaller horizontal contributor logos

## Tests
- `npx vitest run --project unit src/release-notes.test.ts src/generate-release-notes-cli.test.ts`
- `npm run typecheck`
- `npm test`
