### PR TITLE
feat(bmwblog): add read-only search adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -3517,6 +3517,42 @@
     "sourceFile": "bluesky/user.js"
   },
   {
+    "site": "bmwblog",
+    "name": "search",
+    "description": "Search published BMWBLOG articles",
+    "access": "read",
+    "domain": "www.bmwblog.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Article search query, for example \"BMW M3\""
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Maximum articles to return (1-50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "date",
+      "excerpt",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "bmwblog/search.js",
+    "sourceFile": "bmwblog/search.js"
+  },
+  {
     "site": "booking",
     "name": "search",
     "description": "Search Booking.com hotels by destination and dates (server-rendered card scrape).",

--- a/clis/bmwblog/search.js
+++ b/clis/bmwblog/search.js
@@ -1,0 +1,153 @@
+// bmwblog search — search published BMWBLOG articles through its public WordPress REST API.
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+
+const API_URL = 'https://www.bmwblog.com/wp-json/wp/v2/posts';
+
+function decodeHtml(value) {
+    const named = {
+        amp: '&', apos: "'", gt: '>', hellip: '…', lt: '<', nbsp: ' ', quot: '"',
+        lsquo: '‘', rsquo: '’', ldquo: '“', rdquo: '”', ndash: '–', mdash: '—',
+        bull: '•', cent: '¢', copy: '©', euro: '€', laquo: '«', middot: '·',
+        pound: '£', raquo: '»', reg: '®', trade: '™', yen: '¥',
+    };
+    const decoded = value
+        .replace(/<[^>]*>/g, ' ')
+        .replace(/&#(x[0-9a-f]+|\d+);/gi, (_, code) => {
+            const number = code[0].toLowerCase() === 'x'
+                ? Number.parseInt(code.slice(1), 16)
+                : Number.parseInt(code, 10);
+            if (!Number.isInteger(number) || number < 0 || number > 0x10ffff || (number >= 0xd800 && number <= 0xdfff)) {
+                throw new CommandExecutionError('BMWBLOG search returned an invalid numeric HTML entity');
+            }
+            return String.fromCodePoint(number);
+        })
+        .replace(/&([a-z]+);/gi, (match, name) => named[name.toLowerCase()] ?? match)
+        .replace(/\s+/g, ' ')
+        .replace(/\s+([,.!?;:…])/g, '$1')
+        .trim();
+    if (/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/.test(decoded)) {
+        throw new CommandExecutionError('BMWBLOG search returned unsafe control characters');
+    }
+    return decoded;
+}
+
+function parseLimit(value) {
+    const limit = value == null || value === '' ? 10 : Number(value);
+    if (!Number.isInteger(limit) || limit < 1 || limit > 50) {
+        throw new ArgumentError('--limit must be an integer between 1 and 50');
+    }
+    return limit;
+}
+
+function normaliseDate(value) {
+    if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?$/.test(value)) {
+        throw new CommandExecutionError('BMWBLOG search returned an invalid publication date');
+    }
+    const parsed = new Date(`${value}Z`);
+    if (Number.isNaN(parsed.getTime()) || !parsed.toISOString().startsWith(value)) {
+        throw new CommandExecutionError('BMWBLOG search returned an invalid publication date');
+    }
+    return `${value}Z`;
+}
+
+function isCanonicalArticleUrl(value) {
+    try {
+        const url = new URL(value);
+        return url.protocol === 'https:'
+            && url.hostname === 'www.bmwblog.com'
+            && url.port === ''
+            && url.username === ''
+            && url.password === ''
+            && url.search === ''
+            && url.hash === ''
+            && /^\/\d{4}\/\d{2}\/\d{2}\/[^/]+\/$/.test(url.pathname);
+    } catch {
+        return false;
+    }
+}
+
+cli({
+    site: 'bmwblog',
+    name: 'search',
+    access: 'read',
+    description: 'Search published BMWBLOG articles',
+    domain: 'www.bmwblog.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, type: 'string', required: true, help: 'Article search query, for example "BMW M3"' },
+        { name: 'limit', type: 'int', default: 10, help: 'Maximum articles to return (1-50)' },
+    ],
+    columns: ['rank', 'id', 'title', 'date', 'excerpt', 'url'],
+    func: async (args) => {
+        const query = String(args.query ?? '').trim();
+        if (!query) throw new ArgumentError('query must be a non-empty string');
+        const limit = parseLimit(args.limit);
+        const params = new URLSearchParams({
+            search: query,
+            per_page: String(limit),
+            _fields: 'id,date_gmt,link,title,excerpt',
+        });
+
+        let response;
+        try {
+            response = await fetch(`${API_URL}?${params}`, {
+                redirect: 'error',
+                headers: {
+                    Accept: 'application/json',
+                    'User-Agent': 'WebCMD BMWBLOG adapter',
+                },
+            });
+        } catch (error) {
+            throw new CommandExecutionError(`BMWBLOG search request failed: ${error instanceof Error ? error.message : String(error)}`);
+        }
+        if (!response.ok) {
+            throw new CommandExecutionError(`BMWBLOG search request failed: HTTP ${response.status}`);
+        }
+
+        let posts;
+        try {
+            posts = await response.json();
+        } catch (error) {
+            throw new CommandExecutionError(`BMWBLOG search returned malformed JSON: ${error instanceof Error ? error.message : String(error)}`);
+        }
+        if (!Array.isArray(posts)) {
+            throw new CommandExecutionError('BMWBLOG search returned an unexpected response shape');
+        }
+        if (!posts.length) {
+            throw new EmptyResultError('bmwblog search', `No BMWBLOG articles matched "${query}".`);
+        }
+
+        const rows = posts.slice(0, limit).map((post, index) => {
+            if (
+                post == null
+                || typeof post !== 'object'
+                || !Number.isSafeInteger(post.id)
+                || post.id <= 0
+                || typeof post.date_gmt !== 'string'
+                || typeof post.link !== 'string'
+                || typeof post.title?.rendered !== 'string'
+                || typeof post.excerpt?.rendered !== 'string'
+            ) {
+                throw new CommandExecutionError('BMWBLOG search returned malformed article data');
+            }
+            const url = post.link.trim();
+            if (!isCanonicalArticleUrl(url)) {
+                throw new CommandExecutionError('BMWBLOG search returned a non-canonical article URL');
+            }
+            return {
+                rank: index + 1,
+                id: post.id,
+                title: decodeHtml(post.title.rendered),
+                date: normaliseDate(post.date_gmt),
+                excerpt: decodeHtml(post.excerpt.rendered),
+                url,
+            };
+        });
+        if (rows.some((row) => !row.title)) {
+            throw new CommandExecutionError('BMWBLOG search returned an empty article title');
+        }
+        return rows;
+    },
+});

--- a/clis/bmwblog/search.test.js
+++ b/clis/bmwblog/search.test.js
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+import { getRegistry } from '@agentrhq/webcmd/registry';
+import './search.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('bmwblog search adapter', () => {
+    const cmd = getRegistry().get('bmwblog/search');
+
+    it('declares an anonymous read-only command', () => {
+        expect(cmd.access).toBe('read');
+        expect(cmd.browser).toBe(false);
+        expect(String(cmd.strategy)).toContain('public');
+    });
+
+    it('rejects an empty query and out-of-range limit before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(cmd.func({ query: '   ', limit: 10 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(cmd.func({ query: 'M3', limit: 0 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(cmd.func({ query: 'M3', limit: 51 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(cmd.func({ query: 'M3', limit: 1.5 })).rejects.toBeInstanceOf(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps published posts with stable ids and canonical URLs', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify([
+            {
+                id: 515560,
+                date_gmt: '2026-07-20T12:00:00',
+                link: 'https://www.bmwblog.com/2026/07/20/bmw-m340i-vs-m3/',
+                slug: 'bmw-m340i-vs-m3',
+                title: { rendered: 'BMW M340i &amp; M3: Buyer&#8217;s Guide' },
+                excerpt: { rendered: '<p>Compare the <strong>two cars</strong>&hellip;</p>' },
+            },
+        ]), { status: 200 })));
+
+        const rows = await cmd.func({ query: 'M3', limit: 5 });
+
+        expect(rows).toEqual([{
+            rank: 1,
+            id: 515560,
+            title: 'BMW M340i & M3: Buyer’s Guide',
+            date: '2026-07-20T12:00:00Z',
+            excerpt: 'Compare the two cars…',
+            url: 'https://www.bmwblog.com/2026/07/20/bmw-m340i-vs-m3/',
+        }]);
+        expect(fetch).toHaveBeenCalledWith(
+            expect.stringContaining('search=M3'),
+            expect.objectContaining({
+                redirect: 'error',
+                headers: expect.objectContaining({ Accept: 'application/json' }),
+            }),
+        );
+    });
+
+    it('throws EmptyResultError when no posts match', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('[]', { status: 200 })));
+        await expect(cmd.func({ query: 'no-such-bmw', limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('rejects malformed nested fields, dates, entities, and non-canonical URLs', async () => {
+        const makePost = (overrides = {}) => ({
+            id: 1,
+            date_gmt: '2026-07-20T12:00:00',
+            link: 'https://www.bmwblog.com/2026/07/20/article/',
+            title: { rendered: 'Article' },
+            excerpt: { rendered: '<p>Excerpt</p>' },
+            ...overrides,
+        });
+        const expectRejectedPost = async (post) => {
+            vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify([post]), { status: 200 })));
+            await expect(cmd.func({ query: 'M3', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+        };
+
+        await expectRejectedPost(makePost({ id: null }));
+        await expectRejectedPost(makePost({ id: Number.MAX_SAFE_INTEGER + 1 }));
+        await expectRejectedPost(makePost({ title: { rendered: { text: 'Article' } } }));
+        await expectRejectedPost(makePost({ excerpt: {} }));
+        await expectRejectedPost(makePost({ date_gmt: 'not-a-date' }));
+        await expectRejectedPost(makePost({ date_gmt: '2026-02-30T12:00:00' }));
+        await expectRejectedPost(makePost({ title: { rendered: '&#99999999;' } }));
+        await expectRejectedPost(makePost({ title: { rendered: '&#27;' } }));
+        await expectRejectedPost(makePost({ title: { rendered: 'Article\u001b[31m' } }));
+        await expectRejectedPost(makePost({ link: { rendered: 'https://www.bmwblog.com/article/' } }));
+        await expectRejectedPost(makePost({ link: 'https://example.com/not-bmwblog/' }));
+        await expectRejectedPost(makePost({ link: 'https://user:pass@www.bmwblog.com/article/' }));
+        await expectRejectedPost(makePost({ link: 'https://www.bmwblog.com:8443/article/' }));
+        await expectRejectedPost(makePost({ link: 'https://www.bmwblog.com/article/' }));
+        await expectRejectedPost(makePost({ link: 'https://www.bmwblog.com/2026/07/20/article/?ref=test' }));
+        await expectRejectedPost(makePost({ link: 'https://www.bmwblog.com/2026/07/20/article/#section' }));
+    });
+
+    it('preserves unsupported or malformed entity text instead of rejecting legitimate content', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify([{
+            id: 1,
+            date_gmt: '2026-07-20T12:00:00',
+            link: 'https://www.bmwblog.com/2026/07/20/article/',
+            title: { rendered: 'BMW &deg; &unsupported; &#xZZ; &#;' },
+            excerpt: { rendered: '<p>Source text</p>' },
+        }]), { status: 200 })));
+
+        const rows = await cmd.func({ query: 'BMW', limit: 5 });
+        expect(rows[0].title).toBe('BMW &deg; &unsupported; &#xZZ; &#;');
+    });
+
+    it('maps HTTP, network, malformed JSON, and malformed shape failures to CommandExecutionError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('unavailable', { status: 503 })));
+        await expect(cmd.func({ query: 'M3', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+        await expect(cmd.func({ query: 'M3', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('<html>', { status: 200 })));
+        await expect(cmd.func({ query: 'M3', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 200 })));
+        await expect(cmd.func({ query: 'M3', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});


### PR DESCRIPTION
## Summary
- add an anonymous, read-only `bmwblog search` command backed by BMWBLOG’s public WordPress REST API
- return stable post IDs, publication timestamps, excerpts, and canonical article URLs
- validate arguments and fail with typed errors for empty results, network failures, malformed responses, unsafe URLs, dates, and control characters
- regenerate `cli-manifest.json`

## Verification
- `npm run build`
- `node dist/src/main.js validate bmwblog/search`
- `node dist/src/main.js bmwblog search --help`
- `node dist/src/main.js bmwblog search "BMW M3" --limit 3 -f json` (anonymous live response: 3 real articles)
- `npx vitest run --project adapter clis/bmwblog/search.test.js` (7 passed)
- `npm run typecheck`
- `npm test` (4903 passed, 1 skipped)
- `npm run check:typed-error-lint`
- `npm run check:hosted-contract`
- `git diff --cached --check`

Closes #137