### PR TITLE
feat: add support for local command execution in hosted mode

### DIFF
--- a/src/hosted/main-lifecycle.test.ts
+++ b/src/hosted/main-lifecycle.test.ts
@@ -92,17 +92,47 @@ describe('hosted CLI process lifecycle', () => {
     expect(result.stdout).toContain('Local-only commands:');
     await expect(readFile(fixture.discoverySentinel, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
   }, 20_000);
+
+  it('runs skills install locally without contacting Cloud when hosted mode is configured', async () => {
+    const fixture = await createHostedFixture('success');
+    const installDir = path.join(fixture.root, 'agent-skills');
+
+    const result = await runCli(['skills', 'install', '--path', installDir, '--json'], fixture.env);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    const body = JSON.parse(result.stdout) as {
+      skills: Array<{ name: string; stableLink: string; destination?: string }>;
+    };
+    expect(body.skills.map(skill => skill.name)).toEqual([
+      'smart-search',
+      'webcmd-adapter-author',
+      'webcmd-autofix',
+      'webcmd-browser',
+      'webcmd-browser-sitemap',
+      'webcmd-sitemap-author',
+      'webcmd-usage',
+    ]);
+    expect(body.skills.every(skill => skill.destination?.startsWith(installDir))).toBe(true);
+    await expect(readFile(path.join(installDir, 'webcmd-usage', 'SKILL.md'), 'utf8'))
+      .resolves.toContain('webcmd-usage');
+    await expect(readFile(fixture.discoverySentinel, 'utf8')).resolves.toBe('read');
+    expect(fixture.requests).toEqual([]);
+  }, 20_000);
 });
 
 async function createHostedFixture(outcome: 'success' | 'failure'): Promise<{
+  root: string;
   env: NodeJS.ProcessEnv;
   discoverySentinel: string;
+  requests: string[];
 }> {
   const root = await mkdtemp(path.join(tmpdir(), 'webcmd-hosted-lifecycle-'));
   tempRoots.push(root);
   const configDir = path.join(root, 'config');
   const userClis = path.join(root, '.webcmd', 'clis', 'lifecycle-sentinel');
   const discoverySentinel = path.join(root, 'local-discovery-ran');
+  const requests: string[] = [];
   await mkdir(configDir, { recursive: true });
   await mkdir(userClis, { recursive: true });
   await writeFile(path.join(userClis, 'sentinel.js'), [
@@ -113,6 +143,7 @@ async function createHostedFixture(outcome: 'success' | 'failure'): Promise<{
   ].join('\n'));
 
   const server = createServer((request, response) => {
+    requests.push(`${request.method ?? 'GET'} ${request.url ?? '/'}`);
     if (request.url === '/v1/manifest') {
       sendChunkedJson(response, {
         ok: true,
@@ -177,10 +208,13 @@ async function createHostedFixture(outcome: 'success' | 'failure'): Promise<{
   })}\n`, { mode: 0o600 });
 
   return {
+    root,
     discoverySentinel,
+    requests,
     env: {
       ...process.env,
       HOME: root,
+      USERPROFILE: root,
       WEBCMD_CONFIG_DIR: configDir,
       WEBCMD_NO_UPDATE_CHECK: '1',
     },

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getCompletionScriptFast, getCompletionsFromManifest, hasAllManifests } from './completion-fast.js';
+import { HOSTED_ROOT_HELP } from './completion-shared.js';
 import { findPackageRoot, getCliManifestPath } from './package-paths.js';
 import { PKG_VERSION } from './version.js';
 import { EXIT_CODES } from './errors.js';
@@ -30,20 +31,9 @@ const __dirname = path.dirname(__filename);
 // Use findPackageRoot so the path works both in dev (src/main.ts) and prod (dist/src/main.js).
 const BUILTIN_CLIS = path.join(findPackageRoot(__filename), 'clis');
 const USER_CLIS = path.join(os.homedir(), CONFIG_DIR_NAME, 'clis');
-const HOSTED_LOCAL_COMMANDS = new Set([
-  'adapter',
-  'antigravity',
-  'auth',
-  'convention-audit',
-  'daemon',
-  'doctor',
-  'external',
-  'plugin',
-  'profile',
-  'skills',
-  'validate',
-  'verify',
-]);
+// Derived from the canonical list (also drives hosted help text and
+// hosted/runner.ts's rejection path) so the two never drift apart.
+const HOSTED_LOCAL_COMMANDS = new Set((HOSTED_ROOT_HELP.localOnlyCommands ?? []).map(command => command.name));
 
 // ── Ultra-fast path: lightweight commands bypass full discovery ──────────
 // These are high-frequency or trivial paths that must not pay the startup tax.

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,20 @@ const __dirname = path.dirname(__filename);
 // Use findPackageRoot so the path works both in dev (src/main.ts) and prod (dist/src/main.js).
 const BUILTIN_CLIS = path.join(findPackageRoot(__filename), 'clis');
 const USER_CLIS = path.join(os.homedir(), CONFIG_DIR_NAME, 'clis');
+const HOSTED_LOCAL_COMMANDS = new Set([
+  'adapter',
+  'antigravity',
+  'auth',
+  'convention-audit',
+  'daemon',
+  'doctor',
+  'external',
+  'plugin',
+  'profile',
+  'skills',
+  'validate',
+  'verify',
+]);
 
 // ── Ultra-fast path: lightweight commands bypass full discovery ──────────
 // These are high-frequency or trivial paths that must not pay the startup tax.
@@ -75,13 +89,23 @@ if (!fastPathHandled) {
     process.exitCode = await runHostedSetup();
   } else {
     const { shouldUseHostedMode } = await import('./hosted/config.js');
-    if (shouldUseHostedMode()) {
+    if (shouldUseHostedMode() && !(await shouldRunLocalCommandInHostedMode(argv))) {
       const { runHostedCli } = await import('./hosted/runner.js');
       const result = await runHostedCli(argv);
       process.exitCode = result.exitCode;
     } else {
       await runLocalMain();
     }
+  }
+}
+
+async function shouldRunLocalCommandInHostedMode(input: readonly string[]): Promise<boolean> {
+  try {
+    const { parseHostedRootCommandSurface } = await import('./root-command-surface.js');
+    const parsed = parseHostedRootCommandSurface(input);
+    return parsed.kind === 'dispatch' && HOSTED_LOCAL_COMMANDS.has(parsed.argv[0]!);
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
## Description

Fixed #92 

`webcmd skills install` (and other local-only management commands: `adapter`, `antigravity`, `auth`, `convention-audit`, `daemon`, `doctor`, `external`, `plugin`, `profile`, `validate`, `verify`) were being routed through the hosted dispatcher whenever hosted mode was configured, causing them to be rejected as unknown hosted commands. `main.ts` now checks the parsed root command surface before dispatching, and routes any command in the local-only set to the local CLI path even when hosted mode is enabled. Added a regression test that runs the real CLI entrypoint under hosted config and confirms `skills install --json --path <dir>` completes locally without contacting the hosted API. Also removed a duplicate hardcoded copy of the local-only command list in `main.ts`, deriving it from the existing canonical list in `completion-shared.ts` (the same list that drives hosted help text and `hosted/runner.ts`'s rejection path) so the two can't drift apart again.

Related issue: #92

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Adapter Notes

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

$ webcmd skills install --json --path ./agent-skills
{"skills":[{"name":"smart-search",...,"destination":"./agent-skills/smart-search"}, ...]}
$ echo $?
0

Test run: `npx vitest run --project unit src/hosted/main-lifecycle.test.ts src/hosted/root-command-surface.test.ts` → 169 passed. `npx tsc --noEmit` → clean.

Note: Adapter Notes checkboxes left unchecked since this change touches CLI dispatch, not an adapter.