### PR TITLE
feat(openlibrary): add anonymous book search adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -15952,6 +15952,45 @@
     "sourceFile": "openfda/food-recall.js"
   },
   {
+    "site": "openlibrary",
+    "name": "search",
+    "description": "Search Open Library books by title, author, ISBN, or keyword",
+    "access": "read",
+    "domain": "openlibrary.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Book title, author, ISBN, or keyword"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Max results (1-50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "workId",
+      "title",
+      "authors",
+      "firstPublishYear",
+      "editionCount",
+      "isbn",
+      "languages",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "openlibrary/search.js",
+    "sourceFile": "openlibrary/search.js"
+  },
+  {
     "site": "openreview",
     "name": "author",
     "description": "List OpenReview submissions by an author profile id (newest first)",

--- a/clis/openlibrary/openlibrary.test.js
+++ b/clis/openlibrary/openlibrary.test.js
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@agentrhq/webcmd/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+import './search.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('openlibrary search adapter', () => {
+    const cmd = getRegistry().get('openlibrary/search');
+
+    it('registers an anonymous read-only public command', () => {
+        expect(cmd).toMatchObject({
+            site: 'openlibrary',
+            name: 'search',
+            access: 'read',
+            browser: false,
+        });
+        expect(cmd.columns).toEqual([
+            'rank', 'workId', 'title', 'authors', 'firstPublishYear',
+            'editionCount', 'isbn', 'languages', 'url',
+        ]);
+    });
+
+    it('rejects empty queries and out-of-range limits before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ query: '', limit: 5 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: 'algorithms', limit: 0 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: 'algorithms', limit: 51 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps Open Library results into stable book rows', async () => {
+        const payload = {
+            numFound: 1,
+            docs: [{
+                key: '/works/OL123W',
+                title: 'Dynamic Programming',
+                author_name: ['Richard Bellman'],
+                first_publish_year: 1957,
+                edition_count: 4,
+                isbn: ['9780691079516', '069107951X'],
+                language: ['eng'],
+            }],
+        };
+        const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const rows = await cmd.func({ query: 'dynamic programming', limit: 5 });
+
+        expect(rows).toEqual([{
+            rank: 1,
+            workId: 'OL123W',
+            title: 'Dynamic Programming',
+            authors: 'Richard Bellman',
+            firstPublishYear: 1957,
+            editionCount: 4,
+            isbn: '9780691079516',
+            languages: 'eng',
+            url: 'https://openlibrary.org/works/OL123W',
+        }]);
+        expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('q=dynamic+programming'), expect.objectContaining({
+            headers: expect.objectContaining({ accept: 'application/json' }),
+        }));
+    });
+
+    it('throws typed errors for empty results and failed responses', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(new Response(JSON.stringify({ docs: [] }), { status: 200 })));
+        await expect(cmd.func({ query: 'nothing', limit: 5 })).rejects.toThrow(EmptyResultError);
+
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(new Response('unavailable', { status: 503 })));
+        await expect(cmd.func({ query: 'anything', limit: 5 })).rejects.toThrow(CommandExecutionError);
+    });
+});

--- a/clis/openlibrary/search.js
+++ b/clis/openlibrary/search.js
@@ -1,0 +1,92 @@
+// Open Library search — anonymous book discovery via the official Search API.
+// API docs: https://openlibrary.org/dev/docs/api/search
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+
+const SEARCH_URL = 'https://openlibrary.org/search.json';
+const USER_AGENT = 'webcmd-openlibrary-adapter (+https://github.com/agentrhq/webcmd)';
+const FIELDS = [
+    'key', 'title', 'author_name', 'first_publish_year',
+    'edition_count', 'isbn', 'language',
+].join(',');
+
+function requireQuery(value) {
+    const query = String(value ?? '').trim();
+    if (!query) throw new ArgumentError('openlibrary search query cannot be empty');
+    return query;
+}
+
+function requireLimit(value) {
+    const limit = value == null ? 10 : Number(value);
+    if (!Number.isInteger(limit) || limit <= 0) {
+        throw new ArgumentError('openlibrary search limit must be a positive integer');
+    }
+    if (limit > 50) throw new ArgumentError('openlibrary search limit must be <= 50');
+    return limit;
+}
+
+async function openLibraryFetch(url) {
+    let response;
+    try {
+        response = await fetch(url, {
+            headers: { accept: 'application/json', 'user-agent': USER_AGENT },
+        });
+    } catch (error) {
+        throw new CommandExecutionError(
+            `openlibrary search request failed: ${error?.message ?? error}`,
+            'Check that openlibrary.org is reachable from this network.',
+        );
+    }
+    if (!response.ok) {
+        throw new CommandExecutionError(`openlibrary search returned HTTP ${response.status}`);
+    }
+    try {
+        return await response.json();
+    } catch (error) {
+        throw new CommandExecutionError(`openlibrary search returned malformed JSON: ${error?.message ?? error}`);
+    }
+}
+
+cli({
+    site: 'openlibrary',
+    name: 'search',
+    access: 'read',
+    description: 'Search Open Library books by title, author, ISBN, or keyword',
+    domain: 'openlibrary.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, type: 'string', required: true, help: 'Book title, author, ISBN, or keyword' },
+        { name: 'limit', type: 'int', default: 10, help: 'Max results (1-50)' },
+    ],
+    columns: [
+        'rank', 'workId', 'title', 'authors', 'firstPublishYear',
+        'editionCount', 'isbn', 'languages', 'url',
+    ],
+    func: async (args) => {
+        const query = requireQuery(args.query);
+        const limit = requireLimit(args.limit);
+        const params = new URLSearchParams({ q: query, limit: String(limit), fields: FIELDS });
+        const payload = await openLibraryFetch(`${SEARCH_URL}?${params}`);
+        const docs = Array.isArray(payload?.docs) ? payload.docs : [];
+        if (docs.length === 0) {
+            throw new EmptyResultError('openlibrary search', `Open Library returned no books matching "${query}".`);
+        }
+        return docs.slice(0, limit).map((book, index) => {
+            const key = typeof book?.key === 'string' ? book.key : '';
+            const workId = key.replace(/^\/works\//, '');
+            const isbns = Array.isArray(book?.isbn) ? book.isbn.map(String).filter(Boolean) : [];
+            return {
+                rank: index + 1,
+                workId,
+                title: String(book?.title ?? '').trim(),
+                authors: Array.isArray(book?.author_name) ? book.author_name.filter(Boolean).join(', ') : '',
+                firstPublishYear: Number.isFinite(Number(book?.first_publish_year)) ? Number(book.first_publish_year) : null,
+                editionCount: Number.isFinite(Number(book?.edition_count)) ? Number(book.edition_count) : null,
+                isbn: isbns.find(isbn => isbn.replace(/[^0-9X]/gi, '').length === 13) ?? isbns[0] ?? '',
+                languages: Array.isArray(book?.language) ? book.language.filter(Boolean).join(', ') : '',
+                url: workId ? `https://openlibrary.org/works/${encodeURIComponent(workId)}` : '',
+            };
+        });
+    },
+});


### PR DESCRIPTION
## Summary
- add `webcmd openlibrary search` using Open Library’s public Search API
- keep the command anonymous, read-only, and browser-free
- return stable book identifiers, authors, publication metadata, ISBN, languages, and work URLs
- add adapter tests and regenerate the CLI manifest

## Verification
- `node dist/src/main.js validate openlibrary/search`
- `node dist/src/main.js openlibrary search "dynamic programming" --limit 3 -f json`
- `npm run typecheck`
- `npm test` (400 files, 4900 passed, 1 skipped)