### PR TITLE
feat: add skills add and remove commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ None.
 
 ### Highlights
 
-- Bundled Webcmd skills are now much easier to install and refresh through `webcmd skills install` and `webcmd skills update`.
+- Bundled Webcmd skills are now much easier to add and refresh through `webcmd skills add` and `webcmd skills update`.
 - Persistent-session commands gained a cleaner authoring model with `freshPage`, which keeps login/profile state while avoiding stale page state.
 - District booking support moved from local-only adapters into the repo.
 

--- a/README.md
+++ b/README.md
@@ -133,10 +133,12 @@ Webcmd is designed to be driven by coding agents such as Codex, Claude Code, Cur
 Install Webcmd skills into your agent environment:
 
 ```bash
-webcmd skills install
+webcmd skills add
 ```
 
 The installer asks whether to install globally or locally, then asks for the coding agent (`agents`, `codex`, `claude`) or a custom skills path. For scripts, pass flags such as `--scope project --provider codex` or `--path ./my-skills`.
+
+Remove Webcmd skill symlinks from all supported global and current-project locations with `webcmd skills remove`. Pass `--path ./my-skills` to include a custom directory. The previous `webcmd skills install` command remains available as an alias for `add`.
 
 ### Which skill to use
 

--- a/README.md
+++ b/README.md
@@ -128,17 +128,17 @@ Agents usually want `-f json`; humans usually want table (default) or yaml.
 
 Webcmd is designed to be driven by coding agents such as Codex, Claude Code, Cursor, and similar tools.
 
-## Install skills (also refreshes existing installs)
+## Add skills (also refreshes existing links)
 
-Install Webcmd skills into your agent environment:
+Add Webcmd skills to your agent environment:
 
 ```bash
 webcmd skills add
 ```
 
-The installer asks whether to install globally or locally, then asks for the coding agent (`agents`, `codex`, `claude`) or a custom skills path. For scripts, pass flags such as `--scope project --provider codex` or `--path ./my-skills`.
+The command asks whether to add globally or locally, then asks for the coding agent (`agents`, `codex`, `claude`) or a custom skills path. For scripts, pass flags such as `--scope project --provider codex` or `--path ./my-skills`.
 
-Remove Webcmd skill symlinks from all supported global and current-project locations with `webcmd skills remove`. Pass `--path ./my-skills` to include a custom directory. The previous `webcmd skills install` command remains available as an alias for `add`.
+Remove Webcmd skill symlinks from all supported global and current-project locations with `webcmd skills remove`. Pass `--path ./my-skills` to include a custom directory.
 
 ### Which skill to use
 
@@ -319,8 +319,8 @@ Common paths:
 | `~/.webcmd/clis/` | Private adapters. |
 | `~/.webcmd/cache/browser-network/` | Cached browser network captures. |
 | `~/.webcmd/external-clis.yaml` | User external CLI registry entries. |
-| `~/.agents/skills/` | Common global skills install target for agent skill managers. |
-| `.agents/skills/` | Common workspace-local skills install target. |
+| `~/.agents/skills/` | Common global skills directory for agent skill managers. |
+| `.agents/skills/` | Common workspace-local skills directory. |
 
 ## Troubleshooting
 

--- a/docs/plugins-and-skills.mdx
+++ b/docs/plugins-and-skills.mdx
@@ -78,9 +78,9 @@ Prompt example:
 Use the Webcmd adapter-author skill to create this command. If the site changes while testing, use the autofix workflow before finishing.
 ```
 
-## Installing Skills for Agents
+## Adding Skills for Agents
 
-Install the bundled Webcmd skills and answer the prompts for global/local scope and agent target.
+Add the bundled Webcmd skills and answer the prompts for global/local scope and agent target.
 
 ```bash
 webcmd skills add
@@ -88,7 +88,7 @@ webcmd skills add
 
 For automation, pass `--scope`, `--provider`, or `--path`.
 
-Run `webcmd skills remove` to remove the bundled skill symlinks from supported global and current-project locations. Pass `--path` to include a custom directory; `webcmd skills install` remains an alias for `add`.
+Run `webcmd skills remove` to remove the bundled skill symlinks from supported global and current-project locations. Pass `--path` to include a custom directory.
 
 ```text
 Before working on this site, load the Webcmd usage and adapter-author skills. Prefer an existing adapter if one exists.

--- a/docs/plugins-and-skills.mdx
+++ b/docs/plugins-and-skills.mdx
@@ -83,10 +83,12 @@ Use the Webcmd adapter-author skill to create this command. If the site changes 
 Install the bundled Webcmd skills and answer the prompts for global/local scope and agent target.
 
 ```bash
-webcmd skills install
+webcmd skills add
 ```
 
 For automation, pass `--scope`, `--provider`, or `--path`.
+
+Run `webcmd skills remove` to remove the bundled skill symlinks from supported global and current-project locations. Pass `--path` to include a custom directory; `webcmd skills install` remains an alias for `add`.
 
 ```text
 Before working on this site, load the Webcmd usage and adapter-author skills. Prefer an existing adapter if one exists.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -81,11 +81,11 @@ describe('createProgram root help descriptions', () => {
     expect(descriptionFor(program, 'external')).toBe('install, list, register');
   });
 
-  it('exposes add and remove while keeping install as an alias', () => {
+  it('exposes add and remove without an install command', () => {
     const skills = createProgram('', '').commands.find((command) => command.name() === 'skills')!;
 
     expect(skills.commands.map((command) => command.name())).toEqual(['list', 'add', 'update', 'remove']);
-    expect(skills.commands.find((command) => command.name() === 'add')?.aliases()).toContain('install');
+    expect(skills.commands.find((command) => command.name() === 'add')?.aliases()).toEqual([]);
   });
 
   it('renders auth namespace structured help', () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -81,6 +81,13 @@ describe('createProgram root help descriptions', () => {
     expect(descriptionFor(program, 'external')).toBe('install, list, register');
   });
 
+  it('exposes add and remove while keeping install as an alias', () => {
+    const skills = createProgram('', '').commands.find((command) => command.name() === 'skills')!;
+
+    expect(skills.commands.map((command) => command.name())).toEqual(['list', 'add', 'update', 'remove']);
+    expect(skills.commands.find((command) => command.name() === 'add')?.aliases()).toContain('install');
+  });
+
   it('renders auth namespace structured help', () => {
     const argv = process.argv;
     try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ import { render as renderOutput } from './output.js';
 import { PKG_VERSION } from './version.js';
 import { printCompletionScript } from './completion.js';
 import { loadExternalClis, executeExternalCli, installExternalCli, registerExternalCli, isBinaryInstalled, formatExternalCliLabel } from './external.js';
-import { installWebcmdSkill, listWebcmdSkills, removeWebcmdSkills, updateWebcmdSkill, type WebcmdSkillInstallResult } from './skills.js';
+import { addWebcmdSkills, listWebcmdSkills, removeWebcmdSkills, updateWebcmdSkill, type WebcmdSkillAddResult } from './skills.js';
 import { registerAllCommands } from './commanderAdapter.js';
 import { buildRootHelpPresentation, classifyAdapter, installCommanderNamespaceStructuredHelp, installRootPresentationHelp, leadingPositionalFromUsage, rootHelpData, type RootAdapterGroups } from './help.js';
 import { EXIT_CODES, getErrorMessage, BrowserConnectError, CliError, ArgumentError } from './errors.js';
@@ -89,16 +89,16 @@ type SkillLinkCommandOptions = {
   json?: boolean;
 };
 
-function isInteractiveInstall(opts: SkillLinkCommandOptions): boolean {
+function isInteractiveSkillAdd(opts: SkillLinkCommandOptions): boolean {
   return !opts.json && process.stdin.isTTY === true && process.stdout.isTTY === true;
 }
 
-async function resolveSkillInstallOptions(opts: SkillLinkCommandOptions): Promise<SkillLinkCommandOptions> {
-  if (!isInteractiveInstall(opts)) return opts;
+async function resolveSkillAddOptions(opts: SkillLinkCommandOptions): Promise<SkillLinkCommandOptions> {
+  if (!isInteractiveSkillAdd(opts)) return opts;
 
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   try {
-    const scope = opts.scope ?? await choosePrompt(rl, 'Where should Webcmd install skills?', [
+    const scope = opts.scope ?? await choosePrompt(rl, 'Where should Webcmd add skills?', [
       { key: '1', label: 'Global', value: 'user', aliases: ['global', 'user', 'g'] },
       { key: '2', label: 'Local project', value: 'project', aliases: ['local', 'project', 'l'] },
     ], '1');
@@ -139,7 +139,7 @@ async function nonEmptyPrompt(rl: readline.Interface, question: string): Promise
   }
 }
 
-async function handleSkillLinkCommand(action: () => WebcmdSkillInstallResult | Promise<WebcmdSkillInstallResult>, json: boolean, verb: string): Promise<void> {
+async function handleSkillLinkCommand(action: () => WebcmdSkillAddResult | Promise<WebcmdSkillAddResult>, json: boolean, verb: string): Promise<void> {
   try {
     const result = await action();
     if (json) {
@@ -871,24 +871,23 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
 
   skillsCmd
     .command('add')
-    .alias('install')
     .description('Add bundled Webcmd skills to an agent skills folder')
     .option('-p, --provider <provider>', 'Agent provider: agents, codex, claude')
-    .option('-s, --scope <scope>', 'Install scope: user/global or project/local')
+    .option('-s, --scope <scope>', 'Add scope: user/global or project/local')
     .option('--path <path>', 'Custom agent skills directory')
     .option('--json', 'Output a JSON envelope', false)
     .action(async (opts) => {
       await handleSkillLinkCommand(async () => {
-        const resolved = await resolveSkillInstallOptions(opts);
+        const resolved = await resolveSkillAddOptions(opts);
         if (resolved.provider === 'custom' && !resolved.path) {
           throw new ArgumentError('Custom skill provider requires --path.', 'Pass --path <skills-dir> or run interactively.');
         }
-        return installWebcmdSkill({
+        return addWebcmdSkills({
           provider: resolved.provider,
           scope: resolved.scope,
           customPath: resolved.path,
         });
-      }, opts.json, 'installed');
+      }, opts.json, 'added');
     });
 
   skillsCmd

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ import { render as renderOutput } from './output.js';
 import { PKG_VERSION } from './version.js';
 import { printCompletionScript } from './completion.js';
 import { loadExternalClis, executeExternalCli, installExternalCli, registerExternalCli, isBinaryInstalled, formatExternalCliLabel } from './external.js';
-import { installWebcmdSkill, listWebcmdSkills, updateWebcmdSkill, type WebcmdSkillInstallResult } from './skills.js';
+import { installWebcmdSkill, listWebcmdSkills, removeWebcmdSkills, updateWebcmdSkill, type WebcmdSkillInstallResult } from './skills.js';
 import { registerAllCommands } from './commanderAdapter.js';
 import { buildRootHelpPresentation, classifyAdapter, installCommanderNamespaceStructuredHelp, installRootPresentationHelp, leadingPositionalFromUsage, rootHelpData, type RootAdapterGroups } from './help.js';
 import { EXIT_CODES, getErrorMessage, BrowserConnectError, CliError, ArgumentError } from './errors.js';
@@ -150,6 +150,22 @@ async function handleSkillLinkCommand(action: () => WebcmdSkillInstallResult | P
     for (const skill of result.skills) {
       console.log(`${skill.name}: ${skill.destination ? `${skill.destination} -> ` : ''}${skill.stableLink}`);
     }
+  } catch (err) {
+    console.error(`Error: ${getErrorMessage(err)}`);
+    if (err instanceof CliError && err.hint) console.error(`Hint: ${err.hint}`);
+    process.exitCode = err instanceof CliError ? err.exitCode : EXIT_CODES.GENERIC_ERROR;
+  }
+}
+
+function handleSkillRemoveCommand(customPath: string | undefined, json: boolean): void {
+  try {
+    const result = removeWebcmdSkills({ customPath });
+    if (json) {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+    console.log(`Webcmd skill links removed: ${result.removed.length}`);
+    for (const linkPath of result.removed) console.log(linkPath);
   } catch (err) {
     console.error(`Error: ${getErrorMessage(err)}`);
     if (err instanceof CliError && err.hint) console.error(`Hint: ${err.hint}`);
@@ -826,7 +842,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
 
   const skillsCmd = program
     .command('skills')
-    .description('List, install, and update bundled Webcmd skills')
+    .description('List, add, update, and remove bundled Webcmd skills')
     .action(() => {
       const rows = listWebcmdSkills();
       renderOutput(rows, {
@@ -854,8 +870,9 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     });
 
   skillsCmd
-    .command('install')
-    .description('Install bundled Webcmd skills into an agent skills folder')
+    .command('add')
+    .alias('install')
+    .description('Add bundled Webcmd skills to an agent skills folder')
     .option('-p, --provider <provider>', 'Agent provider: agents, codex, claude')
     .option('-s, --scope <scope>', 'Install scope: user/global or project/local')
     .option('--path <path>', 'Custom agent skills directory')
@@ -888,6 +905,13 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         customPath: opts.path,
       }), opts.json, 'updated');
     });
+
+  skillsCmd
+    .command('remove')
+    .description('Remove bundled Webcmd skill symlinks from supported locations')
+    .option('--path <path>', 'Also remove links from a custom agent skills directory')
+    .option('--json', 'Output a JSON envelope', false)
+    .action((opts) => handleSkillRemoveCommand(opts.path, opts.json));
 
   const authCmd = registerAuthCommands(program);
 

--- a/src/skills.test.ts
+++ b/src/skills.test.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 import yaml from 'js-yaml';
 import { describe, expect, it } from 'vitest';
 import { ArgumentError } from './errors.js';
-import { installWebcmdSkill, listWebcmdSkills, removeWebcmdSkills, updateWebcmdSkill } from './skills.js';
+import { addWebcmdSkills, listWebcmdSkills, removeWebcmdSkills, updateWebcmdSkill } from './skills.js';
 
 function makePackageRoot(label = 'current'): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), `webcmd-skills-${label}-`));
@@ -89,20 +89,20 @@ describe('webcmd skills content', () => {
     ]);
   });
 
-  it('installs bundled skills once and refreshes them after package updates', () => {
+  it('adds bundled skills once and refreshes them after package updates', () => {
     const firstRoot = makePackageRoot('first');
     const secondRoot = makePackageRoot('second');
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-home-'));
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-project-'));
 
-    const installed = installWebcmdSkill({ packageRoot: firstRoot, homeDir, cwd, provider: 'codex', scope: 'project' });
+    const added = addWebcmdSkills({ packageRoot: firstRoot, homeDir, cwd, provider: 'codex', scope: 'project' });
 
-    expect(installed).toMatchObject({
+    expect(added).toMatchObject({
       provider: 'codex',
       scope: 'project',
     });
-    expect(installed.skills.map((skill) => skill.name)).toEqual(['smart-search', 'webcmd-autofix', 'webcmd-browser']);
-    for (const skill of installed.skills) {
+    expect(added.skills.map((skill) => skill.name)).toEqual(['smart-search', 'webcmd-autofix', 'webcmd-browser']);
+    for (const skill of added.skills) {
       expect(skill.source).toBe(path.join(firstRoot, 'skills', skill.name));
       expect(skill.stableLink).toBe(path.join(homeDir, '.webcmd', 'skills', skill.name));
       expect(skill.destination).toBe(path.join(cwd, '.codex', 'skills', skill.name));
@@ -112,25 +112,25 @@ describe('webcmd skills content', () => {
     const updated = updateWebcmdSkill({ packageRoot: secondRoot, homeDir });
 
     expect(updated.skills.every((skill) => skill.destination === undefined)).toBe(true);
-    for (const skill of installed.skills) {
+    for (const skill of added.skills) {
       expect(real(skill.destination!)).toBe(real(path.join(secondRoot, 'skills', skill.name)));
     }
   });
 
-  it('installs bundled skills into a custom skills directory', () => {
+  it('adds bundled skills into a custom skills directory', () => {
     const packageRoot = makePackageRoot();
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-home-'));
     const customPath = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-custom-skills-'));
 
-    const installed = installWebcmdSkill({ packageRoot, homeDir, customPath });
+    const added = addWebcmdSkills({ packageRoot, homeDir, customPath });
 
-    expect(installed.provider).toBeUndefined();
-    expect(installed.skills.map((skill) => skill.destination)).toEqual([
+    expect(added.provider).toBeUndefined();
+    expect(added.skills.map((skill) => skill.destination)).toEqual([
       path.join(customPath, 'smart-search'),
       path.join(customPath, 'webcmd-autofix'),
       path.join(customPath, 'webcmd-browser'),
     ]);
-    for (const skill of installed.skills) {
+    for (const skill of added.skills) {
       expect(real(skill.destination!)).toBe(real(skill.source));
     }
   });
@@ -151,10 +151,10 @@ describe('webcmd skills content', () => {
     const customPath = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-custom-skills-'));
 
     for (const provider of ['agents', 'codex', 'claude']) {
-      installWebcmdSkill({ packageRoot, homeDir, cwd, provider, scope: 'user' });
-      installWebcmdSkill({ packageRoot, homeDir, cwd, provider, scope: 'project' });
+      addWebcmdSkills({ packageRoot, homeDir, cwd, provider, scope: 'user' });
+      addWebcmdSkills({ packageRoot, homeDir, cwd, provider, scope: 'project' });
     }
-    installWebcmdSkill({ packageRoot, homeDir, cwd, customPath });
+    addWebcmdSkills({ packageRoot, homeDir, cwd, customPath });
 
     const result = removeWebcmdSkills({ packageRoot, homeDir, cwd, customPath });
 
@@ -169,12 +169,12 @@ describe('webcmd skills content', () => {
     const packageRoot = makePackageRoot();
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-home-'));
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-project-'));
-    const installed = installWebcmdSkill({ packageRoot, homeDir, cwd, provider: 'agents', scope: 'user' });
+    const added = addWebcmdSkills({ packageRoot, homeDir, cwd, provider: 'agents', scope: 'user' });
     const blocker = path.join(cwd, '.codex', 'skills', 'smart-search');
     fs.mkdirSync(blocker, { recursive: true });
 
     expect(() => removeWebcmdSkills({ packageRoot, homeDir, cwd })).toThrow(ArgumentError);
-    expect(fs.lstatSync(installed.skills[0].destination!).isSymbolicLink()).toBe(true);
+    expect(fs.lstatSync(added.skills[0].destination!).isSymbolicLink()).toBe(true);
     expect(fs.lstatSync(blocker).isDirectory()).toBe(true);
   });
 });

--- a/src/skills.test.ts
+++ b/src/skills.test.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 import yaml from 'js-yaml';
 import { describe, expect, it } from 'vitest';
 import { ArgumentError } from './errors.js';
-import { installWebcmdSkill, listWebcmdSkills, updateWebcmdSkill } from './skills.js';
+import { installWebcmdSkill, listWebcmdSkills, removeWebcmdSkills, updateWebcmdSkill } from './skills.js';
 
 function makePackageRoot(label = 'current'): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), `webcmd-skills-${label}-`));
@@ -142,5 +142,39 @@ describe('webcmd skills content', () => {
     fs.mkdirSync(stablePath, { recursive: true });
 
     expect(() => updateWebcmdSkill({ packageRoot, homeDir })).toThrow(ArgumentError);
+  });
+
+  it('removes bundled skill links from every supported location', () => {
+    const packageRoot = makePackageRoot();
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-home-'));
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-project-'));
+    const customPath = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-custom-skills-'));
+
+    for (const provider of ['agents', 'codex', 'claude']) {
+      installWebcmdSkill({ packageRoot, homeDir, cwd, provider, scope: 'user' });
+      installWebcmdSkill({ packageRoot, homeDir, cwd, provider, scope: 'project' });
+    }
+    installWebcmdSkill({ packageRoot, homeDir, cwd, customPath });
+
+    const result = removeWebcmdSkills({ packageRoot, homeDir, cwd, customPath });
+
+    expect(result.removed).toHaveLength(24);
+    for (const linkPath of result.removed) {
+      expect(() => fs.lstatSync(linkPath)).toThrow();
+    }
+    expect(removeWebcmdSkills({ packageRoot, homeDir, cwd, customPath })).toEqual({ removed: [] });
+  });
+
+  it('refuses removal before deleting any links when a destination is not a symlink', () => {
+    const packageRoot = makePackageRoot();
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-home-'));
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-project-'));
+    const installed = installWebcmdSkill({ packageRoot, homeDir, cwd, provider: 'agents', scope: 'user' });
+    const blocker = path.join(cwd, '.codex', 'skills', 'smart-search');
+    fs.mkdirSync(blocker, { recursive: true });
+
+    expect(() => removeWebcmdSkills({ packageRoot, homeDir, cwd })).toThrow(ArgumentError);
+    expect(fs.lstatSync(installed.skills[0].destination!).isSymbolicLink()).toBe(true);
+    expect(fs.lstatSync(blocker).isDirectory()).toBe(true);
   });
 });

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -37,6 +37,10 @@ export interface WebcmdSkillInstallResult {
   skills: WebcmdSkillLink[];
 }
 
+export interface WebcmdSkillRemoveResult {
+  removed: string[];
+}
+
 interface SkillFrontmatter {
   name?: unknown;
   description?: unknown;
@@ -88,6 +92,36 @@ export function updateWebcmdSkill(options: WebcmdSkillInstallOptions = {}): Webc
       return { ...skill, destination };
     }),
   };
+}
+
+export function removeWebcmdSkills(options: WebcmdSkillInstallOptions = {}): WebcmdSkillRemoveResult {
+  const homeDir = options.homeDir ?? os.homedir();
+  const cwd = options.cwd ?? process.cwd();
+  const roots = new Set([
+    ...['.agents', '.codex', '.claude'].flatMap((dir) => [
+      path.join(homeDir, dir, 'skills'),
+      path.join(cwd, dir, 'skills'),
+    ]),
+    ...(options.customPath === undefined ? [] : [expandHomePath(options.customPath)]),
+    path.join(homeDir, '.webcmd', 'skills'),
+  ]);
+  const skills = listWebcmdSkills(options.packageRoot);
+  const removed: string[] = [];
+
+  for (const root of roots) {
+    for (const skill of skills) {
+      const linkPath = path.join(root, skill.name);
+      const current = safeLstat(linkPath);
+      if (!current) continue;
+      if (!current.isSymbolicLink()) {
+        throw new ArgumentError(`Refusing to remove non-symlink path: ${linkPath}`, 'Remove it manually if it is no longer needed.');
+      }
+      removed.push(linkPath);
+    }
+  }
+
+  for (const linkPath of removed) fs.unlinkSync(linkPath);
+  return { removed };
 }
 
 function updateStableSkillLinks(options: WebcmdSkillInstallOptions): WebcmdSkillLink[] {

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -15,7 +15,7 @@ export interface WebcmdSkillInfo {
   path: string;
 }
 
-export interface WebcmdSkillInstallOptions {
+export interface WebcmdSkillOptions {
   provider?: string;
   scope?: string;
   customPath?: string;
@@ -31,7 +31,7 @@ export interface WebcmdSkillLink {
   destination?: string;
 }
 
-export interface WebcmdSkillInstallResult {
+export interface WebcmdSkillAddResult {
   provider?: SkillProvider;
   scope?: SkillScope;
   skills: WebcmdSkillLink[];
@@ -65,7 +65,7 @@ export function listWebcmdSkills(packageRoot?: string): WebcmdSkillInfo[] {
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export function installWebcmdSkill(options: WebcmdSkillInstallOptions = {}): WebcmdSkillInstallResult {
+export function addWebcmdSkills(options: WebcmdSkillOptions = {}): WebcmdSkillAddResult {
   const provider = options.customPath === undefined ? normalizeProvider(options.provider) : undefined;
   const scope = normalizeScope(options.scope);
   const skills = updateStableSkillLinks(options)
@@ -77,7 +77,7 @@ export function installWebcmdSkill(options: WebcmdSkillInstallOptions = {}): Web
   return { provider, scope, skills };
 }
 
-export function updateWebcmdSkill(options: WebcmdSkillInstallOptions = {}): WebcmdSkillInstallResult {
+export function updateWebcmdSkill(options: WebcmdSkillOptions = {}): WebcmdSkillAddResult {
   const skills = updateStableSkillLinks(options);
   if (options.provider === undefined && options.scope === undefined && options.customPath === undefined) return { skills };
 
@@ -94,7 +94,7 @@ export function updateWebcmdSkill(options: WebcmdSkillInstallOptions = {}): Webc
   };
 }
 
-export function removeWebcmdSkills(options: WebcmdSkillInstallOptions = {}): WebcmdSkillRemoveResult {
+export function removeWebcmdSkills(options: WebcmdSkillOptions = {}): WebcmdSkillRemoveResult {
   const homeDir = options.homeDir ?? os.homedir();
   const cwd = options.cwd ?? process.cwd();
   const roots = new Set([
@@ -124,7 +124,7 @@ export function removeWebcmdSkills(options: WebcmdSkillInstallOptions = {}): Web
   return { removed };
 }
 
-function updateStableSkillLinks(options: WebcmdSkillInstallOptions): WebcmdSkillLink[] {
+function updateStableSkillLinks(options: WebcmdSkillOptions): WebcmdSkillLink[] {
   const skillsRoot = getSkillsRoot(options.packageRoot);
   const skills = listWebcmdSkills(options.packageRoot);
   if (skills.length === 0) {
@@ -139,7 +139,7 @@ function updateStableSkillLinks(options: WebcmdSkillInstallOptions): WebcmdSkill
   });
 }
 
-function destinationFor(name: string, provider: SkillProvider | undefined, scope: SkillScope, options: WebcmdSkillInstallOptions): string {
+function destinationFor(name: string, provider: SkillProvider | undefined, scope: SkillScope, options: WebcmdSkillOptions): string {
   if (options.customPath !== undefined) return path.join(expandHomePath(options.customPath), name);
   const base = scope === 'project' ? options.cwd ?? process.cwd() : options.homeDir ?? os.homedir();
   const agentDir = provider === 'claude' ? '.claude' : provider === 'codex' ? '.codex' : '.agents';


### PR DESCRIPTION
Closes #68

## Problem

Bundled skills could be added and refreshed, but there was no safe inverse command. The command surface now uses the explicit `add`/`remove` pair.

## Changes

- make `webcmd skills add` the only add command
- add `webcmd skills remove` for all deterministic supported locations: global and current-project `.agents`, `.codex`, and `.claude` directories, an optional custom path, and stable `~/.webcmd/skills` links
- preflight every matching path and refuse non-symlinks before deleting anything
- keep repeated removal idempotent
- update skill-specific code terminology and documentation

## Verification

- `npm run typecheck`
- `npm test` — 399 files passed, 4,888 tests passed, 1 skipped
- `npm run build`
- built-CLI smoke: help exposes only `add`, `list`, `remove`, and `update`; `add` created 7 bundled skills; `remove` deleted 14 provider/stable links; the removed command exits nonzero