### PR TITLE
fix: preserve hosted routing for local-only commands

### DIFF
--- a/src/hosted/main-lifecycle.test.ts
+++ b/src/hosted/main-lifecycle.test.ts
@@ -92,17 +92,47 @@ describe('hosted CLI process lifecycle', () => {
     expect(result.stdout).toContain('Local-only commands:');
     await expect(readFile(fixture.discoverySentinel, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
   }, 20_000);
+
+  it('runs skills install locally without contacting Cloud when hosted mode is configured', async () => {
+    const fixture = await createHostedFixture('success');
+    const installDir = path.join(fixture.root, 'agent-skills');
+
+    const result = await runCli(['skills', 'install', '--path', installDir, '--json'], fixture.env);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    const body = JSON.parse(result.stdout) as {
+      skills: Array<{ name: string; stableLink: string; destination?: string }>;
+    };
+    expect(body.skills.map(skill => skill.name)).toEqual([
+      'smart-search',
+      'webcmd-adapter-author',
+      'webcmd-autofix',
+      'webcmd-browser',
+      'webcmd-browser-sitemap',
+      'webcmd-sitemap-author',
+      'webcmd-usage',
+    ]);
+    expect(body.skills.every(skill => skill.destination?.startsWith(installDir))).toBe(true);
+    await expect(readFile(path.join(installDir, 'webcmd-usage', 'SKILL.md'), 'utf8'))
+      .resolves.toContain('webcmd-usage');
+    await expect(readFile(fixture.discoverySentinel, 'utf8')).resolves.toBe('read');
+    expect(fixture.requests).toEqual([]);
+  }, 20_000);
 });
 
 async function createHostedFixture(outcome: 'success' | 'failure'): Promise<{
+  root: string;
   env: NodeJS.ProcessEnv;
   discoverySentinel: string;
+  requests: string[];
 }> {
   const root = await mkdtemp(path.join(tmpdir(), 'webcmd-hosted-lifecycle-'));
   tempRoots.push(root);
   const configDir = path.join(root, 'config');
   const userClis = path.join(root, '.webcmd', 'clis', 'lifecycle-sentinel');
   const discoverySentinel = path.join(root, 'local-discovery-ran');
+  const requests: string[] = [];
   await mkdir(configDir, { recursive: true });
   await mkdir(userClis, { recursive: true });
   await writeFile(path.join(userClis, 'sentinel.js'), [
@@ -113,6 +143,7 @@ async function createHostedFixture(outcome: 'success' | 'failure'): Promise<{
   ].join('\n'));
 
   const server = createServer((request, response) => {
+    requests.push(`${request.method ?? 'GET'} ${request.url ?? '/'}`);
     if (request.url === '/v1/manifest') {
       sendChunkedJson(response, {
         ok: true,
@@ -177,10 +208,13 @@ async function createHostedFixture(outcome: 'success' | 'failure'): Promise<{
   })}\n`, { mode: 0o600 });
 
   return {
+    root,
     discoverySentinel,
+    requests,
     env: {
       ...process.env,
       HOME: root,
+      USERPROFILE: root,
       WEBCMD_CONFIG_DIR: configDir,
       WEBCMD_NO_UPDATE_CHECK: '1',
     },

--- a/src/hosted/main-lifecycle.test.ts
+++ b/src/hosted/main-lifecycle.test.ts
@@ -27,6 +27,19 @@ const command = {
   defaultFormat: 'plain',
 };
 
+const authCommand = {
+  site: 'auth',
+  name: 'status',
+  command: 'auth/status',
+  description: 'Show hosted login status',
+  access: 'read',
+  strategy: 'PUBLIC',
+  browser: false,
+  args: [],
+  columns: ['value'],
+  defaultFormat: 'plain',
+};
+
 afterEach(async () => {
   await Promise.all(servers.splice(0).map(server => new Promise<void>((resolve, reject) => {
     server.close(error => error ? reject(error) : resolve());
@@ -116,8 +129,30 @@ describe('hosted CLI process lifecycle', () => {
     expect(body.skills.every(skill => skill.destination?.startsWith(installDir))).toBe(true);
     await expect(readFile(path.join(installDir, 'webcmd-usage', 'SKILL.md'), 'utf8'))
       .resolves.toContain('webcmd-usage');
-    await expect(readFile(fixture.discoverySentinel, 'utf8')).resolves.toBe('read');
+    await expect(readFile(fixture.discoverySentinel, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
     expect(fixture.requests).toEqual([]);
+  }, 20_000);
+
+  it('keeps hosted auth on Cloud without local discovery', async () => {
+    const fixture = await createHostedFixture('success');
+
+    const result = await runCli(['auth', 'status', '-f', 'plain'], fixture.env);
+
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+    expect(fixture.requests).toEqual(['GET /v1/manifest', 'POST /v1/execute']);
+    await expect(readFile(fixture.discoverySentinel, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+  }, 20_000);
+
+  it('rejects daemon commands in hosted mode without local discovery', async () => {
+    const fixture = await createHostedFixture('success');
+
+    const result = await runCli(['daemon', 'status'], fixture.env);
+
+    expect(result.status).toBe(78);
+    expect(result.stderr).toContain('Hosted mode has no local daemon.');
+    expect(fixture.requests).toEqual([]);
+    await expect(readFile(fixture.discoverySentinel, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
   }, 20_000);
 });
 
@@ -142,7 +177,7 @@ async function createHostedFixture(outcome: 'success' | 'failure'): Promise<{
     '',
   ].join('\n'));
 
-  const server = createServer((request, response) => {
+  const server = createServer(async (request, response) => {
     requests.push(`${request.method ?? 'GET'} ${request.url ?? '/'}`);
     if (request.url === '/v1/manifest') {
       sendChunkedJson(response, {
@@ -154,12 +189,15 @@ async function createHostedFixture(outcome: 'success' | 'failure'): Promise<{
             webcmdPackageVersion: '0.3.0',
             generatedAt: '2026-07-14T00:00:00.000Z',
           },
-          commands: [command],
+          commands: [command, authCommand],
         },
       });
       return;
     }
     if (request.url === '/v1/execute' && request.method === 'POST') {
+      let requestBody = '';
+      for await (const chunk of request) requestBody += chunk;
+      const invocation = JSON.parse(requestBody) as { command: string; trace?: string };
       if (outcome === 'failure') {
         sendChunkedJson(response, {
           ok: false,
@@ -169,7 +207,7 @@ async function createHostedFixture(outcome: 'success' | 'failure'): Promise<{
             help: 'Retry the lifecycle fixture.',
             exitCode: 69,
           },
-          execution: { id: 'exec_lifecycle', command: command.command, status: 'failed' },
+          execution: { id: 'exec_lifecycle', command: invocation.command, status: 'failed' },
         }, 422);
         return;
       }
@@ -177,8 +215,10 @@ async function createHostedFixture(outcome: 'success' | 'failure'): Promise<{
         ok: true,
         result: { value: largeOutput },
         columns: ['value'],
-        execution: { id: 'exec_lifecycle', command: command.command, status: 'succeeded' },
-        trace: { executionId: 'exec_lifecycle', receipt: traceReceipt },
+        execution: { id: 'exec_lifecycle', command: invocation.command, status: 'succeeded' },
+        ...(invocation.trace === 'on'
+          ? { trace: { executionId: 'exec_lifecycle', receipt: traceReceipt } }
+          : {}),
       });
       return;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getCompletionScriptFast, getCompletionsFromManifest, hasAllManifests } from './completion-fast.js';
+import { HOSTED_ROOT_HELP } from './completion-shared.js';
 import { findPackageRoot, getCliManifestPath } from './package-paths.js';
 import { PKG_VERSION } from './version.js';
 import { EXIT_CODES } from './errors.js';
@@ -30,20 +31,9 @@ const __dirname = path.dirname(__filename);
 // Use findPackageRoot so the path works both in dev (src/main.ts) and prod (dist/src/main.js).
 const BUILTIN_CLIS = path.join(findPackageRoot(__filename), 'clis');
 const USER_CLIS = path.join(os.homedir(), CONFIG_DIR_NAME, 'clis');
-const HOSTED_LOCAL_COMMANDS = new Set([
-  'adapter',
-  'antigravity',
-  'auth',
-  'convention-audit',
-  'daemon',
-  'doctor',
-  'external',
-  'plugin',
-  'profile',
-  'skills',
-  'validate',
-  'verify',
-]);
+// Derived from the canonical list (also drives hosted help text and
+// hosted/runner.ts's rejection path) so the two never drift apart.
+const HOSTED_LOCAL_COMMANDS = new Set((HOSTED_ROOT_HELP.localOnlyCommands ?? []).map(command => command.name));
 
 // ── Ultra-fast path: lightweight commands bypass full discovery ──────────
 // These are high-frequency or trivial paths that must not pay the startup tax.

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,6 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getCompletionScriptFast, getCompletionsFromManifest, hasAllManifests } from './completion-fast.js';
-import { HOSTED_ROOT_HELP } from './completion-shared.js';
 import { findPackageRoot, getCliManifestPath } from './package-paths.js';
 import { PKG_VERSION } from './version.js';
 import { EXIT_CODES } from './errors.js';
@@ -31,9 +30,6 @@ const __dirname = path.dirname(__filename);
 // Use findPackageRoot so the path works both in dev (src/main.ts) and prod (dist/src/main.js).
 const BUILTIN_CLIS = path.join(findPackageRoot(__filename), 'clis');
 const USER_CLIS = path.join(os.homedir(), CONFIG_DIR_NAME, 'clis');
-// Derived from the canonical list (also drives hosted help text and
-// hosted/runner.ts's rejection path) so the two never drift apart.
-const HOSTED_LOCAL_COMMANDS = new Set((HOSTED_ROOT_HELP.localOnlyCommands ?? []).map(command => command.name));
 
 // ── Ultra-fast path: lightweight commands bypass full discovery ──────────
 // These are high-frequency or trivial paths that must not pay the startup tax.
@@ -77,25 +73,18 @@ if (!fastPathHandled) {
   if (argv[0] === 'setup') {
     const { runHostedSetup } = await import('./hosted/setup.js');
     process.exitCode = await runHostedSetup();
+  } else if (argv[0] === 'skills') {
+    const { createProgram } = await import('./cli.js');
+    await createProgram(BUILTIN_CLIS, USER_CLIS).parseAsync(argv, { from: 'user' });
   } else {
     const { shouldUseHostedMode } = await import('./hosted/config.js');
-    if (shouldUseHostedMode() && !(await shouldRunLocalCommandInHostedMode(argv))) {
+    if (shouldUseHostedMode()) {
       const { runHostedCli } = await import('./hosted/runner.js');
       const result = await runHostedCli(argv);
       process.exitCode = result.exitCode;
     } else {
       await runLocalMain();
     }
-  }
-}
-
-async function shouldRunLocalCommandInHostedMode(input: readonly string[]): Promise<boolean> {
-  try {
-    const { parseHostedRootCommandSurface } = await import('./root-command-surface.js');
-    const parsed = parseHostedRootCommandSurface(input);
-    return parsed.kind === 'dispatch' && HOSTED_LOCAL_COMMANDS.has(parsed.argv[0]!);
-  } catch {
-    return false;
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,20 @@ const __dirname = path.dirname(__filename);
 // Use findPackageRoot so the path works both in dev (src/main.ts) and prod (dist/src/main.js).
 const BUILTIN_CLIS = path.join(findPackageRoot(__filename), 'clis');
 const USER_CLIS = path.join(os.homedir(), CONFIG_DIR_NAME, 'clis');
+const HOSTED_LOCAL_COMMANDS = new Set([
+  'adapter',
+  'antigravity',
+  'auth',
+  'convention-audit',
+  'daemon',
+  'doctor',
+  'external',
+  'plugin',
+  'profile',
+  'skills',
+  'validate',
+  'verify',
+]);
 
 // ── Ultra-fast path: lightweight commands bypass full discovery ──────────
 // These are high-frequency or trivial paths that must not pay the startup tax.
@@ -75,13 +89,23 @@ if (!fastPathHandled) {
     process.exitCode = await runHostedSetup();
   } else {
     const { shouldUseHostedMode } = await import('./hosted/config.js');
-    if (shouldUseHostedMode()) {
+    if (shouldUseHostedMode() && !(await shouldRunLocalCommandInHostedMode(argv))) {
       const { runHostedCli } = await import('./hosted/runner.js');
       const result = await runHostedCli(argv);
       process.exitCode = result.exitCode;
     } else {
       await runLocalMain();
     }
+  }
+}
+
+async function shouldRunLocalCommandInHostedMode(input: readonly string[]): Promise<boolean> {
+  try {
+    const { parseHostedRootCommandSurface } = await import('./root-command-surface.js');
+    const parsed = parseHostedRootCommandSurface(input);
+    return parsed.kind === 'dispatch' && HOSTED_LOCAL_COMMANDS.has(parsed.argv[0]!);
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
## Summary

- keep webcmd skills available as a discovery-free client command in both modes
- keep hosted auth routed to Webcmd Cloud and daemon commands rejected
- prevent hosted mode from loading local adapters or plugins

Supersedes #99 with a narrower fix.

Fixes #92.

## Tests

- npm test: 4,805 passed, 1 skipped
- npm run typecheck