### PR TITLE
feat: implement version resolution for cloakbrowser in LocalCloakRuntimeProvider

### DIFF
--- a/src/browser/runtime/local-cloak/provider.ts
+++ b/src/browser/runtime/local-cloak/provider.ts
@@ -2,7 +2,7 @@ import type { BrowserRuntimeCommand, BrowserRuntimeResult, BrowserRuntimeStatus 
 import type { BrowserRuntimeProvider, RuntimeStatusOptions } from '../provider.js';
 import { dispatchCloakAction } from './actions.js';
 import type { LaunchPersistentContext } from './session-manager.js';
-import { CloakSessionManager } from './session-manager.js';
+import { CloakSessionManager, resolveCloakBrowserVersion } from './session-manager.js';
 
 export interface LocalCloakRuntimeProviderOptions {
   baseDir?: string;
@@ -21,7 +21,7 @@ export class LocalCloakRuntimeProvider implements BrowserRuntimeProvider {
     return {
       runtimeConnected: true,
       runtimeName: 'cloak',
-      runtimeVersion: undefined,
+      runtimeVersion: resolveCloakBrowserVersion(),
       profiles,
       pending: 0,
       commandResultUnknown: 0,

--- a/src/browser/runtime/local-cloak/session-manager.ts
+++ b/src/browser/runtime/local-cloak/session-manager.ts
@@ -1,4 +1,6 @@
 import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { execFile } from 'node:child_process';
 import type { BrowserContext, Page as PlaywrightPage } from 'playwright-core';
 import { launchPersistentContext as cloakLaunchPersistentContext } from 'cloakbrowser';
@@ -6,6 +8,22 @@ import type { BrowserSurface, BrowserWindowMode, SiteSessionMode } from '../../p
 import { activateDarwinBackgroundContext, launchDarwinBackgroundPersistentContext } from './darwin-background-launch.js';
 import { normalizeProfileId, resolveCloakProfileDir } from './profiles.js';
 import { CloakNetworkCapture } from './network.js';
+import { findPackageRoot } from '../../../package-paths.js';
+
+let cloakBrowserVersion: string | undefined | null = null;
+
+/** Installed `cloakbrowser` package version, for doctor/status display. Cached — it can't change mid-process. */
+export function resolveCloakBrowserVersion(): string | undefined {
+  if (cloakBrowserVersion !== null) return cloakBrowserVersion;
+  try {
+    const entryPath = fileURLToPath(import.meta.resolve('cloakbrowser'));
+    const pkg = JSON.parse(fs.readFileSync(path.join(findPackageRoot(entryPath), 'package.json'), 'utf-8'));
+    cloakBrowserVersion = typeof pkg.version === 'string' ? pkg.version : undefined;
+  } catch {
+    cloakBrowserVersion = undefined;
+  }
+  return cloakBrowserVersion ?? undefined;
+}
 
 export type LaunchPersistentContext = typeof cloakLaunchPersistentContext;
 export type RecoverLockedProfile = (userDataDir: string) => Promise<boolean>;
@@ -55,7 +73,6 @@ interface ProfileRuntime {
   context: BrowserContext;
   pages: Map<string, PageEntry>;
   selectedPageId?: string;
-  runtimeVersion?: string;
   lastSeenAt: number;
 }
 
@@ -104,7 +121,7 @@ export class CloakSessionManager {
     return [...this.profiles.entries()].map(([contextId, runtime]) => ({
       contextId,
       runtimeConnected: true,
-      runtimeVersion: runtime.runtimeVersion,
+      runtimeVersion: resolveCloakBrowserVersion(),
       pending: 0,
       lastSeenAt: runtime.lastSeenAt,
     }));


### PR DESCRIPTION
## Description

doctor/status always reported the Cloak runtime version as undefined. ProfileRuntime.runtimeVersion was declared and read by profileStatuses() but never assigned in launchProfileRuntime(), and provider.ts hard-coded runtimeVersion: undefined. As a result both the runtime line and every profile line in webcmd doctor fell back to the literal version unknown.

This adds a resolveCloakBrowserVersion() helper that reads the installed cloakbrowser package's package.json version (memoized at module level, since it can't change mid-process), wires it into both provider.status() and CloakSessionManager.profileStatuses(), and removes the now-dead ProfileRuntime.runtimeVersion field.

Related issue: #121

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [ ] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

## Adapter Notes

N/A — no adapter or command-discoverability changes.

## Screenshots / Output

Before
[OK] Runtime: cloak connected (version unknown)

## Profiles:
  • default: connected version unknown, default

## After
[OK] Runtime: cloak connected (vX.Y.Z)

## Profiles:
  • default: connected vX.Y.Z, default

- npx tsc --noEmit clean; provider.test.ts + session-manager.test.ts pass (40 tests).