### PR TITLE
feat: add NDTV top stories adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -14854,6 +14854,36 @@
     "sourceFile": "mercury/reimbursement-plan.js"
   },
   {
+    "site": "ndtv",
+    "name": "top-stories",
+    "description": "NDTV top stories from the public RSS feed",
+    "access": "read",
+    "domain": "www.ndtv.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 5,
+        "required": false,
+        "help": "Number of top stories to return (1-50, default 5)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "title",
+      "description",
+      "pubDate",
+      "id",
+      "url"
+    ],
+    "defaultFormat": "table",
+    "type": "js",
+    "modulePath": "ndtv/top-stories.js",
+    "sourceFile": "ndtv/top-stories.js"
+  },
+  {
     "site": "notebooklm",
     "name": "add-source",
     "description": "Add a URL, text, or local file source to an existing NotebookLM notebook",

--- a/clis/ndtv/top-stories.js
+++ b/clis/ndtv/top-stories.js
@@ -1,0 +1,35 @@
+// ndtv top-stories — public RSS feed, no browser or account required.
+//
+// Strategy: PUBLIC_API
+// Contract: stable public RSS exposed by FeedBurner for NDTV top stories.
+// Evidence: https://feeds.feedburner.com/ndtvnews-top-stories returns HTTP 200
+// with current NDTV article titles, dates, descriptions, and canonical links.
+// Why not simpler: ndtv.com homepage anonymous fetch returns HTTP 403 in this
+// environment, while the official public RSS replay is anonymous and read-only.
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { EmptyResultError } from '@agentrhq/webcmd/errors';
+import { ndtvFetchTopStoriesRss, parseNdtvTopStoriesRss, requireNdtvLimit } from './utils.js';
+
+cli({
+  site: 'ndtv',
+  name: 'top-stories',
+  access: 'read',
+  description: 'NDTV top stories from the public RSS feed',
+  domain: 'www.ndtv.com',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'limit', type: 'int', default: 5, help: 'Number of top stories to return (1-50, default 5)' },
+  ],
+  columns: ['rank', 'title', 'description', 'pubDate', 'id', 'url'],
+  defaultFormat: 'table',
+  func: async (args) => {
+    const limit = requireNdtvLimit(args.limit, 5, 50);
+    const xml = await ndtvFetchTopStoriesRss();
+    const items = parseNdtvTopStoriesRss(xml);
+    if (!items.length) {
+      throw new EmptyResultError('ndtv top-stories', 'NDTV top stories feed returned no items.');
+    }
+    return items.slice(0, limit).map((item, i) => ({ rank: i + 1, ...item }));
+  },
+});

--- a/clis/ndtv/top-stories.test.js
+++ b/clis/ndtv/top-stories.test.js
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+import { getRegistry } from '@agentrhq/webcmd/registry';
+
+const { ndtvFetchTopStoriesRssMock } = vi.hoisted(() => ({ ndtvFetchTopStoriesRssMock: vi.fn() }));
+vi.mock('./utils.js', async () => {
+  const actual = await vi.importActual('./utils.js');
+  return { ...actual, ndtvFetchTopStoriesRss: ndtvFetchTopStoriesRssMock };
+});
+
+import './top-stories.js';
+
+const sampleRss = `<?xml version="1.0" encoding="UTF-8"?>
+<rss><channel>
+  <item>
+    <title><![CDATA[First &amp; Biggest Story]]></title>
+    <description><![CDATA[Lead story summary with <b>markup</b>.]]></description>
+    <link>https://www.ndtv.com/india-news/first-story-123#publisher=newsstand</link>
+    <guid isPermaLink="false">first-story-123</guid>
+    <pubDate>Wed, 22 Jul 2026 09:24:37 GMT</pubDate>
+  </item>
+  <item>
+    <title>Second Story</title>
+    <description>Second summary</description>
+    <link>https://www.ndtv.com/world-news/second-story-456</link>
+    <guid>https://www.ndtv.com/world-news/second-story-456</guid>
+    <pubDate>Wed, 22 Jul 2026 08:15:00 GMT</pubDate>
+  </item>
+</channel></rss>`;
+
+describe('ndtv top-stories', () => {
+  beforeEach(() => {
+    ndtvFetchTopStoriesRssMock.mockReset();
+  });
+
+  it('registers as an anonymous read-only public command with default limit 5', async () => {
+    const command = getRegistry().get('ndtv/top-stories');
+    expect(command).toBeDefined();
+    expect(command.access).toBe('read');
+    expect(command.browser).toBe(false);
+    ndtvFetchTopStoriesRssMock.mockResolvedValueOnce(sampleRss);
+
+    const rows = await command.func({});
+
+    expect(rows).toEqual([
+      {
+        rank: 1,
+        title: 'First & Biggest Story',
+        description: 'Lead story summary with markup.',
+        pubDate: '2026-07-22T09:24:37.000Z',
+        id: 'first-story-123',
+        url: 'https://www.ndtv.com/india-news/first-story-123',
+      },
+      {
+        rank: 2,
+        title: 'Second Story',
+        description: 'Second summary',
+        pubDate: '2026-07-22T08:15:00.000Z',
+        id: 'second-story-456',
+        url: 'https://www.ndtv.com/world-news/second-story-456',
+      },
+    ]);
+  });
+
+  it('rejects invalid limits with typed argument errors', async () => {
+    const command = getRegistry().get('ndtv/top-stories');
+    await expect(command.func({ limit: 0 })).rejects.toBeInstanceOf(ArgumentError);
+    await expect(command.func({ limit: 51 })).rejects.toBeInstanceOf(ArgumentError);
+  });
+
+  it('maps an empty feed to EmptyResultError', async () => {
+    const command = getRegistry().get('ndtv/top-stories');
+    ndtvFetchTopStoriesRssMock.mockResolvedValueOnce('<rss><channel></channel></rss>');
+    await expect(command.func({ limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
+  });
+
+  it('maps malformed RSS to a typed execution error', async () => {
+    const command = getRegistry().get('ndtv/top-stories');
+    ndtvFetchTopStoriesRssMock.mockResolvedValueOnce('<rss><channel><item><title>Missing URL</title></item></channel></rss>');
+    await expect(command.func({ limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+  });
+});

--- a/clis/ndtv/utils.js
+++ b/clis/ndtv/utils.js
@@ -1,0 +1,113 @@
+import { ArgumentError, CommandExecutionError } from '@agentrhq/webcmd/errors';
+
+export const NDTV_TOP_STORIES_RSS_URL = 'https://feeds.feedburner.com/ndtvnews-top-stories';
+const UA = 'webcmd-ndtv-adapter (+https://github.com/agentrhq/webcmd)';
+
+const HTML_ENTITIES = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&apos;': "'",
+  '&#39;': "'",
+  '&nbsp;': ' ',
+};
+
+export function decodeHtmlEntities(value) {
+  return String(value ?? '')
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => String.fromCodePoint(parseInt(h, 16)))
+    .replace(/&#(\d+);/g, (_, d) => String.fromCodePoint(parseInt(d, 10)))
+    .replace(/&(amp|lt|gt|quot|apos|#39|nbsp);/g, (m) => HTML_ENTITIES[m] || m);
+}
+
+export function stripHtml(value) {
+  return decodeHtmlEntities(String(value ?? '').replace(/<[^>]*>/g, ' '))
+    .replace(/\s+/g, ' ')
+    .replace(/\s+([.,;:!?])/g, '$1')
+    .trim();
+}
+
+export function extractRssTag(block, tag) {
+  const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const cdata = block.match(new RegExp(`<${escaped}[^>]*>\\s*<!\\[CDATA\\[([\\s\\S]*?)\\]\\]>\\s*<\\/${escaped}>`));
+  if (cdata) return cdata[1];
+  const plain = block.match(new RegExp(`<${escaped}[^>]*>([\\s\\S]*?)<\\/${escaped}>`));
+  return plain ? plain[1] : '';
+}
+
+export function requireNdtvLimit(value, defaultValue = 5, maxValue = 50) {
+  const raw = value ?? defaultValue;
+  const n = typeof raw === 'number' ? raw : Number(raw);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new ArgumentError('ndtv limit must be a positive integer');
+  }
+  if (n > maxValue) {
+    throw new ArgumentError(`ndtv limit must be <= ${maxValue}`);
+  }
+  return n;
+}
+
+export function canonicalizeNdtvUrl(value) {
+  const raw = decodeHtmlEntities(value).trim();
+  if (!raw) return '';
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new CommandExecutionError(`NDTV feed returned malformed article URL: ${raw}`);
+  }
+  parsed.hash = '';
+  return parsed.toString();
+}
+
+export function ndtvIdFromUrl(url, fallback = '') {
+  const path = new URL(url).pathname;
+  const leaf = path.split('/').filter(Boolean).pop() || '';
+  return leaf || fallback;
+}
+
+export function parseNdtvTopStoriesRss(xml) {
+  const items = [];
+  const re = /<item[^>]*>([\s\S]*?)<\/item>/g;
+  let m;
+  while ((m = re.exec(String(xml || ''))) !== null) {
+    const block = m[1];
+    const title = stripHtml(extractRssTag(block, 'title'));
+    const description = stripHtml(extractRssTag(block, 'description'));
+    const rawLink = extractRssTag(block, 'link') || extractRssTag(block, 'guid');
+    if (!title || !rawLink) {
+      throw new CommandExecutionError('NDTV top stories feed returned a malformed item without a title or URL');
+    }
+    const url = canonicalizeNdtvUrl(rawLink);
+    const pubDateRaw = stripHtml(extractRssTag(block, 'pubDate'));
+    const date = pubDateRaw ? new Date(pubDateRaw) : null;
+    const pubDate = date && !Number.isNaN(date.getTime()) ? date.toISOString() : '';
+    const guid = stripHtml(extractRssTag(block, 'guid'));
+    items.push({
+      title,
+      description,
+      pubDate,
+      id: ndtvIdFromUrl(url, guid),
+      url,
+    });
+  }
+  return items;
+}
+
+export async function ndtvFetchTopStoriesRss() {
+  let resp;
+  try {
+    resp = await fetch(NDTV_TOP_STORIES_RSS_URL, {
+      headers: { 'user-agent': UA, accept: 'application/rss+xml, application/xml, text/xml' },
+    });
+  } catch (err) {
+    throw new CommandExecutionError(
+      `NDTV top stories request failed: ${err?.message ?? err}`,
+      'Check that feeds.feedburner.com is reachable from this network.',
+    );
+  }
+  if (!resp.ok) {
+    throw new CommandExecutionError(`NDTV top stories returned HTTP ${resp.status} (${NDTV_TOP_STORIES_RSS_URL})`);
+  }
+  return resp.text();
+}


### PR DESCRIPTION
## Summary
- Add `ndtv top-stories`, an anonymous read-only adapter backed by NDTV's public FeedBurner RSS feed.
- Default `--limit` is 5 and results include rank, title, description, publication date, stable URL-derived ID, and canonical NDTV URL.
- Add adapter tests for registration/result mapping, bounds validation, empty feeds, and malformed items; regenerate `cli-manifest.json`.

## Verification
- `webcmd list -f json` before implementation: no existing NDTV adapter in 805 commands.
- Anonymous endpoint replay: `curl -L https://feeds.feedburner.com/ndtvnews-top-stories` returned HTTP 200 and 20 live `<item>` entries.
- `npx vitest run --project adapter clis/ndtv/top-stories.test.js` (RED before implementation: missing adapter; GREEN after implementation: 4 tests passed)
- `npm run build` (manifest compiled: 784 entries)
- `node dist/src/main.js validate ndtv/top-stories` (PASS, 0 errors / 0 warnings)
- `node dist/src/main.js ndtv top-stories --help`
- `node dist/src/main.js ndtv top-stories --limit 5 -f json` (returned 5 live NDTV top stories)
- `npm run typecheck`
- `npm test` (400 files passed, 4900 tests passed, 1 skipped)
- `git diff --check`
