### PR TITLE
docs: add demo video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@
 
 WebCMD learns the navigational context of websites as agents use them, then compiles that knowledge into deterministic commands for faster, cheaper, more reliable browser automation. The goal is simple: stop making agents rediscover the same sites on every run and cut browser-agent token spend by up to 90%.
 
-## Demo
-
-https://github.com/user-attachments/assets/04eceadc-d398-4303-984d-ae3197bfa664
-
 On top of live browser control, WebCMD adds 3 layers of learnings. Each layer collapses cost and variance for the layer above it.
 
 | Layer | Scenario | What Webcmd Helps With |
@@ -41,6 +37,9 @@ On top of live browser control, WebCMD adds 3 layers of learnings. Each layer co
 | 3. CLI authoring | The action space is known, but the path is still too variable for one fixed sequence. | Explicitly author a reusable `webcmd <site>` adapter with structured output, so future agents spend tokens on the task instead of navigation. |
 | 4. Extend existing CLIs | The workflow is deterministic enough to stop browsing. | Extend the `webcmd <site>` adapter with a tailored command so the workflow runs instantly with the least amount of tokens. |
 
+## Demo
+
+https://github.com/user-attachments/assets/04eceadc-d398-4303-984d-ae3197bfa664
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@
 
 WebCMD learns the navigational context of websites as agents use them, then compiles that knowledge into deterministic commands for faster, cheaper, more reliable browser automation. The goal is simple: stop making agents rediscover the same sites on every run and cut browser-agent token spend by up to 90%.
 
+## Demo
+
+https://github.com/user-attachments/assets/04eceadc-d398-4303-984d-ae3197bfa664
+
 On top of live browser control, WebCMD adds 3 layers of learnings. Each layer collapses cost and variance for the layer above it.
 
 | Layer | Scenario | What Webcmd Helps With |


### PR DESCRIPTION
## Summary

- add the GitHub-hosted demo video to the README
- surface it near the project overview

Related to #89.

## Verification

- `npm test` (399 files passed; 4,896 tests passed; 1 skipped)
- `git diff --check`