### PR TITLE
fix: recover Cloak sessions and arbitrate persistent writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,7 @@ jobs:
         if: runner.os == 'Linux'
         run: npm run check:hosted-contract
 
-      - name: Check npm package executable
-        if: runner.os == 'Linux'
+      - name: Verify packed CLI executables
         run: npm run check:package-bin
 
       - name: Check silent column drops
@@ -144,3 +143,39 @@ jobs:
 
       - name: Run smoke tests
         run: npx vitest run --project smoke --reporter=verbose
+
+  windows-cloak-smoke:
+    name: Windows real Cloak smoke
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify packed CLI executables
+        run: npm run check:package-bin
+
+      - name: Run real Cloak lifecycle smoke
+        run: npx vitest run --project e2e tests/e2e/cloak-runtime.test.ts
+
+      - name: Collect sanitized diagnostics
+        if: failure()
+        shell: pwsh
+        run: ./scripts/collect-ci-diagnostics.ps1
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: windows-cloak-diagnostics
+          path: artifacts/windows-cloak/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,13 +166,19 @@ jobs:
       - name: Verify packed CLI executables
         run: npm run check:package-bin
 
+      - name: Validate diagnostics safety self-test
+        shell: pwsh
+        run: ./scripts/collect-ci-diagnostics.ps1 -SelfTest
+
       - name: Run real Cloak lifecycle smoke
         run: npx vitest run --project e2e tests/e2e/cloak-runtime.test.ts
 
       - name: Collect sanitized diagnostics
         if: failure()
         shell: pwsh
-        run: ./scripts/collect-ci-diagnostics.ps1
+        run: |
+          ./scripts/collect-ci-diagnostics.ps1 -SelfTest
+          ./scripts/collect-ci-diagnostics.ps1
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/scripts/check-package-bin.mjs
+++ b/scripts/check-package-bin.mjs
@@ -5,6 +5,10 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  formatPackageBinSpawnFailure,
+  packageBinSpawnOptions,
+} from '../dist/src/package-bin-process.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
@@ -20,14 +24,11 @@ function run(command, args, opts = {}) {
     cwd: ROOT,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
+    ...packageBinSpawnOptions(process.platform, command),
     ...opts,
   });
-  if (result.status !== 0) {
-    fail([
-      `${command} ${args.join(' ')} exited ${result.status}`,
-      result.stdout.trim(),
-      result.stderr.trim(),
-    ].filter(Boolean).join('\n'));
+  if (result.error || result.status !== 0) {
+    fail(formatPackageBinSpawnFailure(command, args, result));
   }
   return result;
 }

--- a/scripts/collect-ci-diagnostics.ps1
+++ b/scripts/collect-ci-diagnostics.ps1
@@ -1,0 +1,107 @@
+$ErrorActionPreference = 'Continue'
+
+$artifactRoot = Join-Path $PWD 'artifacts/windows-cloak'
+New-Item -ItemType Directory -Path $artifactRoot -Force | Out-Null
+
+function Write-SanitizedText {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [AllowEmptyString()][string]$Text
+  )
+
+  $sensitiveLinePattern = '(?i)(authorization|proxy-authorization|set-cookie|cookie|cdp(?:\s+endpoint)?|devtools|page[ _-]?content|document\.|innerhtml|outerhtml|snapshot|<html|<body|\b(?:html|body|content)\b\s*"?\s*:)'
+  $liveUrlPattern = '(?i)\b[a-z][a-z0-9+.-]*://[^\s"''<>]+'
+  $sanitized = foreach ($line in ($Text -split "`r?`n")) {
+    if ($line -match $sensitiveLinePattern) {
+      '[REDACTED sensitive diagnostic line]'
+      continue
+    }
+    $line -replace $liveUrlPattern, '[REDACTED_URL]'
+  }
+
+  $sanitized | Set-Content -LiteralPath $Path -Encoding utf8
+}
+
+function Write-SanitizedJson {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][AllowNull()][AllowEmptyCollection()]$Value
+  )
+
+  Write-SanitizedText -Path $Path -Text (ConvertTo-Json -InputObject $Value -Depth 20)
+}
+
+$runnerMetadata = [ordered]@{
+  collectedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+  nodeVersion = (& node --version 2>&1 | Out-String).Trim()
+  npmVersion = (& npm --version 2>&1 | Out-String).Trim()
+  runner = [ordered]@{
+    os = $env:RUNNER_OS
+    architecture = $env:RUNNER_ARCH
+    imageOs = $env:ImageOS
+    imageVersion = $env:ImageVersion
+    machineName = $env:COMPUTERNAME
+  }
+  github = [ordered]@{
+    runId = $env:GITHUB_RUN_ID
+    runAttempt = $env:GITHUB_RUN_ATTEMPT
+    sha = $env:GITHUB_SHA
+  }
+}
+
+try {
+  $windows = Get-CimInstance Win32_OperatingSystem -ErrorAction Stop
+  $runnerMetadata['windows'] = [ordered]@{
+    caption = $windows.Caption
+    version = $windows.Version
+    buildNumber = $windows.BuildNumber
+  }
+} catch {
+  $runnerMetadata['windows'] = @{ error = 'Windows metadata unavailable' }
+}
+Write-SanitizedJson -Path (Join-Path $artifactRoot 'runner-metadata.json') -Value $runnerMetadata
+
+$headers = @{ 'X-Webcmd' = '1' }
+try {
+  $daemonStatus = Invoke-RestMethod -Uri 'http://127.0.0.1:9777/status' -Headers $headers -TimeoutSec 5
+  Write-SanitizedJson -Path (Join-Path $artifactRoot 'daemon-status.json') -Value $daemonStatus
+} catch {
+  Write-SanitizedText -Path (Join-Path $artifactRoot 'daemon-status.txt') -Text 'Daemon status unavailable.'
+}
+
+try {
+  $daemonLogs = Invoke-RestMethod -Uri 'http://127.0.0.1:9777/logs' -Headers $headers -TimeoutSec 5
+  Write-SanitizedJson -Path (Join-Path $artifactRoot 'daemon-logs.json') -Value $daemonLogs
+} catch {
+  Write-SanitizedText -Path (Join-Path $artifactRoot 'daemon-logs.txt') -Text 'Daemon logs unavailable.'
+}
+
+$processMetadata = Get-Process -ErrorAction SilentlyContinue |
+  Where-Object { $_.ProcessName -match '(?i)^(node|chrome|chromium|cloak)' } |
+  ForEach-Object {
+    [ordered]@{
+      name = $_.ProcessName
+      id = $_.Id
+      startedAtUtc = if ($_.StartTime) { $_.StartTime.ToUniversalTime().ToString('o') } else { $null }
+      workingSetBytes = $_.WorkingSet64
+      cpuSeconds = $_.CPU
+    }
+  }
+Write-SanitizedJson -Path (Join-Path $artifactRoot 'process-metadata.json') -Value @($processMetadata)
+
+$cloakRoot = if ($env:USERPROFILE) { Join-Path $env:USERPROFILE '.webcmd/cloak' } else { $null }
+$cloakLogMetadata = @()
+if ($cloakRoot -and (Test-Path -LiteralPath $cloakRoot)) {
+  $cloakLogMetadata = Get-ChildItem -LiteralPath $cloakRoot -Recurse -File -ErrorAction SilentlyContinue |
+    Where-Object { $_.Extension -eq '.log' -or $_.Name -match '(?i)(debug|log)' } |
+    ForEach-Object {
+      [ordered]@{
+        relativePath = [System.IO.Path]::GetRelativePath($cloakRoot, $_.FullName)
+        bytes = $_.Length
+        lastWriteUtc = $_.LastWriteTimeUtc.ToString('o')
+      }
+    }
+}
+Write-SanitizedJson -Path (Join-Path $artifactRoot 'cloak-log-metadata.json') -Value @($cloakLogMetadata)
+
+Write-Host "Sanitized diagnostics written to $artifactRoot"

--- a/scripts/collect-ci-diagnostics.ps1
+++ b/scripts/collect-ci-diagnostics.ps1
@@ -88,6 +88,29 @@ function Get-DaemonLogMetadata {
   }
 }
 
+function Test-CloakDiagnosticLogName {
+  param(
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+
+  return $Name.EndsWith('.log', [StringComparison]::OrdinalIgnoreCase) -or
+    $Name.Equals('LOG', [StringComparison]::OrdinalIgnoreCase) -or
+    $Name.Equals('LOG.old', [StringComparison]::OrdinalIgnoreCase)
+}
+
+function Get-CloakLogFileMetadata {
+  param(
+    [Parameter(Mandatory = $true)][string]$Root,
+    [Parameter(Mandatory = $true)]$File
+  )
+
+  return [pscustomobject][ordered]@{
+    relativePath = [System.IO.Path]::GetRelativePath($Root, $File.FullName)
+    bytes = $File.Length
+    lastWriteUtc = $File.LastWriteTimeUtc.ToString('o')
+  }
+}
+
 function Assert-DiagnosticsSelfTest {
   param(
     [Parameter(Mandatory = $true)][bool]$Condition,
@@ -146,6 +169,25 @@ function Invoke-DiagnosticsSelfTest {
   Assert-DiagnosticsSelfTest -Condition (-not $metadataJson.Contains($unlabeledPageText)) -Message 'unlabeled page text survived daemon metadata projection'
   Assert-DiagnosticsSelfTest -Condition ($metadataJson -notmatch '(?i)"(?:msg|text|value|data)"\s*:') -Message 'free-form daemon fields survived metadata projection'
   Assert-DiagnosticsSelfTest -Condition (($metadata.PSObject.Properties.Name -join ',') -eq 'totalCount,countsByKnownLevel,unrecognizedLevelCount,earliestTimestampUtc,latestTimestampUtc') -Message 'daemon metadata contains a non-allowlisted field'
+
+  $diagnosticLogNames = @('browser.log', 'debug.log', 'LOG', 'LOG.old')
+  foreach ($name in $diagnosticLogNames) {
+    Assert-DiagnosticsSelfTest -Condition (Test-CloakDiagnosticLogName -Name $name) -Message "known diagnostic log name was rejected: $name"
+  }
+  foreach ($name in @('Login Data', 'catalog.json', 'debug.txt', 'LOG.bak')) {
+    Assert-DiagnosticsSelfTest -Condition (-not (Test-CloakDiagnosticLogName -Name $name)) -Message "non-log profile file was accepted: $name"
+  }
+
+  $syntheticFile = [pscustomobject]@{
+    FullName = Join-Path ([System.IO.Path]::GetTempPath()) 'debug.log'
+    Length = 42
+    LastWriteTimeUtc = [DateTime]::Parse('2024-01-03T00:00:00Z').ToUniversalTime()
+    SensitiveContent = 'cookie=sensitive-value'
+  }
+  $fileMetadata = Get-CloakLogFileMetadata -Root ([System.IO.Path]::GetTempPath()) -File $syntheticFile
+  $fileMetadataJson = ConvertTo-Json -InputObject $fileMetadata -Depth 3
+  Assert-DiagnosticsSelfTest -Condition (($fileMetadata.PSObject.Properties.Name -join ',') -eq 'relativePath,bytes,lastWriteUtc') -Message 'Cloak file metadata contains a non-allowlisted field'
+  Assert-DiagnosticsSelfTest -Condition (-not $fileMetadataJson.Contains('sensitive-value')) -Message 'Cloak file contents survived metadata projection'
 
   Write-Host 'Diagnostics self-test passed.'
 }
@@ -222,13 +264,9 @@ $cloakRoot = if ($env:USERPROFILE) { Join-Path $env:USERPROFILE '.webcmd/cloak' 
 $cloakLogMetadata = @()
 if ($cloakRoot -and (Test-Path -LiteralPath $cloakRoot)) {
   $cloakLogMetadata = Get-ChildItem -LiteralPath $cloakRoot -Recurse -File -ErrorAction SilentlyContinue |
-    Where-Object { $_.Extension -eq '.log' -or $_.Name -match '(?i)(debug|log)' } |
+    Where-Object { Test-CloakDiagnosticLogName -Name $_.Name } |
     ForEach-Object {
-      [ordered]@{
-        relativePath = [System.IO.Path]::GetRelativePath($cloakRoot, $_.FullName)
-        bytes = $_.Length
-        lastWriteUtc = $_.LastWriteTimeUtc.ToString('o')
-      }
+      Get-CloakLogFileMetadata -Root $cloakRoot -File $_
     }
 }
 Write-SanitizedJson -Path (Join-Path $artifactRoot 'cloak-log-metadata.json') -Value @($cloakLogMetadata)

--- a/scripts/collect-ci-diagnostics.ps1
+++ b/scripts/collect-ci-diagnostics.ps1
@@ -1,7 +1,27 @@
+[CmdletBinding()]
+param(
+  [switch]$SelfTest
+)
+
 $ErrorActionPreference = 'Continue'
 
-$artifactRoot = Join-Path $PWD 'artifacts/windows-cloak'
-New-Item -ItemType Directory -Path $artifactRoot -Force | Out-Null
+function Protect-SensitiveDiagnosticText {
+  param(
+    [AllowEmptyString()][string]$Text
+  )
+
+  $sensitiveLinePattern = '(?i)(?:^|[^a-z0-9])(?:auth(?:[-_]?token)?|authorization|proxy[-_]?authorization|bearer|token|api[-_]?key|secret|password|credentials?|set[-_]?cookie|cookie|cdp(?:[-_\s]?(?:endpoint|url))?|devtools(?:[-_\s]?url)?|live[-_\s]?url|browser[-_\s]?url|websocket[-_\s]?url|ws[-_\s]?url|page[-_\s]?(?:content|text|html)|innerhtml|outerhtml|snapshot)(?:$|[^a-z0-9])|document\.|<html|<body|\b(?:html|body|content)\b\s*"?\s*:'
+  $schemeUrlPattern = '(?i)\b[a-z][a-z0-9+.-]*://[^\s"''<>]+'
+  $sanitized = foreach ($line in ($Text -split "`r?`n")) {
+    if ($line -match $sensitiveLinePattern) {
+      '[REDACTED sensitive diagnostic line]'
+      continue
+    }
+    $line -replace $schemeUrlPattern, '[REDACTED_URL]'
+  }
+
+  return ($sanitized -join [Environment]::NewLine)
+}
 
 function Write-SanitizedText {
   param(
@@ -9,17 +29,7 @@ function Write-SanitizedText {
     [AllowEmptyString()][string]$Text
   )
 
-  $sensitiveLinePattern = '(?i)(authorization|proxy-authorization|set-cookie|cookie|cdp(?:\s+endpoint)?|devtools|page[ _-]?content|document\.|innerhtml|outerhtml|snapshot|<html|<body|\b(?:html|body|content)\b\s*"?\s*:)'
-  $liveUrlPattern = '(?i)\b[a-z][a-z0-9+.-]*://[^\s"''<>]+'
-  $sanitized = foreach ($line in ($Text -split "`r?`n")) {
-    if ($line -match $sensitiveLinePattern) {
-      '[REDACTED sensitive diagnostic line]'
-      continue
-    }
-    $line -replace $liveUrlPattern, '[REDACTED_URL]'
-  }
-
-  $sanitized | Set-Content -LiteralPath $Path -Encoding utf8
+  Protect-SensitiveDiagnosticText -Text $Text | Set-Content -LiteralPath $Path -Encoding utf8
 }
 
 function Write-SanitizedJson {
@@ -30,6 +40,124 @@ function Write-SanitizedJson {
 
   Write-SanitizedText -Path $Path -Text (ConvertTo-Json -InputObject $Value -Depth 20)
 }
+
+function Get-DaemonLogMetadata {
+  param(
+    [Parameter(Mandatory = $true)][AllowNull()]$Response
+  )
+
+  $knownLevels = @('debug', 'info', 'warn', 'error')
+  $logs = if ($null -ne $Response -and $null -ne $Response.logs) { @($Response.logs) } else { @() }
+  $countsByKnownLevel = [ordered]@{}
+  foreach ($knownLevel in $knownLevels) {
+    $countsByKnownLevel[$knownLevel] = 0
+  }
+
+  $unrecognizedLevelCount = 0
+  $timestamps = @()
+  $maximumTimestamp = [DateTimeOffset]::UtcNow.AddDays(1).ToUnixTimeMilliseconds()
+  foreach ($entry in $logs) {
+    $level = if ($null -ne $entry.level) { ([string]$entry.level).ToLowerInvariant() } else { '' }
+    if ($knownLevels -contains $level) {
+      $countsByKnownLevel[$level] += 1
+    } else {
+      $unrecognizedLevelCount += 1
+    }
+
+    $timestamp = 0L
+    if ($null -ne $entry.ts -and [Int64]::TryParse(([string]$entry.ts), [ref]$timestamp) -and $timestamp -ge 0 -and $timestamp -le $maximumTimestamp) {
+      $timestamps += $timestamp
+    }
+  }
+
+  $earliestTimestampUtc = $null
+  $latestTimestampUtc = $null
+  if ($timestamps.Count -gt 0) {
+    $earliestTimestamp = [Int64](($timestamps | Measure-Object -Minimum).Minimum)
+    $latestTimestamp = [Int64](($timestamps | Measure-Object -Maximum).Maximum)
+    $earliestTimestampUtc = [DateTimeOffset]::FromUnixTimeMilliseconds($earliestTimestamp).UtcDateTime.ToString('o')
+    $latestTimestampUtc = [DateTimeOffset]::FromUnixTimeMilliseconds($latestTimestamp).UtcDateTime.ToString('o')
+  }
+
+  return [pscustomobject][ordered]@{
+    totalCount = $logs.Count
+    countsByKnownLevel = [pscustomobject]$countsByKnownLevel
+    unrecognizedLevelCount = $unrecognizedLevelCount
+    earliestTimestampUtc = $earliestTimestampUtc
+    latestTimestampUtc = $latestTimestampUtc
+  }
+}
+
+function Assert-DiagnosticsSelfTest {
+  param(
+    [Parameter(Mandatory = $true)][bool]$Condition,
+    [Parameter(Mandatory = $true)][string]$Message
+  )
+
+  if (-not $Condition) {
+    throw "Diagnostics self-test failed: $Message"
+  }
+}
+
+function Invoke-DiagnosticsSelfTest {
+  $sensitiveSamples = @(
+    'auth: sensitive-value',
+    'authToken: sensitive-value',
+    'auth_token: sensitive-value',
+    'authorization: Bearer sensitive-value',
+    'bearer sensitive-value',
+    'token: sensitive-value',
+    'api-key: sensitive-value',
+    'api_key: sensitive-value',
+    'apiKey: sensitive-value',
+    'secret: sensitive-value',
+    'password: sensitive-value',
+    'credentials: sensitive-value',
+    'cookie: sensitive-value',
+    'cdpUrl: ws://127.0.0.1/devtools/sensitive-value',
+    'cdp_url: ws://127.0.0.1/devtools/sensitive-value',
+    'CDP endpoint: ws://127.0.0.1/devtools/sensitive-value',
+    'liveUrl: https://example.test/sensitive-value',
+    'live_url: https://example.test/sensitive-value',
+    'live URL: https://example.test/sensitive-value',
+    'scheme only https://example.test/sensitive-value'
+  )
+  foreach ($sample in $sensitiveSamples) {
+    $protected = Protect-SensitiveDiagnosticText -Text $sample
+    Assert-DiagnosticsSelfTest -Condition (-not $protected.Contains('sensitive-value')) -Message "sensitive sample survived: $sample"
+  }
+
+  $unlabeledPageText = 'Customer account balance is 1234 and the recovery phrase is violet quartz'
+  $syntheticLogs = [pscustomobject]@{
+    ok = $true
+    logs = @(
+      [pscustomobject]@{ level = 'warn'; msg = $unlabeledPageText; text = 'private text'; value = 'private value'; data = @{ private = $true }; ts = 1704067200000 },
+      [pscustomobject]@{ level = 'info'; msg = 'https://example.test/private'; ts = 1704153600000 },
+      [pscustomobject]@{ level = 'custom'; msg = 'secret but unlabeled'; ts = -1 }
+    )
+  }
+  $metadata = Get-DaemonLogMetadata -Response $syntheticLogs
+  $metadataJson = ConvertTo-Json -InputObject $metadata -Depth 5
+  Assert-DiagnosticsSelfTest -Condition ($metadata.totalCount -eq 3) -Message 'daemon log total count is incorrect'
+  Assert-DiagnosticsSelfTest -Condition ($metadata.countsByKnownLevel.warn -eq 1 -and $metadata.countsByKnownLevel.info -eq 1) -Message 'known daemon log level counts are incorrect'
+  Assert-DiagnosticsSelfTest -Condition ($metadata.unrecognizedLevelCount -eq 1) -Message 'unrecognized daemon log level count is incorrect'
+  Assert-DiagnosticsSelfTest -Condition ($metadata.earliestTimestampUtc -eq '2024-01-01T00:00:00.0000000Z') -Message 'earliest bounded timestamp is incorrect'
+  Assert-DiagnosticsSelfTest -Condition ($metadata.latestTimestampUtc -eq '2024-01-02T00:00:00.0000000Z') -Message 'latest bounded timestamp is incorrect'
+  Assert-DiagnosticsSelfTest -Condition (-not $metadataJson.Contains($unlabeledPageText)) -Message 'unlabeled page text survived daemon metadata projection'
+  Assert-DiagnosticsSelfTest -Condition ($metadataJson -notmatch '(?i)"(?:msg|text|value|data)"\s*:') -Message 'free-form daemon fields survived metadata projection'
+  Assert-DiagnosticsSelfTest -Condition (($metadata.PSObject.Properties.Name -join ',') -eq 'totalCount,countsByKnownLevel,unrecognizedLevelCount,earliestTimestampUtc,latestTimestampUtc') -Message 'daemon metadata contains a non-allowlisted field'
+
+  Write-Host 'Diagnostics self-test passed.'
+}
+
+if ($SelfTest) {
+  $ErrorActionPreference = 'Stop'
+  Invoke-DiagnosticsSelfTest
+  return
+}
+
+$artifactRoot = Join-Path $PWD 'artifacts/windows-cloak'
+New-Item -ItemType Directory -Path $artifactRoot -Force | Out-Null
 
 $runnerMetadata = [ordered]@{
   collectedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
@@ -71,9 +199,10 @@ try {
 
 try {
   $daemonLogs = Invoke-RestMethod -Uri 'http://127.0.0.1:9777/logs' -Headers $headers -TimeoutSec 5
-  Write-SanitizedJson -Path (Join-Path $artifactRoot 'daemon-logs.json') -Value $daemonLogs
+  $daemonLogMetadata = Get-DaemonLogMetadata -Response $daemonLogs
+  Write-SanitizedJson -Path (Join-Path $artifactRoot 'daemon-log-metadata.json') -Value $daemonLogMetadata
 } catch {
-  Write-SanitizedText -Path (Join-Path $artifactRoot 'daemon-logs.txt') -Text 'Daemon logs unavailable.'
+  Write-SanitizedText -Path (Join-Path $artifactRoot 'daemon-log-metadata.txt') -Text 'Daemon log metadata unavailable.'
 }
 
 $processMetadata = Get-Process -ErrorAction SilentlyContinue |

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -302,22 +302,49 @@ describe('daemon-client', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('releaseSiteSessionLease sends a daemon-local release and ignores failures', async () => {
+  it('releaseSiteSessionLease makes one best-effort POST without starting or retrying the daemon', async () => {
     setDaemonRunContext({
       runId: 'run_9999_newer_2',
       command: 'newer write',
       access: 'write',
     });
-    vi.mocked(fetch).mockRejectedValueOnce(new Error('daemon stopped'));
+    const ensureSpy = vi.spyOn(daemonLifecycle, 'ensureBrowserBridgeReady');
+    vi.mocked(fetch).mockRejectedValueOnce(new TypeError('fetch failed'));
 
     await expect(releaseSiteSessionLease('run_4242_1000_1')).resolves.toBeUndefined();
 
     expect(fetch).toHaveBeenCalledTimes(1);
+    expect(ensureSpy).not.toHaveBeenCalled();
     const body = JSON.parse(String(vi.mocked(fetch).mock.calls[0][1]?.body));
     expect(body).toMatchObject({
       action: 'lease-release',
       runId: 'run_4242_1000_1',
     });
+  });
+
+  it('releaseSiteSessionLease aborts its best-effort POST after two seconds', async () => {
+    vi.useFakeTimers();
+    try {
+      let aborted = false;
+      vi.mocked(fetch).mockImplementationOnce((_url, init) => new Promise((_, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          aborted = true;
+          reject(Object.assign(new Error('This operation was aborted'), { name: 'AbortError' }));
+        });
+      }));
+
+      const pending = releaseSiteSessionLease('run_4242_1000_1');
+
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(aborted).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(aborted).toBe(true);
+      await expect(pending).resolves.toBeUndefined();
+      expect(fetch).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('sendCommand does not retry command_result_unknown even when the message looks transient', async () => {

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -4,11 +4,13 @@ import {
   BrowserCommandError,
   fetchDaemonStatus,
   getDaemonHealth,
+  releaseSiteSessionLease,
   requestDaemonShutdown,
   sendCommand,
   setDaemonCommandTimeoutSeconds,
 } from './daemon-client.js';
 import * as daemonLifecycle from './daemon-lifecycle.js';
+import { clearDaemonRunContext, getDaemonRunContext, setDaemonRunContext } from '../session-lease.js';
 
 describe('daemon-client', () => {
   beforeEach(() => {
@@ -16,6 +18,8 @@ describe('daemon-client', () => {
   });
 
   afterEach(() => {
+    const run = getDaemonRunContext();
+    if (run) clearDaemonRunContext(run.runId);
     if (typeof setDaemonCommandTimeoutSeconds === 'function') {
       setDaemonCommandTimeoutSeconds(null);
     }
@@ -180,6 +184,28 @@ describe('daemon-client', () => {
     expect(ids[0]).not.toBe(ids[1]);
   });
 
+  it('sendCommand binds the active logical run metadata to each daemon operation', async () => {
+    setDaemonRunContext({
+      runId: 'run_4242_1000_1',
+      command: 'example write',
+      access: 'write',
+    });
+    vi.mocked(fetch).mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ id: 'server', ok: true, data: 'ok' }),
+    } as Response);
+
+    await sendCommand('exec', { code: '1' });
+
+    const body = JSON.parse(String(vi.mocked(fetch).mock.calls[0][1]?.body));
+    expect(body).toMatchObject({
+      runId: 'run_4242_1000_1',
+      command: 'example write',
+      access: 'write',
+      pid: process.pid,
+    });
+  });
+
   it('sendCommand forwards WEBCMD_PROFILE as a hard contextId requirement', async () => {
     vi.stubEnv('WEBCMD_PROFILE', 'work');
     vi.spyOn(Date, 'now').mockReturnValue(1_763_000_000_000);
@@ -249,6 +275,49 @@ describe('daemon-client', () => {
       code: 'command_result_unknown',
     } satisfies Partial<BrowserCommandError>);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps daemon session_busy conflicts to SessionBusyError without retrying', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      json: () => Promise.resolve({
+        ok: false,
+        code: 'session_busy',
+        holder: {
+          command: 'other write',
+          pid: 4242,
+          acquiredAt: 1_000,
+          heartbeatAt: 2_000,
+        },
+      }),
+    } as Response);
+
+    await expect(sendCommand('exec', { code: '1' })).rejects.toMatchObject({
+      name: 'SessionBusyError',
+      code: 'SESSION_BUSY',
+      message: expect.stringContaining('other write'),
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('releaseSiteSessionLease sends a daemon-local release and ignores failures', async () => {
+    setDaemonRunContext({
+      runId: 'run_9999_newer_2',
+      command: 'newer write',
+      access: 'write',
+    });
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('daemon stopped'));
+
+    await expect(releaseSiteSessionLease('run_4242_1000_1')).resolves.toBeUndefined();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(String(vi.mocked(fetch).mock.calls[0][1]?.body));
+    expect(body).toMatchObject({
+      action: 'lease-release',
+      runId: 'run_4242_1000_1',
+    });
   });
 
   it('sendCommand does not retry command_result_unknown even when the message looks transient', async () => {

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -266,7 +266,17 @@ export async function sendCommandFull(
 }
 
 export async function releaseSiteSessionLease(runId: string): Promise<void> {
-  await sendCommand('lease-release', { runId }).catch(() => undefined);
+  const command: DaemonCommand = {
+    id: generateId(),
+    action: 'lease-release',
+    runId,
+  };
+  await requestDaemon('/command', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(command),
+    timeout: 2_000,
+  }).catch(() => undefined);
 }
 
 export async function bindTab(session: string, opts: { contextId?: string; preferredContextId?: string; page?: string; index?: number; windowMode?: BrowserWindowMode } = {}): Promise<unknown> {

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -5,8 +5,9 @@
  */
 
 import { sleep } from '../utils.js';
-import { BrowserConnectError } from '../errors.js';
+import { BrowserConnectError, SessionBusyError } from '../errors.js';
 import { COMMAND_RESULT_UNKNOWN_CODE, COMMAND_RESULT_UNKNOWN_HINT } from '../daemon-utils.js';
+import { getDaemonRunContext, type SessionLeaseHolder } from '../session-lease.js';
 import { classifyBrowserError } from './errors.js';
 import { profileRouteParams, resolveProfileSelection } from './profile.js';
 import { DEFAULT_BROWSER_CONNECT_TIMEOUT } from './config.js';
@@ -147,6 +148,7 @@ async function sendCommandRaw(
     }
 
     const remainingMs = Math.max(1000, deadlineAt - Date.now());
+    const run = action === 'lease-release' ? undefined : getDaemonRunContext();
     const command: DaemonCommand = {
       id,
       action,
@@ -156,6 +158,12 @@ async function sendCommandRaw(
       ...(contextId && { contextId }),
       ...(preferredContextId && { preferredContextId }),
       ...(windowMode && { windowMode }),
+      ...(run && {
+        runId: run.runId,
+        command: run.command,
+        access: run.access,
+        pid: process.pid,
+      }),
     };
     try {
       const res = await requestDaemon('/command', {
@@ -165,9 +173,16 @@ async function sendCommandRaw(
         timeout: remainingMs + HTTP_TIMEOUT_MARGIN_MS,
       });
 
-      const result = (await res.json()) as DaemonResult;
+      const result = (await res.json()) as DaemonResult & {
+        code?: string;
+        holder?: SessionLeaseHolder;
+      };
 
       if (result.ok) return result;
+
+      if (res.status === 409 && result.code === 'session_busy' && result.holder) {
+        throw new SessionBusyError(result.holder);
+      }
 
       if (result.errorCode && UNKNOWN_OUTCOME_CODES.has(result.errorCode)) {
         throw new BrowserCommandError(result.error ?? 'Browser command result is unknown', result.errorCode, result.errorHint);
@@ -248,6 +263,10 @@ export async function sendCommandFull(
 ): Promise<{ data: unknown; page?: string }> {
   const result = await sendCommandRaw(action, params);
   return { data: result.data, page: result.page };
+}
+
+export async function releaseSiteSessionLease(runId: string): Promise<void> {
+  await sendCommand('lease-release', { runId }).catch(() => undefined);
 }
 
 export async function bindTab(session: string, opts: { contextId?: string; preferredContextId?: string; page?: string; index?: number; windowMode?: BrowserWindowMode } = {}): Promise<unknown> {

--- a/src/browser/daemon-transport.ts
+++ b/src/browser/daemon-transport.ts
@@ -1,4 +1,5 @@
 import { DAEMON_HEADER_NAME, DEFAULT_DAEMON_PORT } from '../constants.js';
+import type { SessionLeaseStatus } from '../session-lease.js';
 
 const DAEMON_PORT = DEFAULT_DAEMON_PORT;
 const DAEMON_URL = `http://127.0.0.1:${DAEMON_PORT}`;
@@ -18,6 +19,7 @@ export interface DaemonStatus {
   profiles?: BrowserProfileStatus[];
   pending: number;
   commandResultUnknown?: number;
+  sessionLeases?: SessionLeaseStatus[];
   memoryMB: number;
   port: number;
 }

--- a/src/browser/protocol.ts
+++ b/src/browser/protocol.ts
@@ -1,3 +1,5 @@
+import type { SessionLeaseStatus } from '../session-lease.js';
+
 export type BrowserRuntimeAction =
   | 'exec'
   | 'navigate'
@@ -12,7 +14,8 @@ export type BrowserRuntimeAction =
   | 'network-capture-read'
   | 'wait-download'
   | 'cdp'
-  | 'frames';
+  | 'frames'
+  | 'lease-release';
 
 export type BrowserSurface = 'browser' | 'adapter';
 export type SiteSessionMode = 'ephemeral' | 'persistent';
@@ -54,6 +57,14 @@ export interface BrowserRuntimeCommand {
   contextId?: string;
   preferredContextId?: string;
   profileId?: string;
+  /** Stable identity for the complete logical CLI command run. */
+  runId?: string;
+  /** Human-readable canonical command that owns the logical run. */
+  command?: string;
+  /** Access classification used by daemon-local lease arbitration. */
+  access?: 'read' | 'write';
+  /** Originating CLI process, used only for actionable local busy guidance. */
+  pid?: number;
 }
 
 export interface BrowserRuntimeResult {
@@ -84,4 +95,6 @@ export interface BrowserRuntimeStatus {
   profiles: BrowserRuntimeProfileStatus[];
   pending: number;
   commandResultUnknown?: number;
+  /** Active local leases with internal run ownership tokens removed. */
+  sessionLeases?: SessionLeaseStatus[];
 }

--- a/src/browser/runtime/local-cloak/actions.ts
+++ b/src/browser/runtime/local-cloak/actions.ts
@@ -14,7 +14,7 @@ class CloakActionError extends Error {
   }
 }
 
-function commandProfileId(manager: CloakSessionManager, command: BrowserRuntimeCommand): string {
+export function resolveCloakCommandProfileId(manager: CloakSessionManager, command: BrowserRuntimeCommand): string {
   const requested = command.profileId ?? command.contextId;
   if (requested?.trim()) return requested.trim();
 
@@ -46,7 +46,7 @@ async function resolveLease(manager: CloakSessionManager, command: BrowserRuntim
     throw new CloakActionError('stale_page_identity', `Page not found: ${command.page} — stale page identity`);
   }
   return manager.getPage({
-    profileId: commandProfileId(manager, command),
+    profileId: resolveCloakCommandProfileId(manager, command),
     session: command.session,
     surface: command.surface,
     siteSession: command.siteSession,
@@ -113,11 +113,11 @@ export async function dispatchCloakAction(manager: CloakSessionManager, command:
       }
       case 'close-window': {
         if (command.page) {
-          const closed = await manager.closePage({ profileId: commandProfileId(manager, command), pageId: command.page });
+          const closed = await manager.closePage({ profileId: resolveCloakCommandProfileId(manager, command), pageId: command.page });
           return { id: command.id, ok: true, data: { closed: Boolean(closed), page: closed ?? command.page, session: command.session } };
         } else {
           await manager.release({
-            profileId: commandProfileId(manager, command),
+            profileId: resolveCloakCommandProfileId(manager, command),
             session: command.session,
             surface: command.surface,
           });
@@ -127,12 +127,12 @@ export async function dispatchCloakAction(manager: CloakSessionManager, command:
       case 'tabs': {
         switch (command.op ?? 'list') {
           case 'list': {
-            const tabs = await manager.listPages({ profileId: commandProfileId(manager, command) });
+            const tabs = await manager.listPages({ profileId: resolveCloakCommandProfileId(manager, command) });
             return { id: command.id, ok: true, data: tabs };
           }
           case 'new': {
             const lease = await manager.newPage({
-              profileId: commandProfileId(manager, command),
+              profileId: resolveCloakCommandProfileId(manager, command),
               session: command.session,
               surface: command.surface,
               siteSession: command.siteSession,
@@ -143,12 +143,12 @@ export async function dispatchCloakAction(manager: CloakSessionManager, command:
             return { id: command.id, ok: true, data: { title: await lease.page.title(), url: lease.page.url() }, page: lease.pageId };
           }
           case 'select': {
-            const lease = await manager.selectPage({ profileId: commandProfileId(manager, command), pageId: command.page, index: command.index, windowMode: command.windowMode });
+            const lease = await manager.selectPage({ profileId: resolveCloakCommandProfileId(manager, command), pageId: command.page, index: command.index, windowMode: command.windowMode });
             if (!lease) return { id: command.id, ok: false, errorCode: 'runtime_command_failed', error: 'Tab not found' };
             return { id: command.id, ok: true, data: { selected: true, url: lease.page.url() }, page: lease.pageId };
           }
           case 'close': {
-            const closed = await manager.closePage({ profileId: commandProfileId(manager, command), pageId: command.page, index: command.index });
+            const closed = await manager.closePage({ profileId: resolveCloakCommandProfileId(manager, command), pageId: command.page, index: command.index });
             if (!closed) return { id: command.id, ok: false, errorCode: 'runtime_command_failed', error: 'Tab not found' };
             return { id: command.id, ok: true, data: { closed } };
           }
@@ -212,7 +212,7 @@ export async function dispatchCloakAction(manager: CloakSessionManager, command:
         }
         {
           const lease = await manager.bindPage({
-            profileId: commandProfileId(manager, command),
+            profileId: resolveCloakCommandProfileId(manager, command),
             session: command.session,
             surface: command.surface,
             siteSession: command.siteSession,

--- a/src/browser/runtime/local-cloak/provider.test.ts
+++ b/src/browser/runtime/local-cloak/provider.test.ts
@@ -29,6 +29,7 @@ function fakePage(url: string) {
 function makeProviderWithFakePage() {
   const pages = [fakePage('https://example.com/')];
   const context = {
+    on: vi.fn(),
     pages: vi.fn(() => pages.filter((page) => !page.isClosed())),
     newPage: vi.fn(async () => {
       const page = fakePage('about:blank');

--- a/src/browser/runtime/local-cloak/provider.ts
+++ b/src/browser/runtime/local-cloak/provider.ts
@@ -1,6 +1,6 @@
 import type { BrowserRuntimeCommand, BrowserRuntimeResult, BrowserRuntimeStatus } from '../../protocol.js';
 import type { BrowserRuntimeProvider, RuntimeStatusOptions } from '../provider.js';
-import { dispatchCloakAction } from './actions.js';
+import { dispatchCloakAction, resolveCloakCommandProfileId } from './actions.js';
 import type { LaunchPersistentContext } from './session-manager.js';
 import { CloakSessionManager } from './session-manager.js';
 
@@ -26,6 +26,10 @@ export class LocalCloakRuntimeProvider implements BrowserRuntimeProvider {
       pending: 0,
       commandResultUnknown: 0,
     };
+  }
+
+  resolveProfileId(command: BrowserRuntimeCommand): string {
+    return resolveCloakCommandProfileId(this.manager, command);
   }
 
   async dispatch(command: BrowserRuntimeCommand): Promise<BrowserRuntimeResult> {

--- a/src/browser/runtime/local-cloak/session-manager.test.ts
+++ b/src/browser/runtime/local-cloak/session-manager.test.ts
@@ -5,6 +5,7 @@ import { CloakSessionManager } from './session-manager.js';
 import { dispatchCloakAction } from './actions.js';
 
 function fakeContext() {
+  const listeners = new Map<string, Set<() => void>>();
   const page = {
     goto: vi.fn().mockResolvedValue(undefined),
     evaluate: vi.fn().mockResolvedValue('ok'),
@@ -16,6 +17,14 @@ function fakeContext() {
   };
   return {
     context: {
+      on(event: string, listener: () => void) {
+        const bucket = listeners.get(event) ?? new Set();
+        bucket.add(listener);
+        listeners.set(event, bucket);
+      },
+      emit(event: string) {
+        for (const listener of listeners.get(event) ?? []) listener();
+      },
       pages: vi.fn().mockReturnValue([page]),
       newPage: vi.fn().mockResolvedValue(page),
       cookies: vi.fn().mockResolvedValue([{ name: 'sid', value: '1', domain: 'example.com', path: '/' }]),
@@ -116,6 +125,214 @@ describe('CloakSessionManager', () => {
     expect(first.page).toBe(second.page);
   });
 
+  it('evicts a closed runtime and clears every tracked page resource', async () => {
+    vi.useFakeTimers();
+    const launched = fakeContext();
+    const secondPage = fakeContext().page;
+    launched.context.newPage.mockResolvedValue(secondPage);
+    const manager = new CloakSessionManager({
+      baseDir: '/tmp/webcmd-test',
+      launchPersistentContext: vi.fn().mockResolvedValue(launched.context),
+    });
+    const stopCapture = vi.spyOn(manager.networkCapture, 'stop');
+
+    const first = await manager.getPage({ profileId: 'default', session: 'one', surface: 'browser', idleTimeout: 25 });
+    const second = await manager.newPage({ profileId: 'default', session: 'two', surface: 'browser', idleTimeout: 25 });
+    expect(manager.activeProfileIds()).toEqual(['default']);
+    expect(vi.getTimerCount()).toBe(2);
+
+    launched.context.emit('close');
+
+    expect(manager.activeProfileIds()).toEqual([]);
+    expect(manager.profileStatuses()).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(stopCapture).toHaveBeenCalledTimes(2);
+    expect(stopCapture).toHaveBeenCalledWith(first.page);
+    expect(stopCapture).toHaveBeenCalledWith(second.page);
+    await vi.advanceTimersByTimeAsync(25);
+    expect(first.page.close).not.toHaveBeenCalled();
+    expect(second.page.close).not.toHaveBeenCalled();
+  });
+
+  it('does not let a late close from an old runtime evict its replacement', async () => {
+    const first = fakeContext();
+    const replacement = fakeContext();
+    const launchPersistentContext = vi.fn()
+      .mockResolvedValueOnce(first.context)
+      .mockResolvedValueOnce(replacement.context);
+    const manager = new CloakSessionManager({ baseDir: '/tmp/webcmd-test', launchPersistentContext });
+
+    await manager.getPage({ profileId: 'default', session: 'first', surface: 'browser' });
+    first.context.emit('close');
+    const replacementLease = await manager.getPage({ profileId: 'default', session: 'replacement', surface: 'browser' });
+
+    first.context.emit('close');
+
+    expect(manager.activeProfileIds()).toEqual(['default']);
+    expect(manager.profileStatuses()).toHaveLength(1);
+    expect((await manager.getPage({ profileId: 'default', session: 'replacement', surface: 'browser' })).context)
+      .toBe(replacementLease.context);
+    expect(launchPersistentContext).toHaveBeenCalledTimes(2);
+  });
+
+  it('coalesces simultaneous replacement launches after a context closes', async () => {
+    const first = fakeContext();
+    const replacement = fakeContext();
+    let resolveReplacement!: (context: BrowserContext) => void;
+    const launchPersistentContext = vi.fn()
+      .mockResolvedValueOnce(first.context)
+      .mockImplementationOnce(() => new Promise<BrowserContext>((resolve) => {
+        resolveReplacement = resolve;
+      }));
+    const manager = new CloakSessionManager({ baseDir: '/tmp/webcmd-test', launchPersistentContext });
+    await manager.getPage({ profileId: 'default', session: 'first', surface: 'browser' });
+    first.context.emit('close');
+
+    const one = manager.getPage({ profileId: 'default', session: 'one', surface: 'browser' });
+    const two = manager.getPage({ profileId: 'default', session: 'two', surface: 'browser' });
+    await Promise.resolve();
+
+    expect(launchPersistentContext).toHaveBeenCalledTimes(2);
+    resolveReplacement(replacement.context as unknown as BrowserContext);
+    const leases = await Promise.all([one, two]);
+    expect(leases[0].context).toBe(replacement.context);
+    expect(leases[1].context).toBe(replacement.context);
+  });
+
+  it('retries when page creation finishes after its runtime closes', async () => {
+    const first = fakeContext();
+    first.context.pages.mockReturnValue([]);
+    let resolveFirstPage!: (page: typeof first.page) => void;
+    let markPageCreationStarted!: () => void;
+    const pageCreationStarted = new Promise<void>((resolve) => {
+      markPageCreationStarted = resolve;
+    });
+    first.context.newPage.mockImplementation(() => {
+      markPageCreationStarted();
+      return new Promise<typeof first.page>((resolve) => {
+        resolveFirstPage = resolve;
+      });
+    });
+    const replacement = fakeContext();
+    replacement.context.pages.mockReturnValue([]);
+    const launchPersistentContext = vi.fn()
+      .mockResolvedValueOnce(first.context)
+      .mockResolvedValueOnce(replacement.context);
+    const manager = new CloakSessionManager({ baseDir: '/tmp/webcmd-test', launchPersistentContext });
+
+    const pendingLease = manager.getPage({ profileId: 'default', session: 'work', surface: 'browser' });
+    await pageCreationStarted;
+    first.context.emit('close');
+    resolveFirstPage(first.page);
+
+    const lease = await pendingLease;
+    expect(first.page.close).toHaveBeenCalled();
+    expect(lease.context).toBe(replacement.context);
+    expect(manager.activeProfileIds()).toEqual(['default']);
+    expect(launchPersistentContext).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not publish an orphaned page after acquisition validation', async () => {
+    vi.useFakeTimers();
+    const first = fakeContext();
+    first.context.pages.mockReturnValue([]);
+    first.context.newPage.mockImplementation(() => ({
+      then(resolve: (page: typeof first.page) => void) {
+        resolve(first.page);
+        queueMicrotask(() => first.context.emit('close'));
+      },
+    }));
+    const replacement = fakeContext();
+    replacement.context.pages.mockReturnValue([]);
+    const launchPersistentContext = vi.fn()
+      .mockResolvedValueOnce(first.context)
+      .mockResolvedValueOnce(replacement.context);
+    const manager = new CloakSessionManager({ baseDir: '/tmp/webcmd-test', launchPersistentContext });
+
+    await manager.getPage({ profileId: 'default', session: 'first', surface: 'browser', idleTimeout: 25 });
+
+    expect(manager.activeProfileIds()).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+    const lease = await manager.getPage({ profileId: 'default', session: 'replacement', surface: 'browser' });
+    expect(lease.context).toBe(replacement.context);
+    expect(launchPersistentContext).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries getPage page creation once after a closed-context failure', async () => {
+    const closed = new Error('Target page, context or browser has been closed');
+    const first = fakeContext();
+    first.context.pages.mockReturnValue([]);
+    first.context.newPage.mockRejectedValue(closed);
+    const replacement = fakeContext();
+    replacement.context.pages.mockReturnValue([]);
+    const launchPersistentContext = vi.fn()
+      .mockResolvedValueOnce(first.context)
+      .mockResolvedValueOnce(replacement.context);
+    const manager = new CloakSessionManager({ baseDir: '/tmp/webcmd-test', launchPersistentContext });
+
+    const lease = await manager.getPage({ profileId: 'default', session: 'work', surface: 'browser' });
+
+    expect(lease.context).toBe(replacement.context);
+    expect(first.context.newPage).toHaveBeenCalledTimes(1);
+    expect(replacement.context.newPage).toHaveBeenCalledTimes(1);
+    expect(launchPersistentContext).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries explicit newPage page creation once after a closed-context failure', async () => {
+    const closed = new Error('browserContext.newPage: Target page, context or browser has been closed');
+    const first = fakeContext();
+    first.context.newPage.mockRejectedValue(closed);
+    const replacement = fakeContext();
+    const launchPersistentContext = vi.fn()
+      .mockResolvedValueOnce(first.context)
+      .mockResolvedValueOnce(replacement.context);
+    const manager = new CloakSessionManager({ baseDir: '/tmp/webcmd-test', launchPersistentContext });
+
+    const lease = await manager.newPage({ profileId: 'default', session: 'work', surface: 'browser' });
+
+    expect(lease.context).toBe(replacement.context);
+    expect(first.context.newPage).toHaveBeenCalledTimes(1);
+    expect(replacement.context.newPage).toHaveBeenCalledTimes(1);
+    expect(launchPersistentContext).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns the second closed-context page creation failure without looping', async () => {
+    const firstFailure = new Error('Target page, context or browser has been closed');
+    const secondFailure = new Error('Target page, context or browser has been closed again');
+    const first = fakeContext();
+    first.context.newPage.mockRejectedValue(firstFailure);
+    const replacement = fakeContext();
+    replacement.context.newPage.mockRejectedValue(secondFailure);
+    const launchPersistentContext = vi.fn()
+      .mockResolvedValueOnce(first.context)
+      .mockResolvedValueOnce(replacement.context);
+    const manager = new CloakSessionManager({ baseDir: '/tmp/webcmd-test', launchPersistentContext });
+
+    await expect(manager.newPage({ profileId: 'default', session: 'work', surface: 'browser' }))
+      .rejects.toBe(secondFailure);
+    expect(first.context.newPage).toHaveBeenCalledTimes(1);
+    expect(replacement.context.newPage).toHaveBeenCalledTimes(1);
+    expect(launchPersistentContext).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry or retain a page when navigation fails after creation', async () => {
+    const navigationFailure = new Error('Target page, context or browser has been closed');
+    const launched = fakeContext();
+    launched.page.goto.mockRejectedValue(navigationFailure);
+    const launchPersistentContext = vi.fn().mockResolvedValue(launched.context);
+    const manager = new CloakSessionManager({ baseDir: '/tmp/webcmd-test', launchPersistentContext });
+
+    await expect(manager.newPage({
+      profileId: 'default',
+      session: 'work',
+      surface: 'browser',
+      url: 'https://example.com/',
+    })).rejects.toBe(navigationFailure);
+
+    expect(launchPersistentContext).toHaveBeenCalledTimes(1);
+    expect(await manager.listPages({ profileId: 'default' })).toEqual([]);
+  });
+
   it('clears a stale Cloak profile owner and retries when Chromium reports an existing session', async () => {
     const launched = fakeContext();
     const launchPersistentContext = vi.fn()
@@ -146,6 +363,7 @@ describe('CloakSessionManager', () => {
     });
     const openPages: ReturnType<typeof makePage>[] = [];
     const context = {
+      on: vi.fn(),
       pages: vi.fn(() => openPages),
       newPage: vi.fn(async () => {
         const page = makePage();
@@ -184,6 +402,7 @@ describe('CloakSessionManager', () => {
       close: vi.fn().mockResolvedValue(undefined),
     };
     const context = {
+      on: vi.fn(),
       pages: vi.fn().mockReturnValue([leftover]),
       newPage: vi.fn().mockResolvedValue(created),
       cookies: vi.fn().mockResolvedValue([]),

--- a/src/browser/runtime/local-cloak/session-manager.test.ts
+++ b/src/browser/runtime/local-cloak/session-manager.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import path from 'node:path';
-import type { BrowserContext } from 'playwright-core';
+import type { BrowserContext, Page as PlaywrightPage } from 'playwright-core';
 import { CloakSessionManager } from './session-manager.js';
 import { dispatchCloakAction } from './actions.js';
 
@@ -199,7 +199,7 @@ describe('CloakSessionManager', () => {
     expect(leases[1].context).toBe(replacement.context);
   });
 
-  it('retries when page creation finishes after its runtime closes', async () => {
+  it('discards a page created after its runtime closes and defers recovery to the next command', async () => {
     const first = fakeContext();
     first.context.pages.mockReturnValue([]);
     let resolveFirstPage!: (page: typeof first.page) => void;
@@ -225,10 +225,13 @@ describe('CloakSessionManager', () => {
     first.context.emit('close');
     resolveFirstPage(first.page);
 
-    const lease = await pendingLease;
+    await expect(pendingLease).rejects.toThrow('Target page, context or browser has been closed');
     expect(first.page.close).toHaveBeenCalled();
+    expect(manager.activeProfileIds()).toEqual([]);
+    expect(launchPersistentContext).toHaveBeenCalledTimes(1);
+
+    const lease = await manager.getPage({ profileId: 'default', session: 'work', surface: 'browser' });
     expect(lease.context).toBe(replacement.context);
-    expect(manager.activeProfileIds()).toEqual(['default']);
     expect(launchPersistentContext).toHaveBeenCalledTimes(2);
   });
 
@@ -315,6 +318,47 @@ describe('CloakSessionManager', () => {
     expect(launchPersistentContext).toHaveBeenCalledTimes(2);
   });
 
+  it('keeps an explicitly navigated page untracked until navigation succeeds', async () => {
+    vi.useFakeTimers();
+    const launched = fakeContext();
+    let resolveNavigation!: () => void;
+    let markNavigationStarted!: () => void;
+    const navigationStarted = new Promise<void>((resolve) => {
+      markNavigationStarted = resolve;
+    });
+    launched.page.goto.mockImplementation(() => {
+      markNavigationStarted();
+      return new Promise<void>((resolve) => {
+        resolveNavigation = resolve;
+      });
+    });
+    const manager = new CloakSessionManager({
+      baseDir: '/tmp/webcmd-test',
+      launchPersistentContext: vi.fn().mockResolvedValue(launched.context),
+    });
+
+    const pendingLease = manager.newPage({
+      profileId: 'default',
+      session: 'work',
+      surface: 'browser',
+      idleTimeout: 25,
+      url: 'https://example.com/',
+    });
+    await navigationStarted;
+    const pagesDuringNavigation = await manager.listPages({ profileId: 'default' });
+    const pageIdDuringNavigation = manager.pageIdFor(launched.page as unknown as PlaywrightPage);
+    const timersDuringNavigation = vi.getTimerCount();
+    resolveNavigation();
+    const lease = await pendingLease;
+
+    expect(pagesDuringNavigation).toEqual([]);
+    expect(pageIdDuringNavigation).toBeUndefined();
+    expect(timersDuringNavigation).toBe(0);
+    expect(manager.pageIdFor(launched.page as unknown as PlaywrightPage)).toBe(lease.pageId);
+    expect(await manager.listPages({ profileId: 'default' })).toHaveLength(1);
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
   it('does not retry or retain a page when navigation fails after creation', async () => {
     const navigationFailure = new Error('Target page, context or browser has been closed');
     const launched = fakeContext();
@@ -330,6 +374,9 @@ describe('CloakSessionManager', () => {
     })).rejects.toBe(navigationFailure);
 
     expect(launchPersistentContext).toHaveBeenCalledTimes(1);
+    expect(launched.context.newPage).toHaveBeenCalledTimes(1);
+    expect(launched.page.goto).toHaveBeenCalledTimes(1);
+    expect(launched.page.close).toHaveBeenCalledTimes(1);
     expect(await manager.listPages({ profileId: 'default' })).toEqual([]);
   });
 

--- a/src/browser/runtime/local-cloak/session-manager.ts
+++ b/src/browser/runtime/local-cloak/session-manager.ts
@@ -81,6 +81,11 @@ function pageIsClosed(page: PlaywrightPage): boolean {
   return page.isClosed?.() === true;
 }
 
+function isClosedContextError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /Target page, context or browser has been closed/i.test(message);
+}
+
 export class CloakSessionManager {
   readonly networkCapture = new CloakNetworkCapture();
 
@@ -135,16 +140,26 @@ export class CloakSessionManager {
       if (!pageIsClosed(existing.page)) await existing.page.close().catch(() => {});
     }
 
-    const existingPages = runtime.context.pages();
-    // freshPage must never adopt a leftover tab — its whole point is a clean DOM.
-    const page = !freshPage && existingPages[0] && runtime.pages.size === 0 ? existingPages[0] : await runtime.context.newPage();
-    const pageId = nextPageId();
-    const entry: PageEntry = { page, pageId, session, surface, siteSession: input.siteSession, idleTimeout: input.idleTimeout };
-    runtime.pages.set(leaseKey, entry);
-    this.refreshIdleTimer(runtime, leaseKey, entry);
-    runtime.selectedPageId = pageId;
-    runtime.lastSeenAt = Date.now();
-    return { profileId, leaseKey, context: runtime.context, page, pageId };
+    return this.createPageWithRecovery(
+      profileId,
+      input.windowMode,
+      (candidate) => {
+        const existingPages = candidate.context.pages();
+        // freshPage must never adopt a leftover tab — its whole point is a clean DOM.
+        return !freshPage && existingPages[0] && candidate.pages.size === 0
+          ? existingPages[0]
+          : candidate.context.newPage();
+      },
+      (candidate, page) => {
+        const pageId = nextPageId();
+        const entry: PageEntry = { page, pageId, session, surface, siteSession: input.siteSession, idleTimeout: input.idleTimeout };
+        candidate.pages.set(leaseKey, entry);
+        this.refreshIdleTimer(candidate, leaseKey, entry);
+        candidate.selectedPageId = pageId;
+        candidate.lastSeenAt = Date.now();
+        return { profileId, leaseKey, context: candidate.context, page, pageId };
+      },
+    );
   }
 
   findPageById(pageId: string, opts: Pick<SessionKeyInput, 'idleTimeout'> = {}): CloakPageLease | null {
@@ -207,18 +222,34 @@ export class CloakSessionManager {
     const profileId = normalizeProfileId(input.profileId);
     const session = requireSession(input.session);
     const surface = normalizeSurface(input.surface);
-    const runtime = await this.getProfileRuntime(profileId, input.windowMode);
-    const page = await runtime.context.newPage();
+    const lease = await this.createPageWithRecovery(
+      profileId,
+      input.windowMode,
+      (candidate) => candidate.context.newPage(),
+      (candidate, page) => {
+        const pageId = nextPageId();
+        const leaseKey = `${resolveLeaseKey(input)}\u0000${pageId}`;
+        const entry: PageEntry = { page, pageId, session, surface, siteSession: input.siteSession, idleTimeout: input.idleTimeout };
+        candidate.pages.set(leaseKey, entry);
+        this.refreshIdleTimer(candidate, leaseKey, entry);
+        candidate.lastSeenAt = Date.now();
+        return { profileId, leaseKey, context: candidate.context, page, pageId };
+      },
+    );
     if (input.url) {
-      await page.goto(input.url, { waitUntil: 'load' });
+      try {
+        await lease.page.goto(input.url, { waitUntil: 'load' });
+      } catch (error) {
+        const runtime = this.profiles.get(profileId);
+        const entry = runtime?.pages.get(lease.leaseKey);
+        if (runtime && entry?.page === lease.page) {
+          runtime.pages.delete(lease.leaseKey);
+          this.clearIdleTimer(entry);
+        }
+        throw error;
+      }
     }
-    const pageId = nextPageId();
-    const leaseKey = `${resolveLeaseKey(input)}\u0000${pageId}`;
-    const entry: PageEntry = { page, pageId, session, surface, siteSession: input.siteSession, idleTimeout: input.idleTimeout };
-    runtime.pages.set(leaseKey, entry);
-    this.refreshIdleTimer(runtime, leaseKey, entry);
-    runtime.lastSeenAt = Date.now();
-    return { profileId, leaseKey, context: runtime.context, page, pageId };
+    return lease;
   }
 
   async selectPage(input: Pick<SessionKeyInput, 'profileId' | 'windowMode'> & { pageId?: string; index?: number }): Promise<CloakPageLease | null> {
@@ -350,8 +381,48 @@ export class CloakSessionManager {
       context = await launchPersistentContext(launchOptions);
     }
     const runtime = { context, pages: new Map(), lastSeenAt: Date.now() };
+    this.attachRuntimeLifecycle(profileId, runtime);
     this.profiles.set(profileId, runtime);
     return runtime;
+  }
+
+  private invalidateProfileRuntime(profileId: string, runtime: ProfileRuntime): void {
+    if (this.profiles.get(profileId) !== runtime) return;
+    this.profiles.delete(profileId);
+    for (const entry of runtime.pages.values()) {
+      if (entry.idleTimer) clearTimeout(entry.idleTimer);
+      this.networkCapture.stop(entry.page);
+    }
+    runtime.pages.clear();
+    runtime.selectedPageId = undefined;
+  }
+
+  private attachRuntimeLifecycle(profileId: string, runtime: ProfileRuntime): void {
+    runtime.context.on('close', () => this.invalidateProfileRuntime(profileId, runtime));
+  }
+
+  private async createPageWithRecovery<T>(
+    profileId: string,
+    windowMode: BrowserWindowMode | undefined,
+    createPage: (runtime: ProfileRuntime) => PlaywrightPage | Promise<PlaywrightPage>,
+    commitPage: (runtime: ProfileRuntime, page: PlaywrightPage) => T,
+    attempt = 0,
+  ): Promise<T> {
+    const runtime = await this.getProfileRuntime(profileId, windowMode);
+    let page: PlaywrightPage;
+    try {
+      page = await createPage(runtime);
+    } catch (error) {
+      if (attempt !== 0 || !isClosedContextError(error)) throw error;
+      this.invalidateProfileRuntime(profileId, runtime);
+      return this.createPageWithRecovery(profileId, windowMode, createPage, commitPage, 1);
+    }
+    if (this.profiles.get(profileId) !== runtime) {
+      if (!pageIsClosed(page)) await page.close().catch(() => {});
+      if (attempt !== 0) throw new Error('Target page, context or browser has been closed');
+      return this.createPageWithRecovery(profileId, windowMode, createPage, commitPage, 1);
+    }
+    return commitPage(runtime, page);
   }
 
   private openEntries(runtime: ProfileRuntime): [string, PageEntry][] {

--- a/src/browser/runtime/local-cloak/session-manager.ts
+++ b/src/browser/runtime/local-cloak/session-manager.ts
@@ -222,34 +222,38 @@ export class CloakSessionManager {
     const profileId = normalizeProfileId(input.profileId);
     const session = requireSession(input.session);
     const surface = normalizeSurface(input.surface);
-    const lease = await this.createPageWithRecovery(
+    const acquired = await this.createPageWithRecovery(
       profileId,
       input.windowMode,
       (candidate) => candidate.context.newPage(),
-      (candidate, page) => {
-        const pageId = nextPageId();
-        const leaseKey = `${resolveLeaseKey(input)}\u0000${pageId}`;
-        const entry: PageEntry = { page, pageId, session, surface, siteSession: input.siteSession, idleTimeout: input.idleTimeout };
-        candidate.pages.set(leaseKey, entry);
-        this.refreshIdleTimer(candidate, leaseKey, entry);
-        candidate.lastSeenAt = Date.now();
-        return { profileId, leaseKey, context: candidate.context, page, pageId };
-      },
+      (runtime, page) => ({ runtime, page }),
     );
     if (input.url) {
       try {
-        await lease.page.goto(input.url, { waitUntil: 'load' });
+        await acquired.page.goto(input.url, { waitUntil: 'load' });
       } catch (error) {
-        const runtime = this.profiles.get(profileId);
-        const entry = runtime?.pages.get(lease.leaseKey);
-        if (runtime && entry?.page === lease.page) {
-          runtime.pages.delete(lease.leaseKey);
-          this.clearIdleTimer(entry);
-        }
+        if (!pageIsClosed(acquired.page)) await acquired.page.close().catch(() => {});
         throw error;
       }
     }
-    return lease;
+    if (this.profiles.get(profileId) !== acquired.runtime) {
+      if (!pageIsClosed(acquired.page)) await acquired.page.close().catch(() => {});
+      throw new Error('Target page, context or browser has been closed');
+    }
+    const pageId = nextPageId();
+    const leaseKey = `${resolveLeaseKey(input)}\u0000${pageId}`;
+    const entry: PageEntry = {
+      page: acquired.page,
+      pageId,
+      session,
+      surface,
+      siteSession: input.siteSession,
+      idleTimeout: input.idleTimeout,
+    };
+    acquired.runtime.pages.set(leaseKey, entry);
+    this.refreshIdleTimer(acquired.runtime, leaseKey, entry);
+    acquired.runtime.lastSeenAt = Date.now();
+    return { profileId, leaseKey, context: acquired.runtime.context, page: acquired.page, pageId };
   }
 
   async selectPage(input: Pick<SessionKeyInput, 'profileId' | 'windowMode'> & { pageId?: string; index?: number }): Promise<CloakPageLease | null> {
@@ -419,8 +423,7 @@ export class CloakSessionManager {
     }
     if (this.profiles.get(profileId) !== runtime) {
       if (!pageIsClosed(page)) await page.close().catch(() => {});
-      if (attempt !== 0) throw new Error('Target page, context or browser has been closed');
-      return this.createPageWithRecovery(profileId, windowMode, createPage, commitPage, 1);
+      throw new Error('Target page, context or browser has been closed');
     }
     return commitPage(runtime, page);
   }

--- a/src/browser/runtime/provider.ts
+++ b/src/browser/runtime/provider.ts
@@ -6,6 +6,7 @@ export interface RuntimeStatusOptions {
 
 export interface BrowserRuntimeProvider {
   status(opts?: RuntimeStatusOptions): Promise<BrowserRuntimeStatus>;
+  resolveProfileId?(command: BrowserRuntimeCommand): string;
   dispatch(command: BrowserRuntimeCommand): Promise<BrowserRuntimeResult>;
   shutdown(): Promise<void>;
 }

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -44,6 +44,7 @@ describe('createDaemonServer', () => {
 
   afterEach(async () => {
     while (servers.length) await servers.pop()!.close();
+    vi.useRealTimers();
   });
 
   async function start(provider = new FakeProvider()) {
@@ -290,6 +291,79 @@ describe('createDaemonServer', () => {
     } finally {
       settle?.();
       await pending.catch(() => undefined);
+    }
+  });
+
+  it('keeps timed-out provider work pending until provider settlement', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    let settleProvider: (() => void) | undefined;
+    let providerStarted!: () => void;
+    const providerStartedPromise = new Promise<void>((resolve) => {
+      providerStarted = resolve;
+    });
+    const provider = new FakeProvider();
+    provider.dispatchImpl = (command) => {
+      if (command.id !== 'timed-out') {
+        return Promise.resolve({ id: command.id, ok: true, data: 'done' });
+      }
+      if (provider.commands.filter(({ id }) => id === command.id).length > 1) {
+        return Promise.resolve({ id: command.id, ok: true, data: 'duplicate dispatch' });
+      }
+      providerStarted();
+      return new Promise((resolve) => {
+        settleProvider = () => resolve({ id: command.id, ok: true, data: 'done' });
+      });
+    };
+    const { baseUrl } = await start(provider);
+
+    const firstRequest = postCommand(baseUrl, persistentWrite('timed-out', 'run_100_1_1', { timeout: 1 }));
+    try {
+      await providerStartedPromise;
+      await vi.advanceTimersByTimeAsync(1_000);
+      const timedOut = await firstRequest;
+      expect(timedOut.status).toBe(408);
+      await expect(timedOut.json()).resolves.toMatchObject({
+        id: 'timed-out',
+        ok: false,
+        errorCode: 'command_result_unknown',
+      });
+
+      await vi.advanceTimersByTimeAsync(45_001);
+      const duplicateRequest = postCommand(
+        baseUrl,
+        persistentWrite('timed-out', 'run_100_1_1', { timeout: 120 }),
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      const whileProviderPending = await fetch(`${baseUrl}/status`, { headers: { [DAEMON_HEADER_NAME]: '1' } });
+      await expect(whileProviderPending.json()).resolves.toMatchObject({
+        pending: 1,
+        sessionLeases: [{ command: 'example write', heartbeatAt: 1_000 }],
+      });
+      expect(provider.commands.map((command) => command.id)).toEqual(['timed-out']);
+
+      const conflict = await postCommand(baseUrl, persistentWrite('conflict', 'run_200_2_2'));
+      expect(conflict.status).toBe(409);
+      expect(provider.commands.map((command) => command.id)).toEqual(['timed-out']);
+
+      settleProvider?.();
+      await vi.advanceTimersByTimeAsync(0);
+      const duplicate = await duplicateRequest;
+      expect(duplicate.status).toBe(200);
+      await expect(duplicate.json()).resolves.toMatchObject({ data: 'done' });
+      const afterProviderSettle = await fetch(`${baseUrl}/status`, { headers: { [DAEMON_HEADER_NAME]: '1' } });
+      await expect(afterProviderSettle.json()).resolves.toMatchObject({
+        pending: 0,
+        sessionLeases: [{ command: 'example write', heartbeatAt: 47_001 }],
+      });
+
+      await vi.advanceTimersByTimeAsync(45_001);
+      const reclaimed = await postCommand(baseUrl, persistentWrite('reclaimed', 'run_200_2_2'));
+      expect(reclaimed.status).toBe(200);
+      expect(provider.commands.map((command) => command.id)).toEqual(['timed-out', 'reclaimed']);
+    } finally {
+      settleProvider?.();
+      await firstRequest.catch(() => undefined);
     }
   });
 

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -295,8 +295,8 @@ describe('createDaemonServer', () => {
   });
 
   it('keeps timed-out provider work pending until provider settlement', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(1_000);
+    let now = 1_000;
+    const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => now);
     let settleProvider: (() => void) | undefined;
     let providerStarted!: () => void;
     const providerStartedPromise = new Promise<void>((resolve) => {
@@ -317,10 +317,9 @@ describe('createDaemonServer', () => {
     };
     const { baseUrl } = await start(provider);
 
-    const firstRequest = postCommand(baseUrl, persistentWrite('timed-out', 'run_100_1_1', { timeout: 1 }));
+    const firstRequest = postCommand(baseUrl, persistentWrite('timed-out', 'run_100_1_1', { timeout: 0.01 }));
     try {
       await providerStartedPromise;
-      await vi.advanceTimersByTimeAsync(1_000);
       const timedOut = await firstRequest;
       expect(timedOut.status).toBe(408);
       await expect(timedOut.json()).resolves.toMatchObject({
@@ -329,12 +328,11 @@ describe('createDaemonServer', () => {
         errorCode: 'command_result_unknown',
       });
 
-      await vi.advanceTimersByTimeAsync(45_001);
+      now = 47_001;
       const duplicateRequest = postCommand(
         baseUrl,
         persistentWrite('timed-out', 'run_100_1_1', { timeout: 120 }),
       );
-      await vi.advanceTimersByTimeAsync(0);
       const whileProviderPending = await fetch(`${baseUrl}/status`, { headers: { [DAEMON_HEADER_NAME]: '1' } });
       await expect(whileProviderPending.json()).resolves.toMatchObject({
         pending: 1,
@@ -347,7 +345,6 @@ describe('createDaemonServer', () => {
       expect(provider.commands.map((command) => command.id)).toEqual(['timed-out']);
 
       settleProvider?.();
-      await vi.advanceTimersByTimeAsync(0);
       const duplicate = await duplicateRequest;
       expect(duplicate.status).toBe(200);
       await expect(duplicate.json()).resolves.toMatchObject({ data: 'done' });
@@ -357,13 +354,14 @@ describe('createDaemonServer', () => {
         sessionLeases: [{ command: 'example write', heartbeatAt: 47_001 }],
       });
 
-      await vi.advanceTimersByTimeAsync(45_001);
+      now = 92_002;
       const reclaimed = await postCommand(baseUrl, persistentWrite('reclaimed', 'run_200_2_2'));
       expect(reclaimed.status).toBe(200);
       expect(provider.commands.map((command) => command.id)).toEqual(['timed-out', 'reclaimed']);
     } finally {
       settleProvider?.();
       await firstRequest.catch(() => undefined);
+      dateNow.mockRestore();
     }
   });
 

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -1,7 +1,7 @@
 import { AddressInfo } from 'node:net';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DAEMON_HEADER_NAME } from '../constants.js';
-import type { BrowserRuntimeCommand, BrowserRuntimeStatus } from '../browser/protocol.js';
+import type { BrowserRuntimeCommand, BrowserRuntimeResult, BrowserRuntimeStatus } from '../browser/protocol.js';
 import type { BrowserRuntimeProvider } from '../browser/runtime/provider.js';
 import { createDaemonServer } from './server.js';
 
@@ -9,6 +9,12 @@ class FakeProvider implements BrowserRuntimeProvider {
   commands: BrowserRuntimeCommand[] = [];
   shutdownCalled = false;
   delayMs = 0;
+  dispatchImpl?: (command: BrowserRuntimeCommand) => Promise<BrowserRuntimeResult>;
+  resolveProfileId?: (command: BrowserRuntimeCommand) => string;
+
+  private result(command: BrowserRuntimeCommand) {
+    return { id: command.id, ok: true as const, data: { action: command.action }, page: 'page-1' };
+  }
 
   async status(): Promise<BrowserRuntimeStatus> {
     return {
@@ -22,9 +28,10 @@ class FakeProvider implements BrowserRuntimeProvider {
   }
 
   async dispatch(command: BrowserRuntimeCommand) {
-    if (this.delayMs > 0) await new Promise((resolve) => setTimeout(resolve, this.delayMs));
     this.commands.push(command);
-    return { id: command.id, ok: true, data: { action: command.action }, page: 'page-1' };
+    if (this.dispatchImpl) return this.dispatchImpl(command);
+    if (this.delayMs > 0) await new Promise((resolve) => setTimeout(resolve, this.delayMs));
+    return this.result(command);
   }
 
   async shutdown() {
@@ -45,6 +52,34 @@ describe('createDaemonServer', () => {
     servers.push(daemon);
     const address = daemon.server.address() as AddressInfo;
     return { provider, baseUrl: `http://127.0.0.1:${address.port}` };
+  }
+
+  function postCommand(baseUrl: string, body: Partial<BrowserRuntimeCommand> & Pick<BrowserRuntimeCommand, 'id' | 'action'>) {
+    return fetch(`${baseUrl}/command`, {
+      method: 'POST',
+      headers: { [DAEMON_HEADER_NAME]: '1', 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  function persistentWrite(
+    id: string,
+    runId: string,
+    overrides: Partial<BrowserRuntimeCommand> = {},
+  ): BrowserRuntimeCommand {
+    return {
+      id,
+      action: 'exec',
+      code: '1',
+      surface: 'adapter',
+      siteSession: 'persistent',
+      access: 'write',
+      session: 'site:example',
+      runId,
+      command: 'example write',
+      pid: 4242,
+      ...overrides,
+    };
   }
 
   it('returns runtime-named status fields without extension aliases', async () => {
@@ -160,6 +195,139 @@ describe('createDaemonServer', () => {
     await expect(first.json()).resolves.toMatchObject({ id: 'same-id', ok: true });
     await expect(second.json()).resolves.toMatchObject({ id: 'same-id', ok: true });
     expect(provider.commands).toHaveLength(1);
+  });
+
+  it('rejects a second persistent adapter writer for the same resolved profile and session', async () => {
+    const provider = new FakeProvider();
+    provider.resolveProfileId = () => 'resolved-work';
+    const { baseUrl } = await start(provider);
+
+    const first = await postCommand(baseUrl, persistentWrite('first', 'run_100_1_1'));
+    expect(first.status).toBe(200);
+
+    const second = await postCommand(baseUrl, persistentWrite('second', 'run_200_2_2'));
+    expect(second.status).toBe(409);
+    await expect(second.json()).resolves.toMatchObject({
+      ok: false,
+      code: 'session_busy',
+      holder: {
+        command: 'example write',
+        pid: 4242,
+        acquiredAt: expect.any(Number),
+        heartbeatAt: expect.any(Number),
+      },
+    });
+    expect(provider.commands.map((command) => command.id)).toEqual(['first']);
+  });
+
+  it('lets one logical run issue multiple operations and heartbeat its lease', async () => {
+    let now = 1_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const { provider, baseUrl } = await start();
+
+    expect((await postCommand(baseUrl, persistentWrite('first', 'run_100_1_1'))).status).toBe(200);
+    now = 20_000;
+    expect((await postCommand(baseUrl, persistentWrite('second', 'run_100_1_1'))).status).toBe(200);
+
+    const status = await fetch(`${baseUrl}/status`, { headers: { [DAEMON_HEADER_NAME]: '1' } });
+    await expect(status.json()).resolves.toMatchObject({
+      sessionLeases: [{
+        key: 'default␟adapter␟site%3Aexample',
+        command: 'example write',
+        acquiredAt: 1_000,
+        heartbeatAt: 20_000,
+      }],
+    });
+    expect(provider.commands.map((command) => command.id)).toEqual(['first', 'second']);
+  });
+
+  it.each([
+    ['read access', { access: 'read' as const }],
+    ['ephemeral sessions', { siteSession: 'ephemeral' as const }],
+    ['raw browser surface', { surface: 'browser' as const }],
+    ['different sites', { session: 'site:other' }],
+    ['different resolved profiles', { profileId: 'other' }],
+  ])('does not conflict across %s', async (_case, overrides) => {
+    const provider = new FakeProvider();
+    provider.resolveProfileId = (command) => command.profileId ?? 'default';
+    const { baseUrl } = await start(provider);
+
+    expect((await postCommand(baseUrl, persistentWrite('owner', 'run_100_1_1'))).status).toBe(200);
+    expect((await postCommand(baseUrl, persistentWrite('other', 'run_200_2_2', overrides))).status).toBe(200);
+    expect(provider.commands.map((command) => command.id)).toEqual(['owner', 'other']);
+  });
+
+  it('keeps pending holders live past the TTL and heartbeats them before pending removal', async () => {
+    let now = 1_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    let settle: (() => void) | undefined;
+    const provider = new FakeProvider();
+    provider.dispatchImpl = (command) => new Promise((resolve) => {
+      settle = () => resolve({ id: command.id, ok: true, data: 'done' });
+    });
+    const { baseUrl } = await start(provider);
+
+    const pending = postCommand(baseUrl, persistentWrite('pending', 'run_100_1_1'));
+    try {
+      await vi.waitFor(() => expect(provider.commands).toHaveLength(1));
+      now = 46_001;
+
+      const whilePending = await fetch(`${baseUrl}/status`, { headers: { [DAEMON_HEADER_NAME]: '1' } });
+      await expect(whilePending.json()).resolves.toMatchObject({
+        sessionLeases: [{ command: 'example write', heartbeatAt: 1_000 }],
+      });
+      const conflict = await postCommand(baseUrl, persistentWrite('conflict', 'run_200_2_2'));
+      expect(conflict.status).toBe(409);
+      expect(provider.commands).toHaveLength(1);
+
+      now = 50_000;
+      settle?.();
+      expect((await pending).status).toBe(200);
+      const afterSettle = await fetch(`${baseUrl}/status`, { headers: { [DAEMON_HEADER_NAME]: '1' } });
+      const statusBody = await afterSettle.json() as { sessionLeases: Array<Record<string, unknown>> };
+      expect(statusBody.sessionLeases).toEqual([expect.objectContaining({ heartbeatAt: 50_000 })]);
+      expect(statusBody.sessionLeases[0]).not.toHaveProperty('runId');
+    } finally {
+      settle?.();
+      await pending.catch(() => undefined);
+    }
+  });
+
+  it('handles lease-release locally and permits a new owner', async () => {
+    const { provider, baseUrl } = await start();
+    expect((await postCommand(baseUrl, persistentWrite('owner', 'run_100_1_1'))).status).toBe(200);
+
+    const released = await postCommand(baseUrl, {
+      id: 'release',
+      action: 'lease-release',
+      runId: 'run_100_1_1',
+    });
+    expect(released.status).toBe(200);
+    await expect(released.json()).resolves.toMatchObject({
+      id: 'release',
+      ok: true,
+      data: { released: 1 },
+    });
+    expect(provider.commands.map((command) => command.id)).toEqual(['owner']);
+
+    expect((await postCommand(baseUrl, persistentWrite('next-owner', 'run_200_2_2'))).status).toBe(200);
+    expect(provider.commands.map((command) => command.id)).toEqual(['owner', 'next-owner']);
+  });
+
+  it('returns only sanitized current holders from status', async () => {
+    let now = 1_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const { baseUrl } = await start();
+    expect((await postCommand(baseUrl, persistentWrite('owner', 'run_100_1_1'))).status).toBe(200);
+
+    const current = await fetch(`${baseUrl}/status`, { headers: { [DAEMON_HEADER_NAME]: '1' } });
+    const currentBody = await current.json() as { sessionLeases: Array<Record<string, unknown>> };
+    expect(currentBody.sessionLeases).toHaveLength(1);
+    expect(currentBody.sessionLeases[0]).not.toHaveProperty('runId');
+
+    now = 46_001;
+    const expired = await fetch(`${baseUrl}/status`, { headers: { [DAEMON_HEADER_NAME]: '1' } });
+    await expect(expired.json()).resolves.toMatchObject({ sessionLeases: [] });
   });
 
   it('requires X-Webcmd on non-ping endpoints', async () => {

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -26,6 +26,38 @@ interface PendingCommand {
   leaseKey?: string;
 }
 
+function commandTimeoutMs(command: BrowserRuntimeCommand): number {
+  return typeof command.deadlineAt === 'number' && command.deadlineAt > 0
+    ? Math.max(1000, command.deadlineAt - Date.now())
+    : (typeof command.timeout === 'number' && command.timeout > 0 ? command.timeout * 1000 : 120_000);
+}
+
+function waitForCommandResult(
+  command: BrowserRuntimeCommand,
+  providerPromise: Promise<BrowserRuntimeResult>,
+): Promise<BrowserRuntimeResult> {
+  const timeoutMs = commandTimeoutMs(command);
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const responsePromise = Promise.race([
+    providerPromise,
+    new Promise<BrowserRuntimeResult>((resolve) => {
+      timeoutId = setTimeout(() => {
+        const failure = buildCommandTimeoutFailure(command.action, timeoutMs);
+        resolve({
+          id: command.id,
+          ok: false,
+          errorCode: failure.errorCode,
+          error: failure.message,
+          errorHint: failure.errorHint,
+        });
+      }, timeoutMs);
+    }),
+  ]);
+  return responsePromise.finally(() => {
+    if (timeoutId) clearTimeout(timeoutId);
+  });
+}
+
 function readBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
@@ -157,7 +189,7 @@ export function createDaemonServer(provider: BrowserRuntimeProvider, opts: Daemo
         }
         const existing = pending.get(body.id);
         if (existing) {
-          const result = await existing.promise;
+          const result = await waitForCommandResult(body, existing.promise);
           jsonResponse(res, result.ok ? 200 : result.errorCode === 'command_result_unknown' ? 408 : 400, result);
           return;
         }
@@ -188,31 +220,12 @@ export function createDaemonServer(provider: BrowserRuntimeProvider, opts: Daemo
             return;
           }
         }
-        const timeoutMs = typeof body.deadlineAt === 'number' && body.deadlineAt > 0
-          ? Math.max(1000, body.deadlineAt - Date.now())
-          : (typeof body.timeout === 'number' && body.timeout > 0 ? body.timeout * 1000 : 120_000);
-        let timeoutId: ReturnType<typeof setTimeout> | undefined;
-        const commandPromise: Promise<BrowserRuntimeResult> = Promise.race([
-          provider.dispatch(body),
-          new Promise<BrowserRuntimeResult>((resolve) => {
-            timeoutId = setTimeout(() => {
-              const failure = buildCommandTimeoutFailure(body.action, timeoutMs);
-              resolve({
-                id: body.id,
-                ok: false,
-                errorCode: failure.errorCode,
-                error: failure.message,
-                errorHint: failure.errorHint,
-              });
-            }, timeoutMs);
-          }),
-        ]).finally(() => {
-          if (timeoutId) clearTimeout(timeoutId);
+        const commandPromise = provider.dispatch(body).finally(() => {
           if (leaseKey && runId) leases.heartbeat(leaseKey, runId);
           pending.delete(body.id);
         });
         pending.set(body.id, { promise: commandPromise, runId, leaseKey });
-        const result = await commandPromise;
+        const result = await waitForCommandResult(body, commandPromise);
         if (!result.ok) pushLog('warn', `Command ${body.id} failed: ${result.error ?? result.errorCode ?? 'unknown error'}`);
         jsonResponse(res, result.ok ? 200 : result.errorCode === 'command_result_unknown' ? 408 : 400, result);
       } catch (err) {

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -3,6 +3,7 @@ import { DAEMON_HEADER_NAME, DEFAULT_DAEMON_PORT } from '../constants.js';
 import type { BrowserRuntimeCommand, BrowserRuntimeResult } from '../browser/protocol.js';
 import type { BrowserRuntimeProvider } from '../browser/runtime/provider.js';
 import { buildCommandTimeoutFailure, getResponseCorsHeaders } from '../daemon-utils.js';
+import { getSessionLeaseKey, isSessionLeaseCommand, SessionLeaseRegistry } from '../session-lease.js';
 
 const MAX_BODY = 1024 * 1024;
 const LOG_BUFFER_SIZE = 200;
@@ -17,6 +18,12 @@ export interface DaemonServerHandle {
   server: Server;
   listen(): Promise<void>;
   close(): Promise<void>;
+}
+
+interface PendingCommand {
+  promise: Promise<BrowserRuntimeResult>;
+  runId?: string;
+  leaseKey?: string;
 }
 
 function readBody(req: IncomingMessage): Promise<string> {
@@ -57,7 +64,9 @@ export function createDaemonServer(provider: BrowserRuntimeProvider, opts: Daemo
   const port = opts.port ?? DEFAULT_DAEMON_PORT;
   const host = opts.host ?? '127.0.0.1';
   const logBuffer: Array<{ level: string; msg: string; ts: number }> = [];
-  const pending = new Map<string, Promise<BrowserRuntimeResult>>();
+  const pending = new Map<string, PendingCommand>();
+  const leases = new SessionLeaseRegistry();
+  const hasPendingWork = (runId: string) => [...pending.values()].some((entry) => entry.runId === runId);
   let shutdownStarted = false;
 
   function pushLog(level: string, msg: string): void {
@@ -108,6 +117,7 @@ export function createDaemonServer(provider: BrowserRuntimeProvider, opts: Daemo
         daemonVersion: opts.version,
         ...runtime,
         pending: pending.size + runtime.pending,
+        sessionLeases: leases.list(hasPendingWork).map(({ runId: _runId, ...lease }) => lease),
         memoryMB: Math.round(mem.rss / 1024 / 1024 * 10) / 10,
         port,
       });
@@ -147,9 +157,36 @@ export function createDaemonServer(provider: BrowserRuntimeProvider, opts: Daemo
         }
         const existing = pending.get(body.id);
         if (existing) {
-          const result = await existing;
+          const result = await existing.promise;
           jsonResponse(res, result.ok ? 200 : result.errorCode === 'command_result_unknown' ? 408 : 400, result);
           return;
+        }
+        if (body.action === 'lease-release') {
+          const released = typeof body.runId === 'string' ? leases.releaseByRunId(body.runId) : 0;
+          jsonResponse(res, 200, { id: body.id, ok: true, data: { released } });
+          return;
+        }
+        let leaseKey: string | undefined;
+        let runId: string | undefined;
+        if (isSessionLeaseCommand(body)) {
+          const profileId = provider.resolveProfileId?.(body)
+            ?? body.profileId
+            ?? body.contextId
+            ?? body.preferredContextId
+            ?? 'default';
+          leaseKey = getSessionLeaseKey(profileId, body.surface, body.session);
+          runId = body.runId;
+          const acquired = leases.acquire({
+            key: leaseKey,
+            runId,
+            command: body.command ?? body.action,
+            pid: body.pid,
+          }, hasPendingWork);
+          if (!acquired.acquired) {
+            const { key: _key, runId: _runId, ...holder } = acquired.holder;
+            jsonResponse(res, 409, { ok: false, code: 'session_busy', holder });
+            return;
+          }
         }
         const timeoutMs = typeof body.deadlineAt === 'number' && body.deadlineAt > 0
           ? Math.max(1000, body.deadlineAt - Date.now())
@@ -171,9 +208,10 @@ export function createDaemonServer(provider: BrowserRuntimeProvider, opts: Daemo
           }),
         ]).finally(() => {
           if (timeoutId) clearTimeout(timeoutId);
+          if (leaseKey && runId) leases.heartbeat(leaseKey, runId);
           pending.delete(body.id);
         });
-        pending.set(body.id, commandPromise);
+        pending.set(body.id, { promise: commandPromise, runId, leaseKey });
         const result = await commandPromise;
         if (!result.ok) pushLog('warn', `Command ${body.id} failed: ${result.error ?? result.errorCode ?? 'unknown error'}`);
         jsonResponse(res, result.ok ? 200 : result.errorCode === 'command_result_unknown' ? 408 : 400, result);

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -10,9 +10,11 @@ import {
   ArgumentError,
   EmptyResultError,
   selectorError,
+  SessionBusyError,
   attachTraceReceipt,
   toEnvelope,
 } from './errors.js';
+import type { SessionLeaseHolder } from './session-lease.js';
 
 describe('Error type hierarchy', () => {
   it('all error types extend CliError', () => {
@@ -95,6 +97,25 @@ describe('toEnvelope', () => {
     });
   });
 
+  it('serializes SessionBusyError with the public code and temporary-failure exit code', () => {
+    const err = new SessionBusyError({
+      command: 'chatgpt ask',
+      pid: 4242,
+      acquiredAt: 1_000,
+      heartbeatAt: 2_000,
+    });
+
+    expect(toEnvelope(err)).toEqual({
+      ok: false,
+      error: {
+        code: 'SESSION_BUSY',
+        message: expect.stringContaining('chatgpt ask'),
+        help: expect.any(String),
+        exitCode: 75,
+      },
+    });
+  });
+
   it('converts CliError without hint (omits help field)', () => {
     const err = new CommandExecutionError('Something broke');
     const envelope = toEnvelope(err);
@@ -147,5 +168,33 @@ describe('toEnvelope', () => {
       executionId: 'exec_failure',
       artifactsUrl: '/v1/executions/exec_failure/artifacts',
     });
+  });
+});
+
+describe('SessionBusyError platform hints', () => {
+  const holder: SessionLeaseHolder = {
+    command: 'chatgpt ask',
+    pid: 4242,
+    acquiredAt: 1_000,
+    heartbeatAt: 2_000,
+  };
+
+  it('uses PowerShell process guidance on Windows when the holder pid is known', () => {
+    const err = new SessionBusyError(holder, 'win32');
+    expect(err.hint).toContain('Stop-Process -Id 4242');
+    expect(err.hint).not.toContain('kill 4242');
+  });
+
+  it('uses Task Manager guidance on Windows when the holder pid is unavailable', () => {
+    const err = new SessionBusyError({ ...holder, pid: undefined }, 'win32');
+    expect(err.hint).toMatch(/wait/i);
+    expect(err.hint).toContain('Task Manager');
+    expect(err.hint).not.toContain('Stop-Process');
+  });
+
+  it('uses kill guidance on POSIX when the holder pid is known', () => {
+    const err = new SessionBusyError(holder, 'linux');
+    expect(err.hint).toContain('kill 4242');
+    expect(err.hint).not.toContain('Stop-Process');
   });
 });

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -197,4 +197,22 @@ describe('SessionBusyError platform hints', () => {
     expect(err.hint).toContain('kill 4242');
     expect(err.hint).not.toContain('Stop-Process');
   });
+
+  it.each([
+    0,
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.MAX_SAFE_INTEGER + 1,
+  ])('does not expose non-actionable pid %s in process guidance', (pid) => {
+    const windowsError = new SessionBusyError({ ...holder, pid }, 'win32');
+    expect(windowsError.message).not.toContain(`pid ${pid}`);
+    expect(windowsError.hint).toContain('Task Manager');
+    expect(windowsError.hint).not.toContain('Stop-Process');
+
+    const posixError = new SessionBusyError({ ...holder, pid }, 'linux');
+    expect(posixError.message).not.toContain(`pid ${pid}`);
+    expect(posixError.hint).not.toContain('kill');
+  });
 });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -20,6 +20,7 @@
  * 130   Interrupted by Ctrl-C           (set by tui.ts SIGINT handler)
  */
 import type { ObservationTraceReceipt } from './observation/events.js';
+import type { SessionLeaseHolder } from './session-lease.js';
 
 // ── Exit code table ──────────────────────────────────────────────────────────
 
@@ -138,6 +139,36 @@ export class TimeoutError extends CliError {
 export class ArgumentError extends CliError {
   constructor(message: string, hint?: string) {
     super('ARGUMENT', message, hint, EXIT_CODES.USAGE_ERROR);
+  }
+}
+
+function formatBusyMessage(holder: SessionLeaseHolder): string {
+  const owner = holder.pid === undefined
+    ? holder.command
+    : `${holder.command} (pid ${holder.pid})`;
+  return `Session is busy: ${owner} is already driving it.`;
+}
+
+function formatBusyHint(holder: SessionLeaseHolder, platform: string): string {
+  if (platform === 'win32') {
+    return holder.pid === undefined
+      ? 'Wait for it to finish, or use Task Manager to stop the owning process if it is stuck.'
+      : `Wait for it to finish, or run \`Stop-Process -Id ${holder.pid}\` in PowerShell if it is stuck.`;
+  }
+  return holder.pid === undefined
+    ? 'Wait for it to finish, or stop the owning process if it is stuck.'
+    : `Wait for it to finish, or run \`kill ${holder.pid}\` if it is stuck.`;
+}
+
+/** A persistent write session is temporarily owned by another logical run. */
+export class SessionBusyError extends CliError {
+  constructor(holder: SessionLeaseHolder, platform: string = process.platform) {
+    super(
+      'SESSION_BUSY',
+      formatBusyMessage(holder),
+      formatBusyHint(holder, platform),
+      EXIT_CODES.TEMPFAIL,
+    );
   }
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -20,7 +20,7 @@
  * 130   Interrupted by Ctrl-C           (set by tui.ts SIGINT handler)
  */
 import type { ObservationTraceReceipt } from './observation/events.js';
-import type { SessionLeaseHolder } from './session-lease.js';
+import { isActionablePid, type SessionLeaseHolder } from './session-lease.js';
 
 // ── Exit code table ──────────────────────────────────────────────────────────
 
@@ -143,7 +143,7 @@ export class ArgumentError extends CliError {
 }
 
 function formatBusyMessage(holder: SessionLeaseHolder): string {
-  const owner = holder.pid === undefined
+  const owner = !isActionablePid(holder.pid)
     ? holder.command
     : `${holder.command} (pid ${holder.pid})`;
   return `Session is busy: ${owner} is already driving it.`;
@@ -151,11 +151,11 @@ function formatBusyMessage(holder: SessionLeaseHolder): string {
 
 function formatBusyHint(holder: SessionLeaseHolder, platform: string): string {
   if (platform === 'win32') {
-    return holder.pid === undefined
+    return !isActionablePid(holder.pid)
       ? 'Wait for it to finish, or use Task Manager to stop the owning process if it is stuck.'
       : `Wait for it to finish, or run \`Stop-Process -Id ${holder.pid}\` in PowerShell if it is stuck.`;
   }
-  return holder.pid === undefined
+  return !isActionablePid(holder.pid)
     ? 'Wait for it to finish, or stop the owning process if it is stuck.'
     : `Wait for it to finish, or run \`kill ${holder.pid}\` if it is stuck.`;
 }

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -397,7 +397,7 @@ describe('executeCommand — non-browser timeout', () => {
       expect(mockReleaseSiteSessionLease).not.toHaveBeenCalled();
     });
 
-    it('keeps the run bound after timeout until the underlying adapter settles', async () => {
+    it('releases after a wrapper timeout when the adapter later succeeds', async () => {
       const adapter = deferred<void>();
       let runId: string | undefined;
       let settledRunId: string | undefined;
@@ -433,6 +433,78 @@ describe('executeCommand — non-browser timeout', () => {
       adapter.resolve();
       await vi.waitFor(() => expect(adapterSettled).toBe(true));
       expect(settledRunId).toBe(runId);
+      expect(getDaemonRunContext()).toBeUndefined();
+      await vi.waitFor(() => expect(mockReleaseSiteSessionLease).toHaveBeenCalledOnce());
+      expect(mockReleaseSiteSessionLease).toHaveBeenCalledWith(runId);
+    });
+
+    it('releases after a wrapper timeout when the adapter later fails ordinarily', async () => {
+      const adapter = deferred<void>();
+      let runId: string | undefined;
+      const mockPage = { closeWindow: vi.fn().mockResolvedValue(undefined) } as any;
+      vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+      vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+      vi.spyOn(runtime, 'runWithTimeout').mockRejectedValueOnce(new TimeoutError('logical run', 1));
+
+      const cmd = cli({
+        site: 'test-execution',
+        name: 'run-timeout-late-ordinary-failure',
+        access: 'write',
+        description: 'test late ordinary failure releases run ownership',
+        browser: true,
+        strategy: Strategy.PUBLIC,
+        siteSession: 'persistent',
+        func: async () => {
+          runId = getDaemonRunContext()?.runId;
+          await adapter.promise;
+        },
+      });
+
+      await expect(executeCommand(cmd, {})).rejects.toBeInstanceOf(TimeoutError);
+      expect(runId).toMatch(/^run_/);
+      expect(mockReleaseSiteSessionLease).not.toHaveBeenCalled();
+
+      adapter.reject(new Error('late ordinary failure'));
+      await vi.waitFor(() => expect(mockReleaseSiteSessionLease).toHaveBeenCalledOnce());
+      expect(mockReleaseSiteSessionLease).toHaveBeenCalledWith(runId);
+      expect(getDaemonRunContext()).toBeUndefined();
+    });
+
+    it('retains ownership for TTL after a wrapper timeout when the adapter later has an unknown outcome', async () => {
+      const adapter = deferred<void>();
+      let runId: string | undefined;
+      let adapterSettled = false;
+      const mockPage = { closeWindow: vi.fn().mockResolvedValue(undefined) } as any;
+      vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+      vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+      vi.spyOn(runtime, 'runWithTimeout').mockRejectedValueOnce(new TimeoutError('logical run', 1));
+
+      const cmd = cli({
+        site: 'test-execution',
+        name: 'run-timeout-late-unknown-failure',
+        access: 'write',
+        description: 'test late unknown failure retains ownership for TTL',
+        browser: true,
+        strategy: Strategy.PUBLIC,
+        siteSession: 'persistent',
+        func: async () => {
+          runId = getDaemonRunContext()?.runId;
+          try {
+            await adapter.promise;
+          } finally {
+            adapterSettled = true;
+          }
+        },
+      });
+
+      await expect(executeCommand(cmd, {})).rejects.toBeInstanceOf(TimeoutError);
+      expect(runId).toMatch(/^run_/);
+      expect(mockReleaseSiteSessionLease).not.toHaveBeenCalled();
+
+      const unknownOutcome = new Error('late result unknown') as Error & { cause?: unknown };
+      unknownOutcome.cause = { code: 'COMMAND_RESULT_UNKNOWN' };
+      adapter.reject(unknownOutcome);
+      await vi.waitFor(() => expect(adapterSettled).toBe(true));
       expect(getDaemonRunContext()).toBeUndefined();
       expect(mockReleaseSiteSessionLease).not.toHaveBeenCalled();
     });
@@ -517,7 +589,8 @@ describe('executeCommand — non-browser timeout', () => {
       secondAdapter.resolve();
       await expect(secondExecution).resolves.toBeUndefined();
       expect(getDaemonRunContext()).toBeUndefined();
-      expect(mockReleaseSiteSessionLease).toHaveBeenCalledOnce();
+      expect(mockReleaseSiteSessionLease).toHaveBeenCalledTimes(2);
+      expect(mockReleaseSiteSessionLease).toHaveBeenCalledWith(firstRunId);
       expect(mockReleaseSiteSessionLease).toHaveBeenCalledWith(secondRunId);
     });
 

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -25,6 +25,7 @@ import { withTimeoutMs } from './runtime.js';
 import * as runtime from './runtime.js';
 import * as capRouting from './capabilityRouting.js';
 import { clearDaemonRunContext, getDaemonRunContext } from './session-lease.js';
+import { sendCommand } from './browser/daemon-client.js';
 
 function deferred<T = void>(): {
   promise: Promise<T>;
@@ -203,6 +204,7 @@ describe('executeCommand — non-browser timeout', () => {
       if (activeRun) clearDaemonRunContext(activeRun.runId);
       mockReleaseSiteSessionLease.mockReset().mockResolvedValue(undefined);
       vi.restoreAllMocks();
+      vi.unstubAllGlobals();
     });
 
     it('binds a run only for browser-backed persistent writes', async () => {
@@ -398,6 +400,8 @@ describe('executeCommand — non-browser timeout', () => {
     it('keeps the run bound after timeout until the underlying adapter settles', async () => {
       const adapter = deferred<void>();
       let runId: string | undefined;
+      let settledRunId: string | undefined;
+      let adapterSettled = false;
       const mockPage = { closeWindow: vi.fn().mockResolvedValue(undefined) } as any;
       vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
       vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
@@ -411,21 +415,55 @@ describe('executeCommand — non-browser timeout', () => {
         browser: true,
         strategy: Strategy.PUBLIC,
         siteSession: 'persistent',
-        func: () => {
+        func: async () => {
           runId = getDaemonRunContext()?.runId;
-          return adapter.promise;
+          await adapter.promise;
+          settledRunId = getDaemonRunContext()?.runId;
+          adapterSettled = true;
         },
       });
 
       await expect(executeCommand(cmd, {})).rejects.toBeInstanceOf(TimeoutError);
 
       expect(runId).toMatch(/^run_/);
-      expect(getDaemonRunContext()?.runId).toBe(runId);
+      expect(adapterSettled).toBe(false);
+      expect(getDaemonRunContext()).toBeUndefined();
       expect(mockReleaseSiteSessionLease).not.toHaveBeenCalled();
 
       adapter.resolve();
-      await vi.waitFor(() => expect(getDaemonRunContext()).toBeUndefined());
+      await vi.waitFor(() => expect(adapterSettled).toBe(true));
+      expect(settledRunId).toBe(runId);
+      expect(getDaemonRunContext()).toBeUndefined();
       expect(mockReleaseSiteSessionLease).not.toHaveBeenCalled();
+    });
+
+    it('releases normally when the adapter itself rejects with TimeoutError', async () => {
+      let runId: string | undefined;
+      const adapterTimeout = new TimeoutError('adapter operation', 1);
+      const mockPage = { closeWindow: vi.fn().mockResolvedValue(undefined) } as any;
+      vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+      vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+
+      const cmd = cli({
+        site: 'test-execution',
+        name: 'run-adapter-timeout',
+        access: 'write',
+        description: 'test a settled adapter timeout releases normally',
+        browser: true,
+        strategy: Strategy.PUBLIC,
+        siteSession: 'persistent',
+        func: async () => {
+          runId = getDaemonRunContext()?.runId;
+          throw adapterTimeout;
+        },
+      });
+
+      await expect(executeCommand(cmd, {})).rejects.toBe(adapterTimeout);
+
+      expect(runId).toMatch(/^run_/);
+      expect(getDaemonRunContext()).toBeUndefined();
+      expect(mockReleaseSiteSessionLease).toHaveBeenCalledOnce();
+      expect(mockReleaseSiteSessionLease).toHaveBeenCalledWith(runId);
     });
 
     it('does not let deferred timeout cleanup clear a later run', async () => {
@@ -474,13 +512,82 @@ describe('executeCommand — non-browser timeout', () => {
 
       firstAdapter.resolve();
       await firstAdapter.promise;
-      await vi.waitFor(() => expect(getDaemonRunContext()?.runId).toBe(secondRunId));
+      await vi.waitFor(() => expect(getDaemonRunContext()).toBeUndefined());
 
       secondAdapter.resolve();
       await expect(secondExecution).resolves.toBeUndefined();
       expect(getDaemonRunContext()).toBeUndefined();
       expect(mockReleaseSiteSessionLease).toHaveBeenCalledOnce();
       expect(mockReleaseSiteSessionLease).toHaveBeenCalledWith(secondRunId);
+    });
+
+    it('keeps daemon metadata scoped to overlapping timed-out and active runs', async () => {
+      const resumeFirst = deferred<void>();
+      const firstFinished = deferred<void>();
+      const finishSecond = deferred<void>();
+      const secondStarted = deferred<void>();
+      let firstRunId: string | undefined;
+      let secondRunId: string | undefined;
+      const mockPage = { closeWindow: vi.fn().mockResolvedValue(undefined) } as any;
+      vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+      vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+      vi.spyOn(runtime, 'runWithTimeout')
+        .mockRejectedValueOnce(new TimeoutError('first logical run', 1))
+        .mockImplementationOnce(async promise => promise);
+      vi.stubGlobal('fetch', vi.fn().mockImplementation(async (_input: unknown, init?: RequestInit) => {
+        const request = JSON.parse(String(init?.body)) as { id: string };
+        return {
+          status: 200,
+          json: async () => ({ id: request.id, ok: true, data: 'ok' }),
+        } as Response;
+      }));
+
+      const firstCommand = cli({
+        site: 'test-execution',
+        name: 'run-overlap-first',
+        access: 'write',
+        description: 'test timed-out run keeps its daemon metadata',
+        browser: true,
+        strategy: Strategy.PUBLIC,
+        siteSession: 'persistent',
+        func: async () => {
+          firstRunId = getDaemonRunContext()?.runId;
+          await resumeFirst.promise;
+          await sendCommand('exec', { code: 'first-after-second' });
+          firstFinished.resolve();
+        },
+      });
+      const secondCommand = cli({
+        site: 'test-execution',
+        name: 'run-overlap-second',
+        access: 'write',
+        description: 'test active run keeps its daemon metadata',
+        browser: true,
+        strategy: Strategy.PUBLIC,
+        siteSession: 'persistent',
+        func: async () => {
+          secondRunId = getDaemonRunContext()?.runId;
+          await sendCommand('exec', { code: 'second-active' });
+          secondStarted.resolve();
+          await finishSecond.promise;
+        },
+      });
+
+      await expect(executeCommand(firstCommand, {})).rejects.toBeInstanceOf(TimeoutError);
+      const secondExecution = executeCommand(secondCommand, {});
+      await secondStarted.promise;
+      resumeFirst.resolve();
+      await firstFinished.promise;
+
+      const bodies = vi.mocked(fetch).mock.calls.map(([, init]) => (
+        JSON.parse(String(init?.body)) as { code?: string; runId?: string }
+      ));
+      expect(bodies.find(body => body.code === 'first-after-second')?.runId).toBe(firstRunId);
+      expect(bodies.find(body => body.code === 'second-active')?.runId).toBe(secondRunId);
+      expect(firstRunId).not.toBe(secondRunId);
+
+      finishSecond.resolve();
+      await expect(secondExecution).resolves.toBeUndefined();
     });
   });
 

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { CliCommand } from './registry.js';
 
-const { mockSetDaemonCommandTimeoutSeconds } = vi.hoisted(() => ({
+const { mockReleaseSiteSessionLease, mockSetDaemonCommandTimeoutSeconds } = vi.hoisted(() => ({
+  mockReleaseSiteSessionLease: vi.fn().mockResolvedValue(undefined),
   mockSetDaemonCommandTimeoutSeconds: vi.fn(),
 }));
 
@@ -12,6 +13,7 @@ vi.mock('./browser/daemon-client.js', async () => {
   const actual = await vi.importActual<typeof import('./browser/daemon-client.js')>('./browser/daemon-client.js');
   return {
     ...actual,
+    releaseSiteSessionLease: mockReleaseSiteSessionLease,
     setDaemonCommandTimeoutSeconds: mockSetDaemonCommandTimeoutSeconds,
   };
 });
@@ -22,6 +24,21 @@ import { cli, Strategy } from './registry.js';
 import { withTimeoutMs } from './runtime.js';
 import * as runtime from './runtime.js';
 import * as capRouting from './capabilityRouting.js';
+import { clearDaemonRunContext, getDaemonRunContext } from './session-lease.js';
+
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
 
 describe('executeCommand — non-browser timeout', () => {
   it('applies the user --timeout arg as the ceiling for non-browser commands', async () => {
@@ -178,6 +195,293 @@ describe('executeCommand — non-browser timeout', () => {
       label: 'test-execution/browser-no-timeout',
     });
     vi.restoreAllMocks();
+  });
+
+  describe('persistent write run ownership', () => {
+    afterEach(() => {
+      const activeRun = getDaemonRunContext();
+      if (activeRun) clearDaemonRunContext(activeRun.runId);
+      mockReleaseSiteSessionLease.mockReset().mockResolvedValue(undefined);
+      vi.restoreAllMocks();
+    });
+
+    it('binds a run only for browser-backed persistent writes', async () => {
+      const seen = new Map<string, ReturnType<typeof getDaemonRunContext>>();
+      const mockPage = { closeWindow: vi.fn().mockResolvedValue(undefined) } as any;
+
+      vi.spyOn(capRouting, 'shouldUseBrowserSession').mockImplementation(cmd => cmd.browser !== false);
+      vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+
+      const makeCommand = (
+        name: string,
+        access: 'read' | 'write',
+        browser: boolean,
+        siteSession: 'ephemeral' | 'persistent',
+      ) => cli({
+        site: 'test-execution',
+        name,
+        access,
+        description: 'test logical run eligibility',
+        browser,
+        strategy: Strategy.PUBLIC,
+        siteSession,
+        func: async () => {
+          seen.set(name, getDaemonRunContext());
+          return [{ ok: true }];
+        },
+      } as Parameters<typeof cli>[0]);
+
+      await executeCommand(makeCommand('run-eligible', 'write', true, 'persistent'), {});
+      await executeCommand(makeCommand('run-read', 'read', true, 'persistent'), {});
+      await executeCommand(makeCommand('run-ephemeral', 'write', true, 'ephemeral'), {});
+      await executeCommand(makeCommand('run-non-browser', 'write', false, 'persistent'), {});
+
+      const eligibleRun = seen.get('run-eligible');
+      expect(eligibleRun).toMatchObject({
+        runId: expect.stringMatching(/^run_/),
+        command: 'test-execution/run-eligible',
+        access: 'write',
+      });
+      expect(seen.get('run-read')).toBeUndefined();
+      expect(seen.get('run-ephemeral')).toBeUndefined();
+      expect(seen.get('run-non-browser')).toBeUndefined();
+      expect(mockReleaseSiteSessionLease).toHaveBeenCalledOnce();
+      expect(mockReleaseSiteSessionLease).toHaveBeenCalledWith(eligibleRun?.runId);
+    });
+
+    it('binds one canonical run before session setup, pre-navigation, and adapter execution', async () => {
+      const seen: Array<{ stage: string; run: ReturnType<typeof getDaemonRunContext> }> = [];
+      const capture = (stage: string) => seen.push({ stage, run: getDaemonRunContext() });
+      const mockPage = {
+        closeWindow: vi.fn().mockResolvedValue(undefined),
+        getCurrentUrl: vi.fn().mockImplementation(async () => {
+          capture('current-url');
+          return 'about:blank';
+        }),
+        goto: vi.fn().mockImplementation(async () => capture('pre-navigation')),
+      } as any;
+
+      vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+      vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => {
+        capture('session');
+        return fn(mockPage);
+      });
+
+      const cmd = cli({
+        site: 'test-execution',
+        name: 'run-bound-before-operations',
+        access: 'write',
+        description: 'test one run spans the complete adapter execution',
+        browser: true,
+        strategy: Strategy.COOKIE,
+        domain: 'example.com',
+        siteSession: 'persistent',
+        func: async () => {
+          capture('adapter');
+          return [{ ok: true }];
+        },
+      });
+
+      await expect(executeCommand(cmd, {})).resolves.toEqual([{ ok: true }]);
+
+      expect(seen.map(entry => entry.stage)).toEqual([
+        'session',
+        'current-url',
+        'pre-navigation',
+        'adapter',
+      ]);
+      const runId = seen[0]?.run?.runId;
+      expect(runId).toMatch(/^run_/);
+      for (const entry of seen) {
+        expect(entry.run).toEqual({
+          runId,
+          command: 'test-execution/run-bound-before-operations',
+          access: 'write',
+        });
+      }
+      expect(getDaemonRunContext()).toBeUndefined();
+      expect(mockReleaseSiteSessionLease).toHaveBeenCalledOnce();
+      expect(mockReleaseSiteSessionLease).toHaveBeenCalledWith(runId);
+    });
+
+    it('clears and releases the run once after an ordinary adapter error', async () => {
+      let runId: string | undefined;
+      const mockPage = { closeWindow: vi.fn().mockResolvedValue(undefined) } as any;
+      vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+      vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+
+      const cmd = cli({
+        site: 'test-execution',
+        name: 'run-ordinary-error',
+        access: 'write',
+        description: 'test ordinary errors release run ownership',
+        browser: true,
+        strategy: Strategy.PUBLIC,
+        siteSession: 'persistent',
+        func: async () => {
+          runId = getDaemonRunContext()?.runId;
+          throw new Error('ordinary adapter failure');
+        },
+      });
+
+      await expect(executeCommand(cmd, {})).rejects.toThrow('ordinary adapter failure');
+
+      expect(runId).toMatch(/^run_/);
+      expect(getDaemonRunContext()).toBeUndefined();
+      expect(mockReleaseSiteSessionLease).toHaveBeenCalledOnce();
+      expect(mockReleaseSiteSessionLease).toHaveBeenCalledWith(runId);
+    });
+
+    it('clears but does not release a run when an error cause has unknown outcome', async () => {
+      let runId: string | undefined;
+      const mockPage = { closeWindow: vi.fn().mockResolvedValue(undefined) } as any;
+      vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+      vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+
+      const unknownOutcome = new Error('wrapped adapter failure') as Error & { cause?: unknown };
+      unknownOutcome.cause = { code: 'COMMAND_RESULT_UNKNOWN' };
+      const cmd = cli({
+        site: 'test-execution',
+        name: 'run-unknown-outcome',
+        access: 'write',
+        description: 'test unknown outcomes retain the daemon lease',
+        browser: true,
+        strategy: Strategy.PUBLIC,
+        siteSession: 'persistent',
+        func: async () => {
+          runId = getDaemonRunContext()?.runId;
+          throw unknownOutcome;
+        },
+      });
+
+      await expect(executeCommand(cmd, {})).rejects.toBe(unknownOutcome);
+
+      expect(runId).toMatch(/^run_/);
+      expect(getDaemonRunContext()).toBeUndefined();
+      expect(mockReleaseSiteSessionLease).not.toHaveBeenCalled();
+    });
+
+    it('does not release a run when pre-navigation has unknown outcome', async () => {
+      let runId: string | undefined;
+      const unknownOutcome = new Error('navigation result unknown') as Error & { cause?: unknown };
+      unknownOutcome.cause = { errorCode: 'COMMAND_LOST' };
+      const mockPage = {
+        closeWindow: vi.fn().mockResolvedValue(undefined),
+        getCurrentUrl: vi.fn().mockResolvedValue('about:blank'),
+        goto: vi.fn().mockImplementation(async () => {
+          runId = getDaemonRunContext()?.runId;
+          throw unknownOutcome;
+        }),
+      } as any;
+      vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+      vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+
+      const cmd = cli({
+        site: 'test-execution',
+        name: 'run-unknown-prenavigation',
+        access: 'write',
+        description: 'test unknown pre-navigation retains the daemon lease',
+        browser: true,
+        strategy: Strategy.COOKIE,
+        domain: 'example.com',
+        siteSession: 'persistent',
+        func: async () => [{ ok: true }],
+      });
+
+      await expect(executeCommand(cmd, {})).rejects.toThrow('Pre-navigation');
+
+      expect(runId).toMatch(/^run_/);
+      expect(getDaemonRunContext()).toBeUndefined();
+      expect(mockReleaseSiteSessionLease).not.toHaveBeenCalled();
+    });
+
+    it('keeps the run bound after timeout until the underlying adapter settles', async () => {
+      const adapter = deferred<void>();
+      let runId: string | undefined;
+      const mockPage = { closeWindow: vi.fn().mockResolvedValue(undefined) } as any;
+      vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+      vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+      vi.spyOn(runtime, 'runWithTimeout').mockRejectedValueOnce(new TimeoutError('logical run', 1));
+
+      const cmd = cli({
+        site: 'test-execution',
+        name: 'run-timeout',
+        access: 'write',
+        description: 'test timeout defers local run cleanup',
+        browser: true,
+        strategy: Strategy.PUBLIC,
+        siteSession: 'persistent',
+        func: () => {
+          runId = getDaemonRunContext()?.runId;
+          return adapter.promise;
+        },
+      });
+
+      await expect(executeCommand(cmd, {})).rejects.toBeInstanceOf(TimeoutError);
+
+      expect(runId).toMatch(/^run_/);
+      expect(getDaemonRunContext()?.runId).toBe(runId);
+      expect(mockReleaseSiteSessionLease).not.toHaveBeenCalled();
+
+      adapter.resolve();
+      await vi.waitFor(() => expect(getDaemonRunContext()).toBeUndefined());
+      expect(mockReleaseSiteSessionLease).not.toHaveBeenCalled();
+    });
+
+    it('does not let deferred timeout cleanup clear a later run', async () => {
+      const firstAdapter = deferred<void>();
+      const secondAdapter = deferred<void>();
+      let firstRunId: string | undefined;
+      let secondRunId: string | undefined;
+      const mockPage = { closeWindow: vi.fn().mockResolvedValue(undefined) } as any;
+      vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+      vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+      vi.spyOn(runtime, 'runWithTimeout')
+        .mockRejectedValueOnce(new TimeoutError('first logical run', 1))
+        .mockImplementationOnce(async promise => promise);
+
+      const firstCommand = cli({
+        site: 'test-execution',
+        name: 'run-timeout-first',
+        access: 'write',
+        description: 'test deferred cleanup for an older run',
+        browser: true,
+        strategy: Strategy.PUBLIC,
+        siteSession: 'persistent',
+        func: () => {
+          firstRunId = getDaemonRunContext()?.runId;
+          return firstAdapter.promise;
+        },
+      });
+      const secondCommand = cli({
+        site: 'test-execution',
+        name: 'run-timeout-second',
+        access: 'write',
+        description: 'test a newer run survives old deferred cleanup',
+        browser: true,
+        strategy: Strategy.PUBLIC,
+        siteSession: 'persistent',
+        func: () => {
+          secondRunId = getDaemonRunContext()?.runId;
+          return secondAdapter.promise;
+        },
+      });
+
+      await expect(executeCommand(firstCommand, {})).rejects.toBeInstanceOf(TimeoutError);
+      const secondExecution = executeCommand(secondCommand, {});
+      await vi.waitFor(() => expect(secondRunId).toMatch(/^run_/));
+      expect(secondRunId).not.toBe(firstRunId);
+
+      firstAdapter.resolve();
+      await firstAdapter.promise;
+      await vi.waitFor(() => expect(getDaemonRunContext()?.runId).toBe(secondRunId));
+
+      secondAdapter.resolve();
+      await expect(secondExecution).resolves.toBeUndefined();
+      expect(getDaemonRunContext()).toBeUndefined();
+      expect(mockReleaseSiteSessionLease).toHaveBeenCalledOnce();
+      expect(mockReleaseSiteSessionLease).toHaveBeenCalledWith(secondRunId);
+    });
   });
 
   it('reuses a persistent site browser session and keeps the tab lease open', async () => {

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -37,7 +37,7 @@ import { probeCDP, resolveElectronEndpoint } from './launcher.js';
 import { ObservationSession, exportObservationSession, type ObservationExportResult, type ObservationExportStatus } from './observation/index.js';
 import { resolveAdapterSourcePath } from './adapter-source.js';
 import { coerceCommandArguments, TRACE_MODES, type TraceMode } from './command-surface.js';
-import { clearDaemonRunContext, generateRunId, isUnknownOutcomeError, setDaemonRunContext } from './session-lease.js';
+import { clearDaemonRunContext, generateRunId, isUnknownOutcomeError, runWithDaemonRunContext } from './session-lease.js';
 
 const _loadedModules = new Map<string, Promise<void>>();
 /** Track mtime of loaded user adapter files for hot-reload in daemon mode. */
@@ -228,10 +228,6 @@ export async function executeCommand(
       let releaseRun = true;
       let deferRunFinalization = false;
 
-      if (runId) {
-        setDaemonRunContext({ runId, command: canonicalCommand, access: 'write' });
-      }
-
       const executeAdapter = async (page: IPage): Promise<unknown> => {
         const observation = traceMode === 'off'
           ? null
@@ -302,6 +298,11 @@ export async function executeCommand(
           }
         }
         const adapterPromise = Promise.resolve(runCommand(cmd, page, kwargs, debug));
+        let adapterSettled = false;
+        void adapterPromise.then(
+          () => { adapterSettled = true; },
+          () => { adapterSettled = true; },
+        );
         try {
           const browserTimeout = userTimeoutSec !== null
             ? userTimeoutSec + RUNTIME_TIMEOUT_PADDING_SECONDS
@@ -326,7 +327,7 @@ export async function executeCommand(
           return result;
         } catch (err) {
           if (runId && isUnknownOutcomeError(err)) releaseRun = false;
-          if (runId && err instanceof TimeoutError) {
+          if (runId && err instanceof TimeoutError && !adapterSettled) {
             releaseRun = false;
             deferRunFinalization = true;
             void adapterPromise
@@ -357,9 +358,23 @@ export async function executeCommand(
           throw err;
         }
       };
+      const executeBrowser = () => browserSession(BrowserFactory, executeAdapter, {
+        session,
+        cdpEndpoint,
+        ...profileRouting,
+        windowMode,
+        surface,
+        siteSession,
+        freshPage: cmd.freshPage === true && siteSession === 'persistent',
+      });
 
       try {
-        result = await browserSession(BrowserFactory, executeAdapter, { session, cdpEndpoint, ...profileRouting, windowMode, surface, siteSession, freshPage: cmd.freshPage === true && siteSession === 'persistent' });
+        result = runId
+          ? await runWithDaemonRunContext(
+              { runId, command: canonicalCommand, access: 'write' },
+              executeBrowser,
+            )
+          : await executeBrowser();
       } catch (err) {
         if (runId && isUnknownOutcomeError(err)) releaseRun = false;
         throw err;

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -331,7 +331,10 @@ export async function executeCommand(
             releaseRun = false;
             deferRunFinalization = true;
             void adapterPromise
-              .finally(() => finalizeRun(runId, false))
+              .then(
+                () => finalizeRun(runId, true),
+                (lateError) => finalizeRun(runId, !isUnknownOutcomeError(lateError)),
+              )
               .catch(() => undefined);
           }
           if (observation) {

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -25,11 +25,11 @@ import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import { executePipeline } from './pipeline/index.js';
-import { adapterLoadError, ArgumentError, CommandExecutionError, attachTraceReceipt, getErrorMessage } from './errors.js';
+import { adapterLoadError, ArgumentError, CommandExecutionError, TimeoutError, attachTraceReceipt, getErrorMessage } from './errors.js';
 import { shouldUseBrowserSession } from './capabilityRouting.js';
 import { getBrowserFactory, browserSession, runWithTimeout, DEFAULT_BROWSER_COMMAND_TIMEOUT, type BrowserWindowMode } from './runtime.js';
 import { profileRouteParams, resolveProfileSelection } from './browser/profile.js';
-import { setDaemonCommandTimeoutSeconds } from './browser/daemon-client.js';
+import { releaseSiteSessionLease, setDaemonCommandTimeoutSeconds } from './browser/daemon-client.js';
 import { emitHook, type HookContext } from './hooks.js';
 import { log } from './logger.js';
 import { isElectronApp } from './electron-apps.js';
@@ -37,11 +37,17 @@ import { probeCDP, resolveElectronEndpoint } from './launcher.js';
 import { ObservationSession, exportObservationSession, type ObservationExportResult, type ObservationExportStatus } from './observation/index.js';
 import { resolveAdapterSourcePath } from './adapter-source.js';
 import { coerceCommandArguments, TRACE_MODES, type TraceMode } from './command-surface.js';
+import { clearDaemonRunContext, generateRunId, isUnknownOutcomeError, setDaemonRunContext } from './session-lease.js';
 
 const _loadedModules = new Map<string, Promise<void>>();
 /** Track mtime of loaded user adapter files for hot-reload in daemon mode. */
 const _moduleMtimes = new Map<string, number>();
 const _userClisDir = `${os.homedir()}/.webcmd/clis/`;
+
+async function finalizeRun(runId: string, release: boolean): Promise<void> {
+  clearDaemonRunContext(runId);
+  if (release) await releaseSiteSessionLease(runId).catch(() => undefined);
+}
 
 function normalizeTraceMode(raw: unknown): TraceMode {
   if (raw === undefined || raw === null || raw === '' || raw === 'off') return 'off';
@@ -213,7 +219,20 @@ export async function executeCommand(
       const session = resolveAdapterBrowserSession(cmd, siteSession);
       const keepTab = resolveKeepTab(siteSession, opts.keepTab);
       const windowMode = resolveBrowserWindowMode(cmd.defaultWindowMode ?? 'background', opts.windowMode);
-      result = await browserSession(BrowserFactory, async (page) => {
+      const surface = 'adapter' as const;
+      const canonicalCommand = fullName(cmd);
+      const leaseEligible = surface === 'adapter'
+        && siteSession === 'persistent'
+        && cmd.access === 'write';
+      const runId = leaseEligible ? generateRunId() : undefined;
+      let releaseRun = true;
+      let deferRunFinalization = false;
+
+      if (runId) {
+        setDaemonRunContext({ runId, command: canonicalCommand, access: 'write' });
+      }
+
+      const executeAdapter = async (page: IPage): Promise<unknown> => {
         const observation = traceMode === 'off'
           ? null
           : new ObservationSession({
@@ -257,6 +276,7 @@ export async function executeCommand(
               data: { url: preNavUrl },
             });
           } catch (err) {
+            if (runId && isUnknownOutcomeError(err)) releaseRun = false;
             observation?.record({
               stream: 'action',
               name: 'pre_navigate',
@@ -281,13 +301,14 @@ export async function executeCommand(
             throw wrapped;
           }
         }
+        const adapterPromise = Promise.resolve(runCommand(cmd, page, kwargs, debug));
         try {
           const browserTimeout = userTimeoutSec !== null
             ? userTimeoutSec + RUNTIME_TIMEOUT_PADDING_SECONDS
             : DEFAULT_BROWSER_COMMAND_TIMEOUT;
-          const result = await runWithTimeout(runCommand(cmd, page, kwargs, debug), {
+          const result = await runWithTimeout(adapterPromise, {
             timeout: browserTimeout,
-            label: fullName(cmd),
+            label: canonicalCommand,
           });
           observation?.record({
             stream: 'action',
@@ -304,6 +325,14 @@ export async function executeCommand(
           if (!keepTab) await page.closeWindow?.().catch(() => {});
           return result;
         } catch (err) {
+          if (runId && isUnknownOutcomeError(err)) releaseRun = false;
+          if (runId && err instanceof TimeoutError) {
+            releaseRun = false;
+            deferRunFinalization = true;
+            void adapterPromise
+              .finally(() => finalizeRun(runId, false))
+              .catch(() => undefined);
+          }
           if (observation) {
             observation.record({
               stream: 'action',
@@ -327,7 +356,16 @@ export async function executeCommand(
           if (!keepTab) await page.closeWindow?.().catch(() => {});
           throw err;
         }
-      }, { session, cdpEndpoint, ...profileRouting, windowMode, surface: 'adapter', siteSession, freshPage: cmd.freshPage === true && siteSession === 'persistent' });
+      };
+
+      try {
+        result = await browserSession(BrowserFactory, executeAdapter, { session, cdpEndpoint, ...profileRouting, windowMode, surface, siteSession, freshPage: cmd.freshPage === true && siteSession === 'persistent' });
+      } catch (err) {
+        if (runId && isUnknownOutcomeError(err)) releaseRun = false;
+        throw err;
+      } finally {
+        if (runId && !deferRunFinalization) await finalizeRun(runId, releaseRun);
+      }
     } else {
       // Non-browser commands: enforce a timeout only when the command exposes
       // a `--timeout` arg (and the resolved value is positive). Without that

--- a/src/package-bin-process.test.ts
+++ b/src/package-bin-process.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatPackageBinSpawnFailure,
+  packageBinSpawnOptions,
+} from './package-bin-process.js';
+
+describe('package bin process options', () => {
+  it('uses a shell for npm and cmd shims on Windows', () => {
+    expect(packageBinSpawnOptions('win32', 'npm')).toEqual({ shell: true });
+    expect(packageBinSpawnOptions('win32', 'C:\\prefix\\webcmd.cmd')).toEqual({ shell: true });
+  });
+
+  it('keeps native executables shell-free', () => {
+    expect(packageBinSpawnOptions('linux', 'npm')).toEqual({});
+    expect(packageBinSpawnOptions('darwin', '/tmp/webcmd')).toEqual({});
+    expect(packageBinSpawnOptions('win32', 'node.exe')).toEqual({});
+  });
+
+  it('reports launch errors without assuming output streams exist', () => {
+    const error = Object.assign(new Error('spawnSync npm EINVAL'), { code: 'EINVAL' });
+
+    expect(formatPackageBinSpawnFailure('npm', ['pack'], {
+      error,
+      status: null,
+      stdout: undefined,
+      stderr: undefined,
+    })).toBe('npm pack failed to start: spawnSync npm EINVAL');
+  });
+});

--- a/src/package-bin-process.ts
+++ b/src/package-bin-process.ts
@@ -1,0 +1,44 @@
+import path from 'node:path';
+
+type SpawnOutput = string | Buffer | null | undefined;
+
+export interface PackageBinSpawnFailure {
+  error?: Error;
+  signal?: NodeJS.Signals | null;
+  status: number | null;
+  stdout?: SpawnOutput;
+  stderr?: SpawnOutput;
+}
+
+export function packageBinSpawnOptions(
+  platform: NodeJS.Platform,
+  command: string,
+): { shell?: true } {
+  if (platform !== 'win32') return {};
+  const basename = path.win32.basename(command).toLowerCase();
+  return basename === 'npm' || basename.endsWith('.cmd') ? { shell: true } : {};
+}
+
+function outputText(output: SpawnOutput): string {
+  return output == null ? '' : output.toString().trim();
+}
+
+export function formatPackageBinSpawnFailure(
+  command: string,
+  args: string[],
+  result: PackageBinSpawnFailure,
+): string {
+  const invocation = [command, ...args].join(' ');
+  if (result.error) {
+    return `${invocation} failed to start: ${result.error.message}`;
+  }
+
+  const outcome = result.status === null
+    ? `terminated by ${result.signal ?? 'an unknown signal'}`
+    : `exited ${result.status}`;
+  return [
+    `${invocation} ${outcome}`,
+    outputText(result.stdout),
+    outputText(result.stderr),
+  ].filter(Boolean).join('\n');
+}

--- a/src/session-lease.test.ts
+++ b/src/session-lease.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 
 import {
   SESSION_LEASE_TTL_MS,
@@ -11,6 +11,7 @@ import {
   isUnknownOutcomeError,
   setDaemonRunContext,
 } from './session-lease.js';
+import type { DaemonRunContext } from './session-lease.js';
 
 const T0 = 1_000_000;
 
@@ -48,6 +49,10 @@ describe('logical daemon run context', () => {
 
     clearDaemonRunContext('run_222_2_2');
     expect(getDaemonRunContext()).toBeUndefined();
+  });
+
+  it('only accepts a concrete run context through the setter', () => {
+    expectTypeOf(setDaemonRunContext).parameter(0).toEqualTypeOf<DaemonRunContext>();
   });
 });
 
@@ -151,6 +156,42 @@ describe('SessionLeaseRegistry', () => {
       acquired: true,
       lease: expect.objectContaining({ pid: 4242 }),
     });
+  });
+
+  it.each([
+    0,
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.MAX_SAFE_INTEGER + 1,
+  ])('omits a non-actionable explicit holder pid (%s)', (pid) => {
+    const leases = registry();
+    const result = leases.acquire(
+      { key: KEY, runId: 'opaque-run-id', command: 'chatgpt ask', pid },
+      () => false,
+    );
+
+    expect(result.acquired).toBe(true);
+    if (result.acquired) expect(result.lease).not.toHaveProperty('pid');
+  });
+
+  it.each([
+    'run_0_1700000000000_1',
+    'run_-1_1700000000000_1',
+    'run_1.5_1700000000000_1',
+    'run_NaN_1700000000000_1',
+    'run_Infinity_1700000000000_1',
+    `run_${Number.MAX_SAFE_INTEGER + 1}_1700000000000_1`,
+  ])('does not recover a non-actionable holder pid from %s', (runId) => {
+    const leases = registry();
+    const result = leases.acquire(
+      { key: KEY, runId, command: 'chatgpt ask' },
+      () => false,
+    );
+
+    expect(result.acquired).toBe(true);
+    if (result.acquired) expect(result.lease).not.toHaveProperty('pid');
   });
 
   it('treats same-run acquisition and explicit heartbeat as owner-only liveness refreshes', () => {

--- a/src/session-lease.test.ts
+++ b/src/session-lease.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  SESSION_LEASE_TTL_MS,
+  SessionLeaseRegistry,
+  clearDaemonRunContext,
+  generateRunId,
+  getDaemonRunContext,
+  getSessionLeaseKey,
+  isSessionLeaseCommand,
+  isUnknownOutcomeError,
+  setDaemonRunContext,
+} from './session-lease.js';
+
+const T0 = 1_000_000;
+
+describe('logical daemon run context', () => {
+  afterEach(() => {
+    const current = getDaemonRunContext();
+    if (current) clearDaemonRunContext(current.runId);
+    vi.restoreAllMocks();
+  });
+
+  it('keeps one run id stable while a logical run is bound and generates a different id for the next run', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_763_000_000_000);
+    const firstRunId = generateRunId();
+    setDaemonRunContext({ runId: firstRunId, command: 'chatgpt ask', access: 'write' });
+
+    expect(getDaemonRunContext()?.runId).toBe(firstRunId);
+    expect(getDaemonRunContext()?.runId).toBe(firstRunId);
+
+    clearDaemonRunContext(firstRunId);
+    const secondRunId = generateRunId();
+    expect(secondRunId).not.toBe(firstRunId);
+    expect(firstRunId).toMatch(new RegExp(`^run_${process.pid}_1763000000000_\\d+$`));
+  });
+
+  it('does not let deferred cleanup from an older run clear a newer run context', () => {
+    setDaemonRunContext({ runId: 'run_111_1_1', command: 'chatgpt ask', access: 'write' });
+    setDaemonRunContext({ runId: 'run_222_2_2', command: 'claude ask', access: 'write' });
+
+    clearDaemonRunContext('run_111_1_1');
+    expect(getDaemonRunContext()).toEqual({
+      runId: 'run_222_2_2',
+      command: 'claude ask',
+      access: 'write',
+    });
+
+    clearDaemonRunContext('run_222_2_2');
+    expect(getDaemonRunContext()).toBeUndefined();
+  });
+});
+
+describe('isUnknownOutcomeError', () => {
+  it('recognizes public, daemon, and message codes case-insensitively', () => {
+    expect(isUnknownOutcomeError({ code: 'COMMAND_RESULT_UNKNOWN' })).toBe(true);
+    expect(isUnknownOutcomeError({ errorCode: 'Command_Lost' })).toBe(true);
+    expect(isUnknownOutcomeError(new Error('daemon returned RESULT_EVICTED'))).toBe(true);
+    expect(isUnknownOutcomeError({ daemonCode: 'attach_failed', message: 'ordinary failure' })).toBe(false);
+  });
+
+  it('walks causes and AggregateError members without looping on cycles', () => {
+    const cyclic = new Error('outer') as Error & { cause?: unknown };
+    cyclic.cause = cyclic;
+    const aggregate = new AggregateError([
+      cyclic,
+      new Error('wrapped', { cause: { errorCode: 'COMMAND_LOST' } }),
+    ]);
+
+    expect(isUnknownOutcomeError(aggregate)).toBe(true);
+    expect(isUnknownOutcomeError(cyclic)).toBe(false);
+  });
+});
+
+describe('session lease partitions', () => {
+  it('partitions persistent writes by resolved profile, surface, and encoded site', () => {
+    const workChatgpt = getSessionLeaseKey('work', 'adapter', 'site:chatgpt');
+    expect(workChatgpt).toBe('work␟adapter␟site%3Achatgpt');
+    expect(workChatgpt).not.toBe(getSessionLeaseKey('personal', 'adapter', 'site:chatgpt'));
+    expect(workChatgpt).not.toBe(getSessionLeaseKey('work', 'adapter', 'site:claude'));
+    expect(workChatgpt).not.toBe(getSessionLeaseKey('work', 'browser', 'site:chatgpt'));
+  });
+
+  it('does not arbitrate reads, ephemeral sessions, raw browser operations, or incomplete identities', () => {
+    const eligible = {
+      surface: 'adapter',
+      siteSession: 'persistent',
+      access: 'write',
+      session: 'site:chatgpt',
+      runId: 'run_111_1_1',
+    };
+    expect(isSessionLeaseCommand(eligible)).toBe(true);
+    expect(isSessionLeaseCommand({ ...eligible, access: 'read' })).toBe(false);
+    expect(isSessionLeaseCommand({ ...eligible, siteSession: 'ephemeral' })).toBe(false);
+    expect(isSessionLeaseCommand({ ...eligible, surface: 'browser' })).toBe(false);
+    expect(isSessionLeaseCommand({ ...eligible, session: '' })).toBe(false);
+    expect(isSessionLeaseCommand({ ...eligible, runId: undefined })).toBe(false);
+  });
+});
+
+describe('SessionLeaseRegistry', () => {
+  const KEY = getSessionLeaseKey('work', 'adapter', 'site:chatgpt');
+  let now = T0;
+
+  beforeEach(() => {
+    now = T0;
+  });
+
+  function registry(): SessionLeaseRegistry {
+    return new SessionLeaseRegistry(() => now);
+  }
+
+  function acquire(registry: SessionLeaseRegistry, runId: string, key = KEY) {
+    return registry.acquire(
+      { key, runId, command: 'chatgpt ask', pid: Number(runId.split('_')[1]) },
+      () => false,
+    );
+  }
+
+  it('acquires a free key and returns the live holder on a conflicting run without mutation', () => {
+    const leases = registry();
+    expect(acquire(leases, 'run_111_1_1')).toEqual({
+      acquired: true,
+      lease: expect.objectContaining({
+        key: KEY,
+        runId: 'run_111_1_1',
+        command: 'chatgpt ask',
+        pid: 111,
+        acquiredAt: T0,
+        heartbeatAt: T0,
+      }),
+    });
+
+    now += 1_000;
+    const conflict = acquire(leases, 'run_222_2_2');
+    expect(conflict).toEqual({
+      acquired: false,
+      holder: expect.objectContaining({ runId: 'run_111_1_1', heartbeatAt: T0 }),
+    });
+    expect(leases.list(() => false)).toEqual([
+      expect.objectContaining({ runId: 'run_111_1_1', heartbeatAt: T0 }),
+    ]);
+  });
+
+  it('recovers the holder pid from a generated run id when explicit metadata is absent', () => {
+    const leases = registry();
+    expect(leases.acquire(
+      { key: KEY, runId: 'run_4242_1700000000000_7', command: 'chatgpt ask' },
+      () => false,
+    )).toEqual({
+      acquired: true,
+      lease: expect.objectContaining({ pid: 4242 }),
+    });
+  });
+
+  it('treats same-run acquisition and explicit heartbeat as owner-only liveness refreshes', () => {
+    const leases = registry();
+    acquire(leases, 'run_111_1_1');
+    now += SESSION_LEASE_TTL_MS;
+
+    const refreshed = acquire(leases, 'run_111_1_1');
+    expect(refreshed).toEqual({
+      acquired: true,
+      lease: expect.objectContaining({ acquiredAt: T0, heartbeatAt: now }),
+    });
+
+    now += 10;
+    expect(leases.heartbeat(KEY, 'run_999_9_9')).toBe(false);
+    expect(leases.heartbeat(KEY, 'run_111_1_1')).toBe(true);
+    expect(leases.list(() => false)[0]).toMatchObject({ acquiredAt: T0, heartbeatAt: now });
+  });
+
+  it('lets a challenger acquire after expiry', () => {
+    const leases = registry();
+    acquire(leases, 'run_111_1_1');
+    now += SESSION_LEASE_TTL_MS + 1;
+
+    expect(acquire(leases, 'run_222_2_2')).toEqual({
+      acquired: true,
+      lease: expect.objectContaining({ runId: 'run_222_2_2', acquiredAt: now }),
+    });
+  });
+
+  it('keeps an expired holder live while the holder still has pending work', () => {
+    const leases = registry();
+    acquire(leases, 'run_111_1_1');
+    now += SESSION_LEASE_TTL_MS + 10_000;
+
+    const conflict = leases.acquire(
+      { key: KEY, runId: 'run_222_2_2', command: 'chatgpt ask', pid: 222 },
+      (runId) => runId === 'run_111_1_1',
+    );
+    expect(conflict).toEqual({
+      acquired: false,
+      holder: expect.objectContaining({ runId: 'run_111_1_1' }),
+    });
+    expect(leases.list((runId) => runId === 'run_111_1_1')).toHaveLength(1);
+    expect(leases.list(() => false)).toEqual([]);
+  });
+
+  it('releases only leases owned by the requested run and reports the count', () => {
+    const leases = registry();
+    acquire(leases, 'run_111_1_1');
+    acquire(leases, 'run_111_1_1', getSessionLeaseKey('work', 'adapter', 'site:claude'));
+
+    expect(leases.releaseByRunId('run_999_9_9')).toBe(0);
+    expect(leases.list(() => false)).toHaveLength(2);
+    expect(leases.releaseByRunId('run_111_1_1')).toBe(2);
+    expect(leases.list(() => false)).toEqual([]);
+  });
+});

--- a/src/session-lease.test.ts
+++ b/src/session-lease.test.ts
@@ -9,6 +9,7 @@ import {
   getSessionLeaseKey,
   isSessionLeaseCommand,
   isUnknownOutcomeError,
+  runWithDaemonRunContext,
   setDaemonRunContext,
 } from './session-lease.js';
 import type { DaemonRunContext } from './session-lease.js';
@@ -53,6 +54,32 @@ describe('logical daemon run context', () => {
 
   it('only accepts a concrete run context through the setter', () => {
     expectTypeOf(setDaemonRunContext).parameter(0).toEqualTypeOf<DaemonRunContext>();
+  });
+
+  it('keeps overlapping async run contexts isolated across awaits', async () => {
+    let resumeFirst!: () => void;
+    const firstGate = new Promise<void>(resolve => { resumeFirst = resolve; });
+    const firstContext: DaemonRunContext = {
+      runId: 'run_111_1_1',
+      command: 'first write',
+      access: 'write',
+    };
+    const secondContext: DaemonRunContext = {
+      runId: 'run_222_2_2',
+      command: 'second write',
+      access: 'write',
+    };
+
+    const first = runWithDaemonRunContext(firstContext, async () => {
+      await firstGate;
+      return getDaemonRunContext();
+    });
+    const second = runWithDaemonRunContext(secondContext, async () => getDaemonRunContext());
+
+    expect(await second).toEqual(secondContext);
+    resumeFirst();
+    expect(await first).toEqual(firstContext);
+    expect(getDaemonRunContext()).toBeUndefined();
   });
 });
 

--- a/src/session-lease.ts
+++ b/src/session-lease.ts
@@ -1,0 +1,216 @@
+/** Inactivity window after which an unowned session lease expires. */
+export const SESSION_LEASE_TTL_MS = 45_000;
+
+let runIdCounter = 0;
+
+/** Generate an id for one complete logical CLI command run. */
+export function generateRunId(): string {
+  return `run_${process.pid}_${Date.now()}_${++runIdCounter}`;
+}
+
+export interface DaemonRunContext {
+  runId: string;
+  command: string;
+  access: 'read' | 'write';
+}
+
+let activeRun: DaemonRunContext | undefined;
+
+export function setDaemonRunContext(context: DaemonRunContext | undefined): void {
+  activeRun = context;
+}
+
+export function getDaemonRunContext(): DaemonRunContext | undefined {
+  return activeRun;
+}
+
+/**
+ * Clear only the context still owned by `runId`. Deferred cleanup from an old
+ * command must not clear a newer command's run identity.
+ */
+export function clearDaemonRunContext(runId: string): void {
+  if (activeRun?.runId === runId) activeRun = undefined;
+}
+
+const UNKNOWN_OUTCOME_CODES = [
+  'command_result_unknown',
+  'command_lost',
+  'result_evicted',
+] as const;
+
+function containsUnknownOutcomeCode(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  const normalized = value.toLowerCase();
+  return UNKNOWN_OUTCOME_CODES.some((code) => {
+    const start = normalized.indexOf(code);
+    if (start < 0) return false;
+    const before = normalized[start - 1];
+    const after = normalized[start + code.length];
+    return (!before || !/[a-z0-9_]/.test(before)) && (!after || !/[a-z0-9_]/.test(after));
+  });
+}
+
+/**
+ * Detect errors whose browser-side result is unknown. The traversal includes
+ * wrapper causes and AggregateError members and tolerates cyclic error graphs.
+ */
+export function isUnknownOutcomeError(error: unknown): boolean {
+  const queue: unknown[] = [error];
+  const seen = new Set<unknown>();
+
+  while (queue.length > 0) {
+    const current = queue.pop();
+    if (!current || (typeof current !== 'object' && typeof current !== 'function') || seen.has(current)) {
+      continue;
+    }
+    seen.add(current);
+
+    const record = current as Record<string, unknown>;
+    if (
+      containsUnknownOutcomeCode(record.code)
+      || containsUnknownOutcomeCode(record.errorCode)
+      || containsUnknownOutcomeCode(record.daemonCode)
+      || containsUnknownOutcomeCode(record.message)
+      || containsUnknownOutcomeCode(record.error)
+    ) {
+      return true;
+    }
+
+    if (record.cause !== undefined) queue.push(record.cause);
+    if (Array.isArray(record.errors)) queue.push(...record.errors);
+  }
+
+  return false;
+}
+
+export interface SessionLeaseHolder {
+  command: string;
+  pid?: number;
+  acquiredAt: number;
+  heartbeatAt: number;
+}
+
+export interface SessionLease extends SessionLeaseHolder {
+  key: string;
+  runId: string;
+}
+
+/** Public status shape: the internal ownership token is intentionally omitted. */
+export type SessionLeaseStatus = Omit<SessionLease, 'runId'>;
+
+export interface AcquireSessionLeaseInput {
+  key: string;
+  runId: string;
+  command: string;
+  pid?: number;
+}
+
+export type AcquireResult =
+  | { acquired: true; lease: SessionLease }
+  | { acquired: false; holder: SessionLease };
+
+/**
+ * Lease key for a site session after the daemon has resolved its actual Cloak
+ * profile. Encoding the session keeps key partitions unambiguous.
+ */
+export function getSessionLeaseKey(profileId: string, surface: string, session: string): string {
+  return `${profileId}␟${surface}␟${encodeURIComponent(session)}`;
+}
+
+function pidFromRunId(runId: string): number | undefined {
+  const match = /^run_(\d+)_/.exec(runId);
+  if (!match) return undefined;
+  const pid = Number(match[1]);
+  return Number.isInteger(pid) && pid > 0 ? pid : undefined;
+}
+
+export interface SessionLeaseCommand {
+  surface?: unknown;
+  siteSession?: unknown;
+  access?: unknown;
+  session?: unknown;
+  runId?: unknown;
+}
+
+/** Only persistent adapter writes with a complete owner identity need a lease. */
+export function isSessionLeaseCommand<T extends SessionLeaseCommand>(
+  command: T,
+): command is T & {
+  surface: 'adapter';
+  siteSession: 'persistent';
+  access: 'write';
+  session: string;
+  runId: string;
+} {
+  return command.surface === 'adapter'
+    && command.siteSession === 'persistent'
+    && command.access === 'write'
+    && typeof command.session === 'string'
+    && command.session.length > 0
+    && typeof command.runId === 'string'
+    && command.runId.length > 0;
+}
+
+export class SessionLeaseRegistry {
+  private readonly leases = new Map<string, SessionLease>();
+
+  constructor(private readonly now = Date.now) {}
+
+  acquire(
+    input: AcquireSessionLeaseInput,
+    hasPendingWork: (runId: string) => boolean,
+  ): AcquireResult {
+    const now = this.now();
+    const current = this.leases.get(input.key);
+    const currentIsLive = current !== undefined
+      && (now - current.heartbeatAt <= SESSION_LEASE_TTL_MS || hasPendingWork(current.runId));
+
+    if (current && currentIsLive && current.runId !== input.runId) {
+      return { acquired: false, holder: { ...current } };
+    }
+
+    const lease: SessionLease = current?.runId === input.runId
+      ? { ...current, heartbeatAt: now }
+      : {
+          key: input.key,
+          runId: input.runId,
+          command: input.command,
+          pid: input.pid ?? pidFromRunId(input.runId),
+          acquiredAt: now,
+          heartbeatAt: now,
+        };
+    this.leases.set(input.key, lease);
+    return { acquired: true, lease: { ...lease } };
+  }
+
+  /** Refresh a lease only when both its key and logical owner match. */
+  heartbeat(key: string, runId: string): boolean {
+    const current = this.leases.get(key);
+    if (!current || current.runId !== runId) return false;
+    current.heartbeatAt = this.now();
+    return true;
+  }
+
+  /** Release all leases owned by one logical run. */
+  releaseByRunId(runId: string): number {
+    let released = 0;
+    for (const [key, lease] of this.leases) {
+      if (lease.runId !== runId) continue;
+      this.leases.delete(key);
+      released += 1;
+    }
+    return released;
+  }
+
+  /** Return a snapshot of currently live leases without exposing mutable state. */
+  list(hasPendingWork: (runId: string) => boolean): SessionLease[] {
+    const now = this.now();
+    const active: SessionLease[] = [];
+    for (const lease of this.leases.values()) {
+      if (now - lease.heartbeatAt <= SESSION_LEASE_TTL_MS || hasPendingWork(lease.runId)) {
+        active.push({ ...lease });
+      }
+    }
+    return active;
+  }
+}

--- a/src/session-lease.ts
+++ b/src/session-lease.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 /** Inactivity window after which an unowned session lease expires. */
 export const SESSION_LEASE_TTL_MS = 45_000;
 
@@ -15,13 +17,19 @@ export interface DaemonRunContext {
 }
 
 let activeRun: DaemonRunContext | undefined;
+const daemonRunContextStorage = new AsyncLocalStorage<DaemonRunContext>();
+
+/** Run one logical execution with context isolated across its async chain. */
+export function runWithDaemonRunContext<T>(context: DaemonRunContext, callback: () => T): T {
+  return daemonRunContextStorage.run(context, callback);
+}
 
 export function setDaemonRunContext(context: DaemonRunContext): void {
   activeRun = context;
 }
 
 export function getDaemonRunContext(): DaemonRunContext | undefined {
-  return activeRun;
+  return daemonRunContextStorage.getStore() ?? activeRun;
 }
 
 /**

--- a/src/session-lease.ts
+++ b/src/session-lease.ts
@@ -16,7 +16,7 @@ export interface DaemonRunContext {
 
 let activeRun: DaemonRunContext | undefined;
 
-export function setDaemonRunContext(context: DaemonRunContext | undefined): void {
+export function setDaemonRunContext(context: DaemonRunContext): void {
   activeRun = context;
 }
 
@@ -117,11 +117,16 @@ export function getSessionLeaseKey(profileId: string, surface: string, session: 
   return `${profileId}␟${surface}␟${encodeURIComponent(session)}`;
 }
 
+/** Whether a process id is safe to interpolate into local process guidance. */
+export function isActionablePid(pid: unknown): pid is number {
+  return typeof pid === 'number' && Number.isSafeInteger(pid) && pid > 0;
+}
+
 function pidFromRunId(runId: string): number | undefined {
   const match = /^run_(\d+)_/.exec(runId);
   if (!match) return undefined;
   const pid = Number(match[1]);
-  return Number.isInteger(pid) && pid > 0 ? pid : undefined;
+  return isActionablePid(pid) ? pid : undefined;
 }
 
 export interface SessionLeaseCommand {
@@ -169,13 +174,16 @@ export class SessionLeaseRegistry {
       return { acquired: false, holder: { ...current } };
     }
 
+    const pid = input.pid === undefined
+      ? pidFromRunId(input.runId)
+      : (isActionablePid(input.pid) ? input.pid : undefined);
     const lease: SessionLease = current?.runId === input.runId
       ? { ...current, heartbeatAt: now }
       : {
           key: input.key,
           runId: input.runId,
           command: input.command,
-          pid: input.pid ?? pidFromRunId(input.runId),
+          ...(pid === undefined ? {} : { pid }),
           acquiredAt: now,
           heartbeatAt: now,
         };

--- a/tests/e2e/cloak-runtime.test.ts
+++ b/tests/e2e/cloak-runtime.test.ts
@@ -1,4 +1,7 @@
+import fs from 'node:fs';
 import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { runCli } from './helpers.js';
 
@@ -16,6 +19,18 @@ beforeAll(async () => {
     if (req.url === '/api') {
       res.setHeader('Content-Type', 'application/json');
       res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+
+    const requestUrl = new URL(req.url ?? '/', 'http://127.0.0.1');
+    if (requestUrl.pathname === '/counter') {
+      const index = requestUrl.searchParams.get('index');
+      if (!index || !/^\d+$/.test(index)) {
+        res.statusCode = 400;
+        res.end('invalid counter index');
+        return;
+      }
+      res.end(`<html><title>Counter ${index}</title><body data-index="${index}">counter</body></html>`);
       return;
     }
 
@@ -49,4 +64,68 @@ describe('Cloak runtime e2e', () => {
     expect(cookies.code).toBe(0);
     expect(cookies.stdout).toContain('webcmd_smoke=ok');
   }, 180_000);
+
+  it('survives sequential open and evaluate cycles in one persistent profile', async () => {
+    const session = `cloak-sequential-${Date.now()}`;
+    const profile = `task5-${Date.now()}`;
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-cloak-sequential-'));
+    const run = (args: string[]) => runCli(args, {
+      timeout: 120_000,
+      env: {
+        WEBCMD_CONFIG_DIR: configDir,
+        WEBCMD_PROFILE: profile,
+      },
+    });
+    const waitForStoppedDaemon = async () => {
+      let status = await run(['daemon', 'status']);
+      for (let attempt = 0; attempt < 20 && !status.stdout.includes('Daemon: not running'); attempt += 1) {
+        await new Promise(resolve => setTimeout(resolve, 250));
+        status = await run(['daemon', 'status']);
+      }
+      return status;
+    };
+    let stopCode: number | undefined;
+    let stoppedStatus = { stdout: '', stderr: '', code: 1 };
+
+    try {
+      expect((await run(['daemon', 'stop'])).code).toBe(0);
+      expect((await waitForStoppedDaemon()).stdout).toContain('Daemon: not running');
+
+      try {
+        expect((await run(['browser', session, 'open', `${baseUrl}/cookie`])).code).toBe(0);
+
+        for (let index = 0; index < 3; index += 1) {
+          const open = await run(['browser', session, 'open', `${baseUrl}/counter?index=${index}`]);
+          expect(open.code).toBe(0);
+
+          const evaluated = await run(['browser', session, 'eval', 'document.body.dataset.index']);
+          expect(evaluated.code).toBe(0);
+          expect(evaluated.stdout.trim()).toBe(String(index));
+        }
+
+        const cookies = await run(['browser', session, 'eval', 'document.cookie']);
+        expect(cookies.code).toBe(0);
+        expect(cookies.stdout).toContain('webcmd_smoke=ok');
+
+        const status = await run(['daemon', 'status']);
+        expect(status.code).toBe(0);
+        expect(status.stdout).toContain('Daemon: running');
+        expect(status.stdout).toContain('Runtime: cloak connected');
+        expect(status.stdout).toContain(`Profiles: ${profile}`);
+      } finally {
+        const stopped = await run(['daemon', 'stop']);
+        stopCode = stopped.code;
+      }
+
+    } finally {
+      if (stopCode !== undefined) {
+        stoppedStatus = await waitForStoppedDaemon();
+      }
+      fs.rmSync(configDir, { recursive: true, force: true });
+    }
+
+    expect(stopCode).toBe(0);
+    expect(stoppedStatus.code).toBe(0);
+    expect(stoppedStatus.stdout).toContain('Daemon: not running');
+  }, 480_000);
 });


### PR DESCRIPTION
## Summary

- recover identity-matched Cloak profile contexts after unexpected closure, with a single bounded page-creation retry
- port the persistent-session write lease and timeout/release semantics from jackwener/OpenCLI#2100, including exit code 75 busy signaling
- add Windows CI coverage, a scheduled real-Cloak lifecycle job, and metadata-only diagnostics

Closes #60.
Related to #41.
Upstream reference: https://github.com/jackwener/OpenCLI/pull/2100

## Verification

- `npm run build`
- `npm test` — 4,874 passed, 1 skipped
- `npm run typecheck`
- `npm run check:package-bin`
- `npm run check:typed-error-lint`
- real Cloak lifecycle E2E — 3/3 passed

Windows execution is covered by the added `windows-latest` GitHub Actions jobs.