### PR TITLE
docs: update README and CONTRIBUTING with documentation links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,10 @@ import { CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors
 
 User adapters, plugins, cache, traces, and site memory live under `~/.webcmd`.
 
+## Documentation
+
+The published docs at [webcmd.dev/docs](https://webcmd.dev/docs) are built by Mintlify from the `docs/` directory in this repo. To change the published docs, edit the `.mdx` pages under `docs/` (and `docs/docs.json` for navigation) — do not edit the site directly.
+
 ## Documentation Sync Review
 
 Every pull request receives one advisory comment checking whether user-facing changes are reflected in `README.md`, `docs/`, and bundled `skills/`. The comment is updated after new commits and reports one of three verdicts:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
   <a href="https://www.npmjs.com/package/@agentrhq/webcmd">
     <img alt="NPM downloads" src="https://img.shields.io/npm/dt/@agentrhq/webcmd.svg?style=for-the-badge&color=1E88E5&labelColor=000000">
   </a>
+  <a href="https://webcmd.dev/docs">
+    <img alt="Documentation" src="https://img.shields.io/badge/docs-webcmd.dev-1E88E5.svg?style=for-the-badge&labelColor=000000">
+  </a>
   <a href="https://github.com/agentrhq/webcmd/blob/main/LICENSE">
     <img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-1E88E5.svg?style=for-the-badge&labelColor=000000">
   </a>
@@ -24,6 +27,8 @@
 **Self-learning browser infra for AI agents.**
 
 WebCMD learns the navigational context of websites as agents use them, then compiles that knowledge into deterministic commands for faster, cheaper, more reliable browser automation. The goal is simple: stop making agents rediscover the same sites on every run and cut browser-agent token spend by up to 90%.
+
+📖 **Full documentation: [webcmd.dev/docs](https://webcmd.dev/docs)**
 
 On top of live browser control, WebCMD adds 3 layers of learnings. Each layer collapses cost and variance for the layer above it.
 

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   ],
   "author": "AgentR",
   "license": "Apache-2.0",
+  "homepage": "https://webcmd.dev/docs",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/agentrhq/webcmd.git"


### PR DESCRIPTION
## Description

Fixes #74

GitHub-facing surfaces didn't point users to the published Mintlify docs site. Added a "docs" badge and a prominent `📖 Full documentation` link to `README.md` pointing at https://webcmd.dev/docs, added a `homepage` field to `package.json` for npm/GitHub package metadata, and added a "Documentation" section to `CONTRIBUTING.md` clarifying that the published site is built from `docs/` via Mintlify and changes must be made there, not on the live site. Checked `README.md`, `CONTRIBUTING.md`, and `docs/` for stale or local-only docs references — found none. `docs/docs.json` and the `.mdx` pages are unchanged and continue to build as the canonical Mintlify source.

Related issue: (docs link consistency)

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Adapter Notes

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```diff
--- a/README.md
+++ b/README.md
@@
+  <a href="https://webcmd.dev/docs">
+    <img alt="Documentation" src="https://img.shields.io/badge/docs-webcmd.dev-1E88E5.svg?style=for-the-badge&labelColor=000000">
+  </a>
@@
+📖 **Full documentation: [webcmd.dev/docs](https://webcmd.dev/docs)**

--- a/package.json
+++ b/package.json
@@
+  "homepage": "https://webcmd.dev/docs",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@
