### PR TITLE
docs: update adapter initialization instructions for clarity

### DIFF
--- a/skills/webcmd-adapter-author/SKILL.md
+++ b/skills/webcmd-adapter-author/SKILL.md
@@ -175,7 +175,7 @@ Check these off step by step:
        [ ] Order: identifier columns -> business numbers -> metadata.
 
 [ ] 9. Write the adapter (`adapter-template.md`):
-       [ ] `webcmd browser init <site>/<name> --strategy <strategy>`
+       [ ] `webcmd browser init <site>/<name>`, then set `strategy: Strategy.<strategy>` in the generated file
        [ ] Find the closest same-site or same-type adapter and copy it.
        [ ] Edit name, URL, and field mapping.
 

--- a/skills/webcmd-adapter-author/references/adapter-template.md
+++ b/skills/webcmd-adapter-author/references/adapter-template.md
@@ -7,14 +7,10 @@ Use this after recon, endpoint verification, field decoding, output design, and 
 For private iteration:
 
 ```bash
-webcmd browser init <site>/<name> --strategy <strategy>
+webcmd browser init <site>/<name>
 ```
 
-Write the working file at:
-
-```text
-~/.webcmd/clis/<site>/<name>.js
-```
+This scaffolds `~/.webcmd/clis/<site>/<name>.js` with a `Strategy.PUBLIC` placeholder — `init` takes no flags, so set the real `strategy:` value (and the other `TODO` fields) by hand once the file exists.
 
 Promote a community CLI to the main repo as a plugin:
 


### PR DESCRIPTION
## Description

Fixes #93

The `webcmd-adapter-author` skill documented `webcmd browser init <site>/<name> --strategy <strategy>` in both `SKILL.md` (Runbook Step 9) and `references/adapter-template.md`, but the shipped v0.3.0+ CLI's `browser init` command (`src/cli.ts`) only accepts a positional `<name>` — there is no `--strategy` flag and never was one. This caused an opencode agent building an adapter to stop and re-check the CLI contract mid-run instead of proceeding. Updated both spots to the real invocation (`webcmd browser init <site>/<name>`) and noted that `strategy:` is set by hand-editing the generated file's `Strategy.PUBLIC` placeholder afterward, matching what `init`'s scaffold template actually emits. Verified `webcmd-usage`'s SKILL.md already had the correct flag-less form, and cross-checked `browser verify`'s documented flags (`--write-fixture`, `--update-fixture`, `--no-fixture`, `--strict-memory`, `--seed-args`, `--trace`) plus all of `webcmd-browser`'s SKILL.md against the actual CLI — no other drift found.

Related issue: #93

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / t
### Adapter Notes

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```diff
--- a/skills/webcmd-adapter-author/SKILL.md
+++ b/skills/webcmd-adapter-author/SKILL.md
@@
-       [ ] `webcmd browser init <site>/<name> --strategy <strategy>`
+       [ ] `webcmd browser init <site>/<name>`, then set `strategy: Strategy.<strategy>` in the generated file

--- a/skills/webcmd-adapter-author/references/adapter-template.md
+++ b/skills/webcmd-adapter-author/references/adapter-template.md
@@
-webcmd browser init <site>/<name> --strategy <strategy>
+webcmd browser init <site>/<name>
+
+This scaffolds `~/.webcmd/clis/<site>/<name>.js` with a `Strategy.PUBLIC` placeholder — `init` takes no flags, so set the real `strategy:` value (and the other `TODO` fields) by hand once the file exists.

grep -r "\-\-strategy" . after the change returns no matches in skills/.