### PR TITLE
style(docs): enlarge logo wordmark

### DIFF
--- a/docs/webcmd-logo-dark.svg
+++ b/docs/webcmd-logo-dark.svg
@@ -5,5 +5,5 @@
     <circle cx="12" cy="12.7" r="0.55" fill="#56C5FF"/><circle cx="14.2" cy="12.7" r="0.55" fill="#56C5FF"/><circle cx="16.4" cy="12.7" r="0.55" fill="#56C5FF"/>
     <path d="M15 19.6L18.2 22.4L15 25.2M19.8 25.2H25" stroke="white" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
-  <text x="48" y="25.4" fill="white" font-family="Courier New, Courier, monospace" font-size="16" font-weight="700">web</text><text x="76.8" y="25.4" fill="#56C5FF" font-family="Courier New, Courier, monospace" font-size="16" font-weight="700">cmd</text>
+  <text x="48" y="26.3" fill="white" font-family="Courier New, Courier, monospace" font-size="18" font-weight="700">web</text><text x="80.4" y="26.3" fill="#56C5FF" font-family="Courier New, Courier, monospace" font-size="18" font-weight="700">cmd</text>
 </svg>

--- a/docs/webcmd-logo-light.svg
+++ b/docs/webcmd-logo-light.svg
@@ -5,5 +5,5 @@
     <circle cx="12" cy="12.7" r="0.55" fill="#006B9A"/><circle cx="14.2" cy="12.7" r="0.55" fill="#006B9A"/><circle cx="16.4" cy="12.7" r="0.55" fill="#006B9A"/>
     <path d="M15 19.6L18.2 22.4L15 25.2M19.8 25.2H25" stroke="#0F0F0F" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
-  <text x="48" y="25.4" fill="#0F0F0F" font-family="Courier New, Courier, monospace" font-size="16" font-weight="700">web</text><text x="76.8" y="25.4" fill="#006B9A" font-family="Courier New, Courier, monospace" font-size="16" font-weight="700">cmd</text>
+  <text x="48" y="26.3" fill="#0F0F0F" font-family="Courier New, Courier, monospace" font-size="18" font-weight="700">web</text><text x="80.4" y="26.3" fill="#006B9A" font-family="Courier New, Courier, monospace" font-size="18" font-weight="700">cmd</text>
 </svg>


### PR DESCRIPTION
## Summary

Increase the `webcmd` wordmark in both navigation logo assets from 16px to 18px while preserving the icon, colors, dimensions, and font treatment.

## Verification

- rendered both SVGs and checked spacing/clipping
- `npm test` — 399 files, 4,896 passed, 1 skipped
- `npm run typecheck`
- Mintlify broken-link validation
- SVG geometry and two-file scope assertions