### PR TITLE
fix: preserve cloud parity for blocked sites and fresh pages

### DIFF
--- a/clis/producthunt/browse.js
+++ b/clis/producthunt/browse.js
@@ -6,7 +6,7 @@
  */
 import { cli, Strategy } from '@agentrhq/webcmd/registry';
 import { CliError } from '@agentrhq/webcmd/errors';
-import { PRODUCTHUNT_CATEGORY_SLUGS } from './utils.js';
+import { assertProductHuntAccessible, PRODUCTHUNT_CATEGORY_SLUGS } from './utils.js';
 cli({
     site: 'producthunt',
     name: 'browse',
@@ -30,7 +30,14 @@ cli({
         const slug = String(args.category || '').trim().toLowerCase();
         await page.installInterceptor('producthunt.com');
         await page.goto(`https://www.producthunt.com/categories/${slug}`);
-        await page.waitForCapture(5);
+        try {
+            await page.waitForCapture(5);
+        }
+        catch (error) {
+            await assertProductHuntAccessible(page);
+            throw error;
+        }
+        await assertProductHuntAccessible(page);
         const domItems = await page.evaluate(`
       (() => {
         const seen = new Set();

--- a/clis/producthunt/browser-commands.test.js
+++ b/clis/producthunt/browser-commands.test.js
@@ -36,7 +36,7 @@ describe('Product Hunt browser commands', () => {
 
         await expect(command.func(pageMock({ evaluations: [challenge] }), args)).rejects.toMatchObject({
             code: 'SITE_BLOCKED',
-            exitCode: 75,
+            exitCode: 69,
         });
     });
 
@@ -48,7 +48,7 @@ describe('Product Hunt browser commands', () => {
             category: 'developer-tools',
         })).rejects.toMatchObject({
             code: 'SITE_BLOCKED',
-            exitCode: 75,
+            exitCode: 69,
         });
     });
 

--- a/clis/producthunt/browser-commands.test.js
+++ b/clis/producthunt/browser-commands.test.js
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@agentrhq/webcmd/registry';
+import './hot.js';
+import './browse.js';
+
+function pageMock({ evaluations, captureError } = {}) {
+    const queue = [...(evaluations ?? [])];
+    return {
+        goto: async () => undefined,
+        wait: async () => undefined,
+        installInterceptor: async () => undefined,
+        waitForCapture: async () => {
+            if (captureError) throw captureError;
+        },
+        evaluate: async () => queue.shift(),
+    };
+}
+
+const challenge = {
+    title: 'Just a moment...',
+    body: 'Performing security verification before proceeding',
+    cloudflare: true,
+};
+const accessible = {
+    title: 'Product Hunt',
+    body: 'Discover your next favorite thing',
+    cloudflare: false,
+};
+
+describe('Product Hunt browser commands', () => {
+    it.each([
+        ['producthunt/hot', {}],
+        ['producthunt/browse', { category: 'developer-tools' }],
+    ])('%s reports verification pages as SITE_BLOCKED', async (name, args) => {
+        const command = getRegistry().get(name);
+
+        await expect(command.func(pageMock({ evaluations: [challenge] }), args)).rejects.toMatchObject({
+            code: 'SITE_BLOCKED',
+            exitCode: 75,
+        });
+    });
+
+    it('reports a challenge when category capture fails on the verification page', async () => {
+        const command = getRegistry().get('producthunt/browse');
+        const captureError = new Error('No network capture within 5s');
+
+        await expect(command.func(pageMock({ evaluations: [challenge], captureError }), {
+            category: 'developer-tools',
+        })).rejects.toMatchObject({
+            code: 'SITE_BLOCKED',
+            exitCode: 75,
+        });
+    });
+
+    it.each([
+        ['producthunt/hot', {}, 'Could not retrieve Product Hunt top posts'],
+        ['producthunt/browse', { category: 'developer-tools' }, 'No products found for category'],
+    ])('%s preserves NO_DATA for an accessible empty page', async (name, args, message) => {
+        const command = getRegistry().get(name);
+
+        await expect(command.func(pageMock({ evaluations: [accessible, []] }), args)).rejects.toMatchObject({
+            code: 'NO_DATA',
+            message: expect.stringContaining(message),
+        });
+    });
+});

--- a/clis/producthunt/hot.js
+++ b/clis/producthunt/hot.js
@@ -5,7 +5,7 @@
  */
 import { cli, Strategy } from '@agentrhq/webcmd/registry';
 import { CliError } from '@agentrhq/webcmd/errors';
-import { pickVoteCount } from './utils.js';
+import { assertProductHuntAccessible, pickVoteCount } from './utils.js';
 cli({
     site: 'producthunt',
     name: 'hot',
@@ -21,6 +21,7 @@ cli({
         const count = Math.min(Number(args.limit) || 20, 50);
         await page.goto('https://www.producthunt.com');
         await page.wait(2);
+        await assertProductHuntAccessible(page);
         const domItems = await page.evaluate(`
       (() => {
         const seen = new Set();

--- a/clis/producthunt/utils.js
+++ b/clis/producthunt/utils.js
@@ -42,7 +42,7 @@ export async function assertProductHuntAccessible(page) {
         'SITE_BLOCKED',
         'Product Hunt served a security verification page',
         'Complete permitted verification in the active browser when available, then retry. Webcmd will not bypass site verification.',
-        EXIT_CODES.TEMPFAIL,
+        EXIT_CODES.SERVICE_UNAVAIL,
     );
 }
 

--- a/clis/producthunt/utils.js
+++ b/clis/producthunt/utils.js
@@ -1,6 +1,8 @@
 /**
  * Product Hunt shared helpers.
  */
+import { CliError, EXIT_CODES } from '@agentrhq/webcmd/errors';
+
 export const PRODUCTHUNT_CATEGORY_SLUGS = [
     'ai-agents',
     'ai-coding-agents',
@@ -19,6 +21,31 @@ export const PRODUCTHUNT_CATEGORY_SLUGS = [
     'engineering-development',
 ];
 const UA = 'Mozilla/5.0 (compatible; webcmd/1.0)';
+
+export function isProductHuntVerificationPage(value) {
+    const title = String(value?.title ?? '');
+    const body = String(value?.body ?? '');
+    return value?.cloudflare === true
+        || /just a moment|security verification/i.test(title)
+        || /performing security verification|verify you are human|enable javascript and cookies/i.test(body);
+}
+
+export async function assertProductHuntAccessible(page) {
+    const state = await page.evaluate(`(() => ({
+      title: document.title || '',
+      body: (document.body?.innerText || '').slice(0, 2000),
+      cloudflare: !!document.querySelector('[id^="cf-"], [class*="cf-challenge"]')
+    }))()`);
+    if (!isProductHuntVerificationPage(state))
+        return;
+    throw new CliError(
+        'SITE_BLOCKED',
+        'Product Hunt served a security verification page',
+        'Complete permitted verification in the active browser when available, then retry. Webcmd will not bypass site verification.',
+        EXIT_CODES.TEMPFAIL,
+    );
+}
+
 /**
  * Fetch Product Hunt Atom RSS feed.
  * @param category  Optional category slug (e.g. "ai", "developer-tools")

--- a/clis/producthunt/utils.test.js
+++ b/clis/producthunt/utils.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { parseFeed, pickVoteCount, PRODUCTHUNT_CATEGORY_SLUGS } from './utils.js';
+import * as productHuntUtils from './utils.js';
 const SAMPLE_ATOM = `<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
   <title>Product Hunt</title>
@@ -60,5 +61,12 @@ describe('parseFeed', () => {
     it('shares category slugs across commands', () => {
         expect(PRODUCTHUNT_CATEGORY_SLUGS).toContain('developer-tools');
         expect(PRODUCTHUNT_CATEGORY_SLUGS).toContain('ai-agents');
+    });
+    it('recognizes explicit Product Hunt verification signals', () => {
+        expect(productHuntUtils.isProductHuntVerificationPage).toBeTypeOf('function');
+        expect(productHuntUtils.isProductHuntVerificationPage({ title: 'Just a moment...', body: '', cloudflare: false })).toBe(true);
+        expect(productHuntUtils.isProductHuntVerificationPage({ title: 'Product Hunt', body: 'Performing security verification', cloudflare: false })).toBe(true);
+        expect(productHuntUtils.isProductHuntVerificationPage({ title: 'Product Hunt', body: '', cloudflare: true })).toBe(true);
+        expect(productHuntUtils.isProductHuntVerificationPage({ title: 'Product Hunt', body: 'Discover your next favorite thing', cloudflare: false })).toBe(false);
     });
 });

--- a/src/hosted/client.test.ts
+++ b/src/hosted/client.test.ts
@@ -108,6 +108,72 @@ describe('HostedClient', () => {
     expect(requests).toEqual([{ url: 'https://api.example.com/v1/manifest', authorization: 'Bearer wcmd_live_test' }]);
   });
 
+  it('accepts boolean freshPage command metadata', async () => {
+    const client = new HostedClient({
+      apiBaseUrl: 'https://api.example.com',
+      apiKey: 'key',
+      fetchImpl: async () => new Response(JSON.stringify({
+        ok: true,
+        manifest: {
+          userId: 'user_demo',
+          metadata: {
+            contractSchemaVersion: 1,
+            webcmdPackageVersion: '0.3.0',
+            generatedAt: 'now',
+          },
+          commands: [{
+            site: 'district',
+            name: 'checkout',
+            command: 'district/checkout',
+            description: 'Checkout',
+            access: 'write',
+            strategy: 'UI',
+            browser: true,
+            args: [],
+            columns: [],
+            freshPage: true,
+          }],
+        },
+      }), { status: 200 }),
+    });
+
+    await expect(client.getManifest()).resolves.toMatchObject({
+      commands: [expect.objectContaining({ freshPage: true })],
+    });
+  });
+
+  it('rejects non-boolean freshPage command metadata', async () => {
+    const client = new HostedClient({
+      apiBaseUrl: 'https://api.example.com',
+      apiKey: 'key',
+      fetchImpl: async () => new Response(JSON.stringify({
+        ok: true,
+        manifest: {
+          userId: 'user_demo',
+          metadata: {
+            contractSchemaVersion: 1,
+            webcmdPackageVersion: '0.3.0',
+            generatedAt: 'now',
+          },
+          commands: [{
+            site: 'district',
+            name: 'checkout',
+            command: 'district/checkout',
+            description: 'Checkout',
+            access: 'write',
+            strategy: 'UI',
+            browser: true,
+            args: [],
+            columns: [],
+            freshPage: 'yes',
+          }],
+        },
+      }), { status: 200 }),
+    });
+
+    await expect(client.getManifest()).rejects.toMatchObject({ code: 'HOSTED_PROTOCOL' });
+  });
+
   it('parses hosted profile rows without provider identifiers', async () => {
     const client = new HostedClient({
       apiBaseUrl: 'https://api.example.com',

--- a/src/hosted/client.ts
+++ b/src/hosted/client.ts
@@ -387,7 +387,7 @@ function isHostedManifestCommand(value: unknown): boolean {
   if (!hasOnlyKeys(value, [
     'site', 'name', 'aliases', 'command', 'description', 'access', 'example', 'domain', 'strategy', 'browser',
     'args', 'columns', 'pipeline', 'defaultFormat', 'type', 'modulePath', 'sourceFile', 'navigateBefore',
-    'siteSession', 'defaultWindowMode', 'adapterPackageId', 'adapterPackageName', 'adapterPackageVersion',
+    'siteSession', 'freshPage', 'defaultWindowMode', 'adapterPackageId', 'adapterPackageName', 'adapterPackageVersion',
   ])) return false;
   if (typeof value.site !== 'string' || typeof value.name !== 'string' || typeof value.command !== 'string') return false;
   if (typeof value.description !== 'string' || typeof value.access !== 'string' || typeof value.strategy !== 'string') return false;
@@ -401,6 +401,7 @@ function isHostedManifestCommand(value: unknown): boolean {
   for (const key of ['type', 'modulePath', 'sourceFile', 'siteSession', 'defaultWindowMode', 'adapterPackageId', 'adapterPackageName', 'adapterPackageVersion']) {
     if (value[key] !== undefined && typeof value[key] !== 'string') return false;
   }
+  if (value.freshPage !== undefined && typeof value.freshPage !== 'boolean') return false;
   return value.navigateBefore === undefined || typeof value.navigateBefore === 'boolean' || typeof value.navigateBefore === 'string';
 }
 

--- a/src/hosted/types.ts
+++ b/src/hosted/types.ts
@@ -31,6 +31,7 @@ export interface HostedCommand extends CommandSurfaceMetadata {
   columns: string[];
   domain?: string | null;
   defaultFormat?: string | null;
+  freshPage?: boolean;
 }
 
 export interface HostedManifest {


### PR DESCRIPTION
## Summary

- detect Product Hunt verification pages and return typed `SITE_BLOCKED`
- use service-unavailable exit semantics so hosted responses survive the edge
- accept and validate boolean `freshPage` metadata from hosted manifests

## Tests

- `npm run typecheck`
- `npm test` — 397 files passed, 4,810 passed, 1 skipped
- `WEBCMD_CONFIG_DIR=/tmp/webcmd-e2e-local-cloud-parity-20260716 npm run test:e2e` — 68 passed
- `npm run build`