### PR TITLE
docs: add Webcmd logo lockup to navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -9,8 +9,8 @@
     "dark": "#006B9A"
   },
   "logo": {
-    "light": "/webcmd.svg",
-    "dark": "/webcmd.svg",
+    "light": "/webcmd-logo-light.svg",
+    "dark": "/webcmd-logo-dark.svg",
     "href": "https://webcmd.dev"
   },
   "favicon": "/webcmd.svg",

--- a/docs/webcmd-logo-dark.svg
+++ b/docs/webcmd-logo-dark.svg
@@ -1,7 +1,9 @@
 <svg width="126" height="40" viewBox="0 0 126 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M28.6 10.4H11.4C10.4059 10.4 9.6 11.2059 9.6 12.2V27.8C9.6 28.7941 10.4059 29.6 11.4 29.6H28.6C29.5941 29.6 30.4 28.7941 30.4 27.8V12.2C30.4 11.2059 29.5941 10.4 28.6 10.4Z" stroke="#56C5FF" stroke-width="0.7"/>
-  <path d="M9.6 15H30.4" stroke="#56C5FF" stroke-width="0.5"/>
-  <circle cx="12" cy="12.7" r="0.55" fill="#56C5FF"/><circle cx="14.2" cy="12.7" r="0.55" fill="#56C5FF"/><circle cx="16.4" cy="12.7" r="0.55" fill="#56C5FF"/>
-  <path d="M15 19.6L18.2 22.4L15 25.2M19.8 25.2H25" stroke="white" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
-  <text x="42" y="26.3" fill="white" font-family="Courier New, Courier, monospace" font-size="20" font-weight="700">web</text><text x="78" y="26.3" fill="#56C5FF" font-family="Courier New, Courier, monospace" font-size="20" font-weight="700">cmd</text>
+  <g transform="translate(20 20) scale(1.77) translate(-20 -20)">
+    <path d="M28.6 10.4H11.4C10.4059 10.4 9.6 11.2059 9.6 12.2V27.8C9.6 28.7941 10.4059 29.6 11.4 29.6H28.6C29.5941 29.6 30.4 28.7941 30.4 27.8V12.2C30.4 11.2059 29.5941 10.4 28.6 10.4Z" stroke="#56C5FF" stroke-width="0.7"/>
+    <path d="M9.6 15H30.4" stroke="#56C5FF" stroke-width="0.5"/>
+    <circle cx="12" cy="12.7" r="0.55" fill="#56C5FF"/><circle cx="14.2" cy="12.7" r="0.55" fill="#56C5FF"/><circle cx="16.4" cy="12.7" r="0.55" fill="#56C5FF"/>
+    <path d="M15 19.6L18.2 22.4L15 25.2M19.8 25.2H25" stroke="white" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <text x="48" y="25.4" fill="white" font-family="Courier New, Courier, monospace" font-size="16" font-weight="700">web</text><text x="76.8" y="25.4" fill="#56C5FF" font-family="Courier New, Courier, monospace" font-size="16" font-weight="700">cmd</text>
 </svg>

--- a/docs/webcmd-logo-dark.svg
+++ b/docs/webcmd-logo-dark.svg
@@ -1,0 +1,7 @@
+<svg width="126" height="40" viewBox="0 0 126 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M28.6 10.4H11.4C10.4059 10.4 9.6 11.2059 9.6 12.2V27.8C9.6 28.7941 10.4059 29.6 11.4 29.6H28.6C29.5941 29.6 30.4 28.7941 30.4 27.8V12.2C30.4 11.2059 29.5941 10.4 28.6 10.4Z" stroke="#56C5FF" stroke-width="0.7"/>
+  <path d="M9.6 15H30.4" stroke="#56C5FF" stroke-width="0.5"/>
+  <circle cx="12" cy="12.7" r="0.55" fill="#56C5FF"/><circle cx="14.2" cy="12.7" r="0.55" fill="#56C5FF"/><circle cx="16.4" cy="12.7" r="0.55" fill="#56C5FF"/>
+  <path d="M15 19.6L18.2 22.4L15 25.2M19.8 25.2H25" stroke="white" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="42" y="26.3" fill="white" font-family="Courier New, Courier, monospace" font-size="20" font-weight="700">web</text><text x="78" y="26.3" fill="#56C5FF" font-family="Courier New, Courier, monospace" font-size="20" font-weight="700">cmd</text>
+</svg>

--- a/docs/webcmd-logo-light.svg
+++ b/docs/webcmd-logo-light.svg
@@ -1,0 +1,7 @@
+<svg width="126" height="40" viewBox="0 0 126 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M28.6 10.4H11.4C10.4059 10.4 9.6 11.2059 9.6 12.2V27.8C9.6 28.7941 10.4059 29.6 11.4 29.6H28.6C29.5941 29.6 30.4 28.7941 30.4 27.8V12.2C30.4 11.2059 29.5941 10.4 28.6 10.4Z" stroke="#56C5FF" stroke-width="0.7"/>
+  <path d="M9.6 15H30.4" stroke="#56C5FF" stroke-width="0.5"/>
+  <circle cx="12" cy="12.7" r="0.55" fill="#56C5FF"/><circle cx="14.2" cy="12.7" r="0.55" fill="#56C5FF"/><circle cx="16.4" cy="12.7" r="0.55" fill="#56C5FF"/>
+  <path d="M15 19.6L18.2 22.4L15 25.2M19.8 25.2H25" stroke="#0F0F0F" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="42" y="26.3" fill="#0F0F0F" font-family="Courier New, Courier, monospace" font-size="20" font-weight="700">web</text><text x="78" y="26.3" fill="#56C5FF" font-family="Courier New, Courier, monospace" font-size="20" font-weight="700">cmd</text>
+</svg>

--- a/docs/webcmd-logo-light.svg
+++ b/docs/webcmd-logo-light.svg
@@ -1,9 +1,9 @@
 <svg width="126" height="40" viewBox="0 0 126 40" fill="none" xmlns="http://www.w3.org/2000/svg">
   <g transform="translate(20 20) scale(1.77) translate(-20 -20)">
-    <path d="M28.6 10.4H11.4C10.4059 10.4 9.6 11.2059 9.6 12.2V27.8C9.6 28.7941 10.4059 29.6 11.4 29.6H28.6C29.5941 29.6 30.4 28.7941 30.4 27.8V12.2C30.4 11.2059 29.5941 10.4 28.6 10.4Z" stroke="#56C5FF" stroke-width="0.7"/>
-    <path d="M9.6 15H30.4" stroke="#56C5FF" stroke-width="0.5"/>
-    <circle cx="12" cy="12.7" r="0.55" fill="#56C5FF"/><circle cx="14.2" cy="12.7" r="0.55" fill="#56C5FF"/><circle cx="16.4" cy="12.7" r="0.55" fill="#56C5FF"/>
+    <path d="M28.6 10.4H11.4C10.4059 10.4 9.6 11.2059 9.6 12.2V27.8C9.6 28.7941 10.4059 29.6 11.4 29.6H28.6C29.5941 29.6 30.4 28.7941 30.4 27.8V12.2C30.4 11.2059 29.5941 10.4 28.6 10.4Z" stroke="#006B9A" stroke-width="0.7"/>
+    <path d="M9.6 15H30.4" stroke="#006B9A" stroke-width="0.5"/>
+    <circle cx="12" cy="12.7" r="0.55" fill="#006B9A"/><circle cx="14.2" cy="12.7" r="0.55" fill="#006B9A"/><circle cx="16.4" cy="12.7" r="0.55" fill="#006B9A"/>
     <path d="M15 19.6L18.2 22.4L15 25.2M19.8 25.2H25" stroke="#0F0F0F" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
-  <text x="48" y="25.4" fill="#0F0F0F" font-family="Courier New, Courier, monospace" font-size="16" font-weight="700">web</text><text x="76.8" y="25.4" fill="#56C5FF" font-family="Courier New, Courier, monospace" font-size="16" font-weight="700">cmd</text>
+  <text x="48" y="25.4" fill="#0F0F0F" font-family="Courier New, Courier, monospace" font-size="16" font-weight="700">web</text><text x="76.8" y="25.4" fill="#006B9A" font-family="Courier New, Courier, monospace" font-size="16" font-weight="700">cmd</text>
 </svg>

--- a/docs/webcmd-logo-light.svg
+++ b/docs/webcmd-logo-light.svg
@@ -1,7 +1,9 @@
 <svg width="126" height="40" viewBox="0 0 126 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M28.6 10.4H11.4C10.4059 10.4 9.6 11.2059 9.6 12.2V27.8C9.6 28.7941 10.4059 29.6 11.4 29.6H28.6C29.5941 29.6 30.4 28.7941 30.4 27.8V12.2C30.4 11.2059 29.5941 10.4 28.6 10.4Z" stroke="#56C5FF" stroke-width="0.7"/>
-  <path d="M9.6 15H30.4" stroke="#56C5FF" stroke-width="0.5"/>
-  <circle cx="12" cy="12.7" r="0.55" fill="#56C5FF"/><circle cx="14.2" cy="12.7" r="0.55" fill="#56C5FF"/><circle cx="16.4" cy="12.7" r="0.55" fill="#56C5FF"/>
-  <path d="M15 19.6L18.2 22.4L15 25.2M19.8 25.2H25" stroke="#0F0F0F" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
-  <text x="42" y="26.3" fill="#0F0F0F" font-family="Courier New, Courier, monospace" font-size="20" font-weight="700">web</text><text x="78" y="26.3" fill="#56C5FF" font-family="Courier New, Courier, monospace" font-size="20" font-weight="700">cmd</text>
+  <g transform="translate(20 20) scale(1.77) translate(-20 -20)">
+    <path d="M28.6 10.4H11.4C10.4059 10.4 9.6 11.2059 9.6 12.2V27.8C9.6 28.7941 10.4059 29.6 11.4 29.6H28.6C29.5941 29.6 30.4 28.7941 30.4 27.8V12.2C30.4 11.2059 29.5941 10.4 28.6 10.4Z" stroke="#56C5FF" stroke-width="0.7"/>
+    <path d="M9.6 15H30.4" stroke="#56C5FF" stroke-width="0.5"/>
+    <circle cx="12" cy="12.7" r="0.55" fill="#56C5FF"/><circle cx="14.2" cy="12.7" r="0.55" fill="#56C5FF"/><circle cx="16.4" cy="12.7" r="0.55" fill="#56C5FF"/>
+    <path d="M15 19.6L18.2 22.4L15 25.2M19.8 25.2H25" stroke="#0F0F0F" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <text x="48" y="25.4" fill="#0F0F0F" font-family="Courier New, Courier, monospace" font-size="16" font-weight="700">web</text><text x="76.8" y="25.4" fill="#56C5FF" font-family="Courier New, Courier, monospace" font-size="16" font-weight="700">cmd</text>
 </svg>

--- a/src/docs-sync-review.test.ts
+++ b/src/docs-sync-review.test.ts
@@ -111,7 +111,7 @@ describe('review context', () => {
     ])).toEqual([
       'README.md',
       'docs/agent-prompts.mdx',
-      'docs/agent-runtime.mdx',
+      'docs/browser-and-sitemap-memory.mdx',
       'docs/cli-reference.mdx',
       'docs/concepts.mdx',
       'skills/webcmd-browser-sitemap/SKILL.md',
@@ -125,7 +125,7 @@ describe('review context', () => {
       'README.md',
       'docs/authoring.mdx',
       'docs/cli-reference.mdx',
-      'docs/plugins-and-skills.mdx',
+      'docs/skills.mdx',
       'skills/webcmd-adapter-author/SKILL.md',
       'skills/webcmd-usage/SKILL.md',
     ]);

--- a/src/docs-sync-review.ts
+++ b/src/docs-sync-review.ts
@@ -172,7 +172,7 @@ const GENERAL_DOCUMENTATION = [
 const BROWSER_DOCUMENTATION = [
   'README.md',
   'docs/agent-prompts.mdx',
-  'docs/agent-runtime.mdx',
+  'docs/browser-and-sitemap-memory.mdx',
   'docs/cli-reference.mdx',
   'docs/concepts.mdx',
   'skills/webcmd-browser-sitemap/SKILL.md',
@@ -184,7 +184,7 @@ const ADAPTER_DOCUMENTATION = [
   'README.md',
   'docs/authoring.mdx',
   'docs/cli-reference.mdx',
-  'docs/plugins-and-skills.mdx',
+  'docs/skills.mdx',
   'skills/webcmd-adapter-author/SKILL.md',
   'skills/webcmd-usage/SKILL.md',
 ];


### PR DESCRIPTION
## Summary

- add light and dark horizontal Webcmd logo lockups to the Mintlify header
- retain the existing square Webcmd favicon
- update docs-sync routing to the replacement browser-memory and skills pages

## Verification

- `npm test` — 399 files, 4,896 passed, 1 skipped
- `npm run typecheck`
- `npx --yes mint@latest broken-links --check-redirects`
- logo config/theme assertions and branch scope checks