### PR TITLE
feat: add BMWBLOG search adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -3517,6 +3517,43 @@
     "sourceFile": "bluesky/user.js"
   },
   {
+    "site": "bmwblog",
+    "name": "search",
+    "description": "Search BMWBLOG articles by keyword",
+    "access": "read",
+    "domain": "www.bmwblog.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Search keywords, e.g. iX3"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Number of articles to return (1-50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "slug",
+      "published",
+      "excerpt",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "bmwblog/search.js",
+    "sourceFile": "bmwblog/search.js"
+  },
+  {
     "site": "booking",
     "name": "search",
     "description": "Search Booking.com hotels by destination and dates (server-rendered card scrape).",

--- a/clis/bmwblog/bmwblog.test.js
+++ b/clis/bmwblog/bmwblog.test.js
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@agentrhq/webcmd/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+import './search.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('bmwblog search adapter', () => {
+    const cmd = getRegistry().get('bmwblog/search');
+
+    it('registers an anonymous public API command with useful article columns', () => {
+        expect(cmd).toBeTruthy();
+        expect(cmd?.browser).toBe(false);
+        expect(cmd?.strategy).toBe('public');
+        expect(cmd?.access).toBe('read');
+        expect(cmd?.columns).toEqual(['rank', 'id', 'title', 'slug', 'published', 'excerpt', 'url']);
+    });
+
+    it('requires a non-empty search query before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ query: '   ', limit: 5 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('requires a bounded positive limit before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ query: 'iX3', limit: 0 })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: 'iX3', limit: 51 })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps WordPress posts into stable article rows', async () => {
+        const posts = [
+            {
+                id: 515381,
+                date: '2026-07-10T08:30:00',
+                slug: 'bmw-ix3-nearly-100000-orders',
+                link: 'https://www.bmwblog.com/2026/07/10/bmw-ix3-nearly-100000-orders/',
+                title: { rendered: 'The New BMW iX3 Is Closing In On 100,000 Orders' },
+                excerpt: { rendered: '<p>BMW&#8217;s new SUV has strong demand &amp; momentum.</p>\n' },
+            },
+        ];
+        const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify(posts), { status: 200 }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const rows = await cmd.func({ query: 'iX3', limit: '5' });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const url = new URL(fetchMock.mock.calls[0][0]);
+        expect(url.origin + url.pathname).toBe('https://www.bmwblog.com/wp-json/wp/v2/posts');
+        expect(url.searchParams.get('search')).toBe('iX3');
+        expect(url.searchParams.get('per_page')).toBe('5');
+        expect(rows).toEqual([
+            {
+                rank: 1,
+                id: 515381,
+                title: 'The New BMW iX3 Is Closing In On 100,000 Orders',
+                slug: 'bmw-ix3-nearly-100000-orders',
+                published: '2026-07-10',
+                excerpt: 'BMW’s new SUV has strong demand & momentum.',
+                url: 'https://www.bmwblog.com/2026/07/10/bmw-ix3-nearly-100000-orders/',
+            },
+        ]);
+    });
+
+    it('surfaces empty result pages as EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('[]', { status: 200 })));
+
+        await expect(cmd.func({ query: 'definitely-no-such-bmwblog-term', limit: 5 }))
+            .rejects.toThrow(EmptyResultError);
+    });
+
+    it('wraps HTTP, network, and malformed JSON failures', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('Server error', { status: 500 })));
+        await expect(cmd.func({ query: 'iX3', limit: 5 })).rejects.toThrow(CommandExecutionError);
+
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+        await expect(cmd.func({ query: 'iX3', limit: 5 })).rejects.toThrow(CommandExecutionError);
+
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not json', { status: 200 })));
+        await expect(cmd.func({ query: 'iX3', limit: 5 })).rejects.toThrow(CommandExecutionError);
+    });
+});

--- a/clis/bmwblog/search.js
+++ b/clis/bmwblog/search.js
@@ -1,0 +1,130 @@
+// BMWBLOG search — anonymous read-only article search.
+//
+// Strategy: PUBLIC_API
+// Contract: stable WordPress REST `/wp-json/wp/v2/posts` public endpoint
+// Evidence: anonymous GET returned HTTP 200, JSON post rows, and `allow: GET`.
+// Why not simpler: RSS exposes latest posts but not arbitrary article search.
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+
+const BASE_URL = 'https://www.bmwblog.com/wp-json/wp/v2/posts';
+const UA = 'webcmd-bmwblog-adapter (+https://github.com/agentrhq/webcmd)';
+
+const HTML_ENTITIES = {
+    amp: '&',
+    lt: '<',
+    gt: '>',
+    quot: '"',
+    apos: "'",
+    nbsp: ' ',
+    rsquo: '’',
+    lsquo: '‘',
+    rdquo: '”',
+    ldquo: '“',
+    hellip: '…',
+    ndash: '–',
+    mdash: '—',
+};
+
+function requireQuery(value) {
+    const query = String(value ?? '').trim();
+    if (!query) {
+        throw new ArgumentError('bmwblog query cannot be empty');
+    }
+    return query;
+}
+
+function requireBoundedInt(value, defaultValue, maxValue, label) {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`bmwblog ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`bmwblog ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+function decodeHtml(value) {
+    return String(value ?? '')
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => {
+            const code = parseInt(hex, 16);
+            return Number.isFinite(code) ? String.fromCodePoint(code) : '';
+        })
+        .replace(/&#(\d+);/g, (_, dec) => {
+            const code = parseInt(dec, 10);
+            return Number.isFinite(code) ? String.fromCodePoint(code) : '';
+        })
+        .replace(/&([a-zA-Z]+);/g, (match, name) => HTML_ENTITIES[name] ?? match)
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+async function fetchJson(url, label) {
+    let resp;
+    try {
+        resp = await fetch(url, {
+            headers: {
+                'user-agent': UA,
+                accept: 'application/json',
+            },
+        });
+    }
+    catch (err) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${err?.message ?? err}`,
+            'Check that www.bmwblog.com is reachable from this network.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    try {
+        return await resp.json();
+    }
+    catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+}
+
+cli({
+    site: 'bmwblog',
+    name: 'search',
+    access: 'read',
+    description: 'Search BMWBLOG articles by keyword',
+    domain: 'www.bmwblog.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', type: 'string', required: true, positional: true, help: 'Search keywords, e.g. iX3' },
+        { name: 'limit', type: 'int', default: 10, help: 'Number of articles to return (1-50)' },
+    ],
+    columns: ['rank', 'id', 'title', 'slug', 'published', 'excerpt', 'url'],
+    func: async (args) => {
+        const query = requireQuery(args.query);
+        const limit = requireBoundedInt(args.limit, 10, 50, 'limit');
+        const url = new URL(BASE_URL);
+        url.searchParams.set('search', query);
+        url.searchParams.set('per_page', String(limit));
+        url.searchParams.set('status', 'publish');
+        url.searchParams.set('_fields', 'id,date,slug,link,title.rendered,excerpt.rendered');
+
+        const body = await fetchJson(url.toString(), 'bmwblog search');
+        const posts = Array.isArray(body) ? body : [];
+        if (!posts.length) {
+            throw new EmptyResultError('bmwblog search', `No BMWBLOG articles found for "${query}".`);
+        }
+
+        return posts.map((post, i) => ({
+            rank: i + 1,
+            id: post.id != null ? Number(post.id) : null,
+            title: decodeHtml(post?.title?.rendered),
+            slug: String(post.slug ?? ''),
+            published: String(post.date ?? '').slice(0, 10),
+            excerpt: decodeHtml(post?.excerpt?.rendered),
+            url: String(post.link ?? ''),
+        }));
+    },
+});


### PR DESCRIPTION
## Summary
- Add a read-only anonymous `bmwblog search` adapter backed by BMWBLOG's public WordPress REST posts endpoint.
- Return stable article rows with rank, id, title, slug, published date, excerpt, and canonical URL.
- Regenerate `cli-manifest.json` and cover registration, argument validation, result mapping, empty results, and HTTP/network/malformed JSON failures.

## Strategy
Strategy: PUBLIC_API
Contract: stable WordPress REST `/wp-json/wp/v2/posts` public endpoint
Evidence: anonymous GET to `https://www.bmwblog.com/wp-json/wp/v2/posts?search=iX3&per_page=3` returned HTTP 200 and public article JSON with `allow: GET`.
Why not simpler: RSS exposes latest posts but not arbitrary article search.

## Verification
- `webcmd list -f json` (805 commands; no BMWBLOG/bmwblog.com hit)
- `curl -sS -D /tmp/bmwblog.headers -o /tmp/bmwblog.posts 'https://www.bmwblog.com/wp-json/wp/v2/posts?per_page=3&_fields=id,date,link,title,excerpt,slug,author,categories'` (HTTP 200, public JSON rows)
- `npm run test:adapter -- clis/bmwblog/bmwblog.test.js` (6 passed; RED first failed on missing `./search.js`)
- `npm run build` (manifest compiled: 784 entries)
- `node dist/src/main.js validate bmwblog/search` (PASS; 1 command, 0 errors, 0 warnings)
- `node dist/src/main.js bmwblog search --help`
- `node dist/src/main.js bmwblog search iX3 -f json` (returned 10 live BMWBLOG article rows)
- `npm run typecheck`
- `npm test` (400 files passed; 4902 passed, 1 skipped)
- `git diff --check`
