### PR TITLE
 fix: report installed cloakbrowser version in webcmd doctor

### DIFF
--- a/src/browser/runtime/local-cloak/provider.ts
+++ b/src/browser/runtime/local-cloak/provider.ts
@@ -2,7 +2,7 @@ import type { BrowserRuntimeCommand, BrowserRuntimeResult, BrowserRuntimeStatus 
 import type { BrowserRuntimeProvider, RuntimeStatusOptions } from '../provider.js';
 import { dispatchCloakAction } from './actions.js';
 import type { LaunchPersistentContext } from './session-manager.js';
-import { CloakSessionManager } from './session-manager.js';
+import { CloakSessionManager, resolveCloakBrowserVersion } from './session-manager.js';
 
 export interface LocalCloakRuntimeProviderOptions {
   baseDir?: string;
@@ -21,7 +21,7 @@ export class LocalCloakRuntimeProvider implements BrowserRuntimeProvider {
     return {
       runtimeConnected: true,
       runtimeName: 'cloak',
-      runtimeVersion: undefined,
+      runtimeVersion: resolveCloakBrowserVersion(),
       profiles,
       pending: 0,
       commandResultUnknown: 0,

--- a/src/browser/runtime/local-cloak/session-manager.ts
+++ b/src/browser/runtime/local-cloak/session-manager.ts
@@ -1,4 +1,6 @@
 import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { execFile } from 'node:child_process';
 import type { BrowserContext, Page as PlaywrightPage } from 'playwright-core';
 import { launchPersistentContext as cloakLaunchPersistentContext } from 'cloakbrowser';
@@ -6,6 +8,18 @@ import type { BrowserSurface, BrowserWindowMode, SiteSessionMode } from '../../p
 import { activateDarwinBackgroundContext, launchDarwinBackgroundPersistentContext } from './darwin-background-launch.js';
 import { normalizeProfileId, resolveCloakProfileDir } from './profiles.js';
 import { CloakNetworkCapture } from './network.js';
+import { findPackageRoot } from '../../../package-paths.js';
+
+/** Installed `cloakbrowser` npm package version, for doctor/status display. */
+export function resolveCloakBrowserVersion(): string | undefined {
+  try {
+    const entryPath = fileURLToPath(import.meta.resolve('cloakbrowser'));
+    const pkg = JSON.parse(fs.readFileSync(path.join(findPackageRoot(entryPath), 'package.json'), 'utf-8'));
+    return typeof pkg.version === 'string' ? pkg.version : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 export type LaunchPersistentContext = typeof cloakLaunchPersistentContext;
 export type RecoverLockedProfile = (userDataDir: string) => Promise<boolean>;
@@ -55,7 +69,6 @@ interface ProfileRuntime {
   context: BrowserContext;
   pages: Map<string, PageEntry>;
   selectedPageId?: string;
-  runtimeVersion?: string;
   lastSeenAt: number;
 }
 
@@ -104,7 +117,7 @@ export class CloakSessionManager {
     return [...this.profiles.entries()].map(([contextId, runtime]) => ({
       contextId,
       runtimeConnected: true,
-      runtimeVersion: runtime.runtimeVersion,
+      runtimeVersion: resolveCloakBrowserVersion(),
       pending: 0,
       lastSeenAt: runtime.lastSeenAt,
     }));


### PR DESCRIPTION
## Description

Fixes #31 

`webcmd doctor` always printed "version unknown" for the Cloak runtime because `runtimeVersion` was never actually populated: `LocalCloakRuntimeProvider.status()` hardcoded `runtimeVersion: undefined`, and the per-profile `ProfileRuntime.runtimeVersion` field in `session-manager.ts` was declared but never assigned anywhere in the codebase. Added `resolveCloakBrowserVersion()` in `session-manager.ts`, which resolves the installed `cloakbrowser` npm package's own `package.json` (via `import.meta.resolve('cloakbrowser')` plus the existing `findPackageRoot` helper from `package-paths.ts` — the same pattern `version.ts` already uses to read webcmd's own version) and reads its `version` field. Wired this into both the top-level runtime status (`provider.ts`) and each profile's status (`session-manager.ts`), and removed the dead `ProfileRuntime.runtimeVersion` field that was never set.

Related issue: #31

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Adapter Notes

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Resolver output confirmed against the installed dependency:

resolved version: 0.4.5

`package.json` dependency: `"cloakbrowser": "0.4.5"` — matches.

`npx tsc --noEmit` — clean. `npx vitest run --project unit` — 1899 passed, 12 pre-existing failures unrelated to this change (Windows symlink/`~`-path quirks in `plugin.test.ts`, `hosted/*`, `docs-sync-review-cli.test.ts`; confirmed identical with the fix stashed out).