### PR TITLE
feat: add Open Library search adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -15952,6 +15952,46 @@
     "sourceFile": "openfda/food-recall.js"
   },
   {
+    "site": "openlibrary",
+    "name": "search",
+    "description": "Search Open Library works by title, author, subject, or ISBN",
+    "access": "read",
+    "domain": "openlibrary.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Book title, author, subject, or ISBN to search for"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max works to return (1-100)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "workKey",
+      "title",
+      "authors",
+      "firstPublishYear",
+      "editionCount",
+      "languages",
+      "subjects",
+      "isbn",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "openlibrary/search.js",
+    "sourceFile": "openlibrary/search.js"
+  },
+  {
     "site": "openreview",
     "name": "author",
     "description": "List OpenReview submissions by an author profile id (newest first)",

--- a/clis/openlibrary/openlibrary.test.js
+++ b/clis/openlibrary/openlibrary.test.js
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@agentrhq/webcmd/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+import './search.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('openlibrary search adapter', () => {
+    const cmd = getRegistry().get('openlibrary/search');
+
+    it('rejects bad args before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ query: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: 'hobbit', limit: 0 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: 'hobbit', limit: 101 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps HTTP 429 to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('rate limited', { status: 429 })));
+        await expect(cmd.func({ query: 'hobbit', limit: 5 })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError when no works match', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ numFound: 0, docs: [] }), { status: 200 })));
+        await expect(cmd.func({ query: 'zzzzzzzzzz-no-book', limit: 5 })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('maps work rows with stable ids and canonical Open Library URLs', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            numFound: 1,
+            docs: [{
+                key: '/works/OL27448W',
+                title: 'The Lord of the Rings',
+                author_name: ['J.R.R. Tolkien', 'Christopher Tolkien'],
+                first_publish_year: 1954,
+                edition_count: 251,
+                language: ['eng', 'fre', 'ger'],
+                subject: ['Middle Earth', 'Fantasy'],
+                isbn: ['9780261103252', '0261103253'],
+            }],
+        }), { status: 200 })));
+
+        const rows = await cmd.func({ query: 'lord of the rings', limit: 5 });
+        expect(rows[0]).toMatchObject({
+            rank: 1,
+            workKey: 'OL27448W',
+            title: 'The Lord of the Rings',
+            authors: 'J.R.R. Tolkien, Christopher Tolkien',
+            firstPublishYear: 1954,
+            editionCount: 251,
+            languages: 'eng, fre, ger',
+            subjects: 'Middle Earth, Fantasy',
+            isbn: '9780261103252',
+            url: 'https://openlibrary.org/works/OL27448W',
+        });
+    });
+});

--- a/clis/openlibrary/search.js
+++ b/clis/openlibrary/search.js
@@ -1,0 +1,59 @@
+// openlibrary search — search public Open Library work records by keyword.
+//
+// Hits `https://openlibrary.org/search.json` anonymously and returns stable work
+// keys that round-trip into canonical Open Library work URLs.
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { EmptyResultError } from '@agentrhq/webcmd/errors';
+import {
+    OPENLIBRARY_BASE, joinList, normalizeWorkKey, openLibraryFetch, requireBoundedInt, requireString,
+} from './utils.js';
+
+cli({
+    site: 'openlibrary',
+    name: 'search',
+    access: 'read',
+    description: 'Search Open Library works by title, author, subject, or ISBN',
+    domain: 'openlibrary.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, type: 'string', required: true, help: 'Book title, author, subject, or ISBN to search for' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max works to return (1-100)' },
+    ],
+    columns: [
+        'rank', 'workKey', 'title', 'authors', 'firstPublishYear', 'editionCount',
+        'languages', 'subjects', 'isbn', 'url',
+    ],
+    func: async (args) => {
+        const query = requireString(args.query, 'query');
+        const limit = requireBoundedInt(args.limit, 20, 100);
+        const url = `${OPENLIBRARY_BASE}/search.json?`
+            + `q=${encodeURIComponent(query)}`
+            + `&limit=${limit}`
+            + '&fields=key,title,author_name,first_publish_year,edition_count,language,subject,isbn';
+        const body = await openLibraryFetch(url, 'openlibrary search');
+        const docs = Array.isArray(body?.docs) ? body.docs : [];
+        if (docs.length === 0) {
+            throw new EmptyResultError('openlibrary search', `No Open Library works matched "${query}".`);
+        }
+        const rows = docs.slice(0, limit).map((doc, i) => {
+            const workKey = normalizeWorkKey(doc?.key);
+            return {
+                rank: i + 1,
+                workKey,
+                title: String(doc?.title ?? '').trim(),
+                authors: joinList(doc?.author_name, 5),
+                firstPublishYear: Number.isInteger(doc?.first_publish_year) ? doc.first_publish_year : null,
+                editionCount: Number.isInteger(doc?.edition_count) ? doc.edition_count : null,
+                languages: joinList(doc?.language, 5),
+                subjects: joinList(doc?.subject, 5),
+                isbn: Array.isArray(doc?.isbn) && doc.isbn.length > 0 ? String(doc.isbn[0]).trim() : '',
+                url: workKey ? `${OPENLIBRARY_BASE}/works/${workKey}` : '',
+            };
+        });
+        if (rows.length === 0) {
+            throw new EmptyResultError('openlibrary search', `Open Library returned no usable works matching "${query}".`);
+        }
+        return rows;
+    },
+});

--- a/clis/openlibrary/utils.js
+++ b/clis/openlibrary/utils.js
@@ -1,0 +1,75 @@
+// Shared helpers for the Open Library adapters.
+//
+// Open Library publishes a free, unauthenticated Books API at
+// https://openlibrary.org/developers/api. This adapter uses the public search
+// endpoint only; no cookies, login, or account state are required.
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+
+export const OPENLIBRARY_BASE = 'https://openlibrary.org';
+const UA = 'webcmd-openlibrary-adapter/1.0 (+https://github.com/agentrhq/webcmd)';
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) throw new ArgumentError(`openlibrary ${label} cannot be empty`);
+    if (s.length > 200) {
+        throw new ArgumentError(`openlibrary ${label} must be <= 200 characters`);
+    }
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`openlibrary ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`openlibrary ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+export async function openLibraryFetch(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that openlibrary.org is reachable from this network.',
+        );
+    }
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `Open Library returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 429 (rate limited)`,
+            'Open Library throttles anonymous traffic; back off and retry.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    try {
+        return await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+}
+
+export function joinList(value, max = 5) {
+    if (!Array.isArray(value)) return '';
+    const items = value.map(item => String(item ?? '').trim()).filter(Boolean);
+    if (items.length === 0) return '';
+    if (items.length > max) return [...items.slice(0, max), `(+${items.length - max})`].join(', ');
+    return items.join(', ');
+}
+
+export function normalizeWorkKey(key) {
+    const s = String(key ?? '').trim();
+    const match = s.match(/^\/works\/(OL\d+W)$/i) ?? s.match(/^(OL\d+W)$/i);
+    return match ? match[1].toUpperCase() : '';
+}


### PR DESCRIPTION
## Summary
- Adds an anonymous read-only `openlibrary search` adapter using Open Library's public `search.json` API.
- Returns stable work keys, canonical Open Library URLs, author/title/publication metadata, languages, subjects, and ISBN.
- Adds adapter tests for argument validation, HTTP/rate-limit error mapping, empty results, and result mapping.

## Verification
- `node dist/src/main.js list -f json` (confirmed no pre-existing Open Library adapter before implementation; after build shows `openlibrary/search`)
- Anonymous endpoint replay: `curl -sS -D /tmp/openlibrary.headers 'https://openlibrary.org/search.json?q=lord%20of%20the%20rings&limit=3' -o /tmp/openlibrary.search.json` returned HTTP 200 and real work rows
- `npx vitest run --project adapter clis/openlibrary/openlibrary.test.js` → 4 tests passed
- `npm run build` → manifest compiled with 784 entries
- `node dist/src/main.js validate openlibrary/search` → PASS, 0 errors, 0 warnings
- `node dist/src/main.js openlibrary search --help` → inspected command help and read/browser metadata
- `node dist/src/main.js openlibrary search 'lord of the rings' --limit 3 -f json` → returned real Open Library rows including `OL27448W`, `OL27513W`, and `OL27479W`
- `npm run typecheck` → passed
- `npm test` → 400 files passed, 4900 tests passed, 1 skipped
- `git diff --check` → passed
