### PR TITLE
feat: add BikeWale search adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -2246,6 +2246,45 @@
     "navigateBefore": "https://www.bigbasket.com"
   },
   {
+    "site": "bikewale",
+    "name": "search",
+    "description": "Search BikeWale public bike and scooter suggestions",
+    "access": "read",
+    "domain": "www.bikewale.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Bike, scooter, brand, or keyword (e.g. \"activa\", \"royal enfield\")"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Maximum suggestions to return (1-20)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "name",
+      "make",
+      "model",
+      "type",
+      "additionalInfo",
+      "modelId",
+      "makeId",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "bikewale/search.js",
+    "sourceFile": "bikewale/search.js"
+  },
+  {
     "site": "binance",
     "name": "asks",
     "description": "Order book ask prices for a trading pair",

--- a/clis/bikewale/bikewale.test.js
+++ b/clis/bikewale/bikewale.test.js
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@agentrhq/webcmd/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+import './search.js';
+
+const cmd = getRegistry().get('bikewale/search');
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('bikewale search adapter', () => {
+    it('rejects invalid args before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ query: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: 'x'.repeat(81) })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: 'activa', limit: 21 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP failures to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('nope', { status: 503 })));
+        await expect(cmd.func({ query: 'activa' })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError on empty suggestions', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify([]), { status: 200 })));
+        await expect(cmd.func({ query: 'no-such-bike' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('maps BikeWale suggestions to round-trippable public rows', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify([
+            {
+                payload: {
+                    modelName: 'Activa', maskingName: 'activa-6g', makeId: 7,
+                    makeName: 'Honda', makeMaskingName: 'honda', modelId: 1354,
+                    url: '/honda-bikes/activa-6g/',
+                },
+                suggestionType: 2,
+                displayName: 'Honda Activa',
+                additionalInfo: '',
+            },
+            {
+                payload: {
+                    modelName: 'Activa 7G', makeId: 7, makeName: 'Honda', modelId: 1986,
+                    url: '/honda-bikes/activa-7g/',
+                },
+                suggestionType: 3,
+                displayName: 'Honda Activa 7G',
+                additionalInfo: 'Coming Soon',
+            },
+        ]), { status: 200 })));
+        const rows = await cmd.func({ query: 'activa', limit: 2 });
+        expect(rows).toEqual([
+            {
+                rank: 1,
+                name: 'Honda Activa',
+                make: 'Honda',
+                model: 'Activa',
+                type: 2,
+                additionalInfo: '',
+                modelId: 1354,
+                makeId: 7,
+                url: 'https://www.bikewale.com/honda-bikes/activa-6g/',
+            },
+            {
+                rank: 2,
+                name: 'Honda Activa 7G',
+                make: 'Honda',
+                model: 'Activa 7G',
+                type: 3,
+                additionalInfo: 'Coming Soon',
+                modelId: 1986,
+                makeId: 7,
+                url: 'https://www.bikewale.com/honda-bikes/activa-7g/',
+            },
+        ]);
+    });
+});

--- a/clis/bikewale/search.js
+++ b/clis/bikewale/search.js
@@ -1,0 +1,63 @@
+// bikewale search — search BikeWale's public bike/model suggestions.
+//
+// Hits the anonymous autocomplete endpoint used by bikewale.com's public search
+// box. Results include stable model/make ids and canonical BikeWale URLs.
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { EmptyResultError } from '@agentrhq/webcmd/errors';
+import {
+    AUTOCOMPLETE_SOURCES,
+    BIKEWALE_BASE,
+    bikewaleFetch,
+    canonicalUrl,
+    requireLimit,
+    requireQuery,
+} from './utils.js';
+
+cli({
+    site: 'bikewale',
+    name: 'search',
+    access: 'read',
+    description: 'Search BikeWale public bike and scooter suggestions',
+    domain: 'www.bikewale.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Bike, scooter, brand, or keyword (e.g. "activa", "royal enfield")' },
+        { name: 'limit', type: 'int', default: 10, help: 'Maximum suggestions to return (1-20)' },
+    ],
+    columns: ['rank', 'name', 'make', 'model', 'type', 'additionalInfo', 'modelId', 'makeId', 'url'],
+    func: async (args) => {
+        const query = requireQuery(args.query);
+        const limit = requireLimit(args.limit);
+        const params = new URLSearchParams({
+            source: AUTOCOMPLETE_SOURCES,
+            value: query,
+            size: String(limit),
+            applicationId: '2',
+            showNoResult: 'true',
+            cityId: '-1',
+        });
+        const body = await bikewaleFetch(`${BIKEWALE_BASE}/api/v4/autocomplete/?${params.toString()}`, 'bikewale search');
+        const list = Array.isArray(body) ? body : [];
+        const results = list
+            .filter((item) => item && typeof item === 'object' && item.displayName)
+            .slice(0, limit);
+        if (!results.length) {
+            throw new EmptyResultError('bikewale search', `No BikeWale suggestions matched "${query}".`);
+        }
+        return results.map((item, i) => {
+            const payload = item.payload && typeof item.payload === 'object' ? item.payload : {};
+            return {
+                rank: i + 1,
+                name: String(item.displayName ?? '').trim(),
+                make: String(payload.makeName ?? '').trim(),
+                model: String(payload.modelName ?? '').trim(),
+                type: item.suggestionType != null ? Number(item.suggestionType) : null,
+                additionalInfo: String(item.additionalInfo ?? '').trim(),
+                modelId: payload.modelId ? Number(payload.modelId) : null,
+                makeId: payload.makeId ? Number(payload.makeId) : null,
+                url: canonicalUrl(payload.url),
+            };
+        });
+    },
+});

--- a/clis/bikewale/utils.js
+++ b/clis/bikewale/utils.js
@@ -1,0 +1,66 @@
+// Shared helpers for the BikeWale adapters.
+//
+// Uses BikeWale's anonymous autocomplete endpoint. The endpoint backs the
+// public search box and returns public model / make suggestions without login.
+import { ArgumentError, CommandExecutionError } from '@agentrhq/webcmd/errors';
+
+export const BIKEWALE_BASE = 'https://www.bikewale.com';
+export const AUTOCOMPLETE_SOURCES = '1,2,3,5,11,15,13,14,10,16,17,4,8,9,6,19,20,21,24,7,34';
+const UA = 'webcmd-bikewale-adapter (+https://github.com/agentrhq/webcmd)';
+
+export function requireQuery(value) {
+    const query = String(value ?? '').trim();
+    if (!query) {
+        throw new ArgumentError('bikewale search query cannot be empty');
+    }
+    if (query.length > 80) {
+        throw new ArgumentError('bikewale search query must be <= 80 characters');
+    }
+    return query;
+}
+
+export function requireLimit(value, defaultValue = 10, maxValue = 20) {
+    const raw = value ?? defaultValue;
+    const limit = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(limit) || limit <= 0) {
+        throw new ArgumentError('bikewale limit must be a positive integer');
+    }
+    if (limit > maxValue) {
+        throw new ArgumentError(`bikewale limit must be <= ${maxValue}`);
+    }
+    return limit;
+}
+
+export async function bikewaleFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, {
+            headers: {
+                accept: 'application/json',
+                'user-agent': UA,
+            },
+        });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that www.bikewale.com is reachable from this network.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    try {
+        return await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+}
+
+export function canonicalUrl(path) {
+    const raw = String(path ?? '').trim();
+    if (!raw) return '';
+    if (/^https?:\/\//i.test(raw)) return raw;
+    return `${BIKEWALE_BASE}${raw.startsWith('/') ? raw : `/${raw}`}`;
+}


### PR DESCRIPTION
## Summary
- Add a public, anonymous BikeWale search adapter backed by BikeWale's autocomplete endpoint
- Return ranked bike/scooter suggestions with make/model ids and canonical URLs
- Add adapter tests and regenerate the CLI manifest

## Verification
- webcmd list -f json (no existing bikewale adapter)
- curl BikeWale autocomplete endpoint for "activa" -> HTTP 200 with JSON suggestions
- npx vitest run --project adapter clis/bikewale/bikewale.test.js -> 4 passed
- npm run build -> pass, manifest regenerated
- node dist/src/main.js validate bikewale/search -> PASS
- node dist/src/main.js bikewale --help -f yaml -> includes bikewale/search help
- node dist/src/main.js bikewale search activa -f yaml --limit 5 -> live public results returned
- npm run typecheck -> pass
- npm test -> 400 files passed, 4900 passed, 1 skipped
- git diff --check -> pass