### PR TITLE
fix(docs): show navigation logo

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -4,23 +4,6 @@ h5 {
   font-family: "Inter", sans-serif;
 }
 
-#navbar .nav-logo {
-  display: none;
-}
-
-#navbar a:has(.nav-logo)::after {
-  color: #006b9a;
-  content: "webcmd";
-  font-family: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 1.125rem;
-  font-weight: 500;
-  letter-spacing: -0.025em;
-}
-
-.dark #navbar a:has(.nav-logo)::after {
-  color: #56c5ff;
-}
-
 code,
 kbd,
 samp,


### PR DESCRIPTION
## Root cause

The configured light/dark logo assets were deployed correctly, but `docs/style.css` hid `.nav-logo` and generated replacement `webcmd` text.

## Fix

Remove only the obsolete logo-hiding and replacement-text CSS blocks so Mintlify renders the configured SVG lockups.

## Verification

- `npm test` — 399 files, 4,896 passed, 1 skipped
- `npm run typecheck`
- Mintlify broken-link validation
- CSS/config visibility assertion
- single-file branch scope check