### PR TITLE
feat(plugin): add pokeapi community plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Webcmd Cloud can run supported commands and browser sessions on hosted infrastru
 
 | Plugin | Description | Author |
 | --- | --- | --- |
+| [`pokeapi`](./plugins/pokeapi/) | Read-only Pokémon data commands powered by PokéAPI | [WebCMD Agent](https://github.com/agentrhq) |
 | [`skyscanner`](./plugins/skyscanner/) | Skyscanner flight search commands for Webcmd | [Rishabh](https://github.com/rishabhraj36) |
 <!-- webcmd-community-plugins:end -->
 

--- a/plugins/pokeapi/README.md
+++ b/plugins/pokeapi/README.md
@@ -1,0 +1,27 @@
+# webcmd-plugin-pokeapi
+
+Read-only Pokémon data commands powered by the public, anonymous [PokéAPI](https://pokeapi.co/).
+
+## Install
+
+```bash
+webcmd plugin install github:agentrhq/webcmd/plugins/pokeapi
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `pokeapi pokemon <name-or-id>` | Get a Pokémon's core details, types, abilities, stats, and sprite |
+| `pokeapi ability <name-or-id>` | Get an ability's English effect and Pokémon usage summary |
+| `pokeapi type <name-or-id>` | Get a type's damage relationships and Pokémon count |
+
+## Examples
+
+```bash
+webcmd pokeapi pokemon pikachu
+webcmd pokeapi ability 9
+webcmd pokeapi type fire
+```
+
+All commands use PokéAPI's unauthenticated read-only REST endpoints. Names are lowercase slugs such as `mr-mime`; numeric resource IDs are also accepted.

--- a/plugins/pokeapi/ability.js
+++ b/plugins/pokeapi/ability.js
@@ -1,0 +1,31 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { englishEntry, pokeFetch, requireResource } from './utils.js';
+
+cli({
+    site: 'pokeapi',
+    name: 'ability',
+    access: 'read',
+    description: 'Get a Pokémon ability by name or PokéAPI id',
+    domain: 'pokeapi.co',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'name-or-id', positional: true, required: true, help: 'Ability name slug or numeric id (e.g. static, 9)' },
+    ],
+    columns: ['id', 'name', 'generation', 'mainSeries', 'pokemonCount', 'effect', 'shortEffect', 'flavorText', 'url'],
+    func: async (args) => {
+        const resource = requireResource(args['name-or-id'], 'ability');
+        const data = await pokeFetch('ability', resource);
+        return [{
+            id: data.id,
+            name: data.name,
+            generation: data.generation?.name ?? '',
+            mainSeries: Boolean(data.is_main_series),
+            pokemonCount: Array.isArray(data.pokemon) ? data.pokemon.length : 0,
+            effect: englishEntry(data.effect_entries, 'effect'),
+            shortEffect: englishEntry(data.effect_entries, 'short_effect'),
+            flavorText: englishEntry(data.flavor_text_entries, 'flavor_text'),
+            url: `${data.id ? `https://pokeapi.co/api/v2/ability/${data.id}/` : ''}`,
+        }];
+    },
+});

--- a/plugins/pokeapi/package.json
+++ b/plugins/pokeapi/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "webcmd-plugin-pokeapi",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Read-only Pokémon data commands powered by PokéAPI",
+  "peerDependencies": {
+    "@agentrhq/webcmd": ">=0.2.0"
+  }
+}

--- a/plugins/pokeapi/pokemon.js
+++ b/plugins/pokeapi/pokemon.js
@@ -1,0 +1,45 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { pokeFetch, requireResource } from './utils.js';
+
+cli({
+    site: 'pokeapi',
+    name: 'pokemon',
+    access: 'read',
+    description: 'Get Pokémon details by name or PokéAPI id',
+    domain: 'pokeapi.co',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'name-or-id', positional: true, required: true, help: 'Pokémon name slug or numeric id (e.g. pikachu, 25)' },
+    ],
+    columns: ['id', 'name', 'types', 'abilities', 'baseExperience', 'height', 'weight', 'stats', 'moveCount', 'sprite', 'url'],
+    func: async (args) => {
+        const resource = requireResource(args['name-or-id'], 'pokemon');
+        const data = await pokeFetch('pokemon', resource);
+        const types = (Array.isArray(data.types) ? data.types : [])
+            .sort((a, b) => Number(a.slot) - Number(b.slot))
+            .map((entry) => entry?.type?.name)
+            .filter(Boolean)
+            .join(', ');
+        const abilities = (Array.isArray(data.abilities) ? data.abilities : [])
+            .map((entry) => `${entry?.ability?.name ?? ''}${entry?.is_hidden ? ' (hidden)' : ''}`)
+            .filter(Boolean)
+            .join(', ');
+        const stats = (Array.isArray(data.stats) ? data.stats : [])
+            .map((entry) => `${entry?.stat?.name ?? 'unknown'}:${entry?.base_stat ?? ''}`)
+            .join(', ');
+        return [{
+            id: data.id,
+            name: data.name,
+            types,
+            abilities,
+            baseExperience: data.base_experience,
+            height: data.height,
+            weight: data.weight,
+            stats,
+            moveCount: Array.isArray(data.moves) ? data.moves.length : 0,
+            sprite: data.sprites?.front_default ?? '',
+            url: data.id ? `https://pokeapi.co/api/v2/pokemon/${data.id}/` : '',
+        }];
+    },
+});

--- a/plugins/pokeapi/type.js
+++ b/plugins/pokeapi/type.js
@@ -1,0 +1,35 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { names, pokeFetch, requireResource } from './utils.js';
+
+cli({
+    site: 'pokeapi',
+    name: 'type',
+    access: 'read',
+    description: 'Get Pokémon type details and damage relationships by name or PokéAPI id',
+    domain: 'pokeapi.co',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'name-or-id', positional: true, required: true, help: 'Type name slug or numeric id (e.g. fire, 10)' },
+    ],
+    columns: ['id', 'name', 'generation', 'doubleDamageFrom', 'doubleDamageTo', 'halfDamageFrom', 'halfDamageTo', 'noDamageFrom', 'noDamageTo', 'pokemonCount', 'moveCount', 'url'],
+    func: async (args) => {
+        const resource = requireResource(args['name-or-id'], 'type');
+        const data = await pokeFetch('type', resource);
+        const damage = data.damage_relations ?? {};
+        return [{
+            id: data.id,
+            name: data.name,
+            generation: data.generation?.name ?? '',
+            doubleDamageFrom: names(damage.double_damage_from),
+            doubleDamageTo: names(damage.double_damage_to),
+            halfDamageFrom: names(damage.half_damage_from),
+            halfDamageTo: names(damage.half_damage_to),
+            noDamageFrom: names(damage.no_damage_from),
+            noDamageTo: names(damage.no_damage_to),
+            pokemonCount: Array.isArray(data.pokemon) ? data.pokemon.length : 0,
+            moveCount: Array.isArray(data.moves) ? data.moves.length : 0,
+            url: `${data.id ? `https://pokeapi.co/api/v2/type/${data.id}/` : ''}`,
+        }];
+    },
+});

--- a/plugins/pokeapi/utils.js
+++ b/plugins/pokeapi/utils.js
@@ -1,0 +1,65 @@
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+
+export const API_BASE = 'https://pokeapi.co/api/v2';
+const RESOURCE = /^(?:[1-9]\d*|[a-z0-9]+(?:-[a-z0-9]+)*)$/;
+
+export function requireResource(value, label) {
+    const resource = String(value ?? '').trim().toLowerCase();
+    if (!resource) {
+        throw new ArgumentError(`pokeapi ${label} name or id is required`);
+    }
+    if (!RESOURCE.test(resource)) {
+        throw new ArgumentError(`pokeapi ${label} must be a positive numeric id or lowercase name slug`);
+    }
+    return resource;
+}
+
+export async function pokeFetch(kind, resource) {
+    const label = `pokeapi ${kind} ${resource}`;
+    const url = `${API_BASE}/${kind}/${encodeURIComponent(resource)}/`;
+    let response;
+    try {
+        response = await fetch(url, {
+            headers: {
+                accept: 'application/json',
+                'user-agent': 'webcmd-pokeapi-plugin (+https://github.com/agentrhq/webcmd)',
+            },
+        });
+    }
+    catch (error) {
+        throw new CommandExecutionError(
+            `${label} request failed: ${error?.message ?? error}`,
+            'Check that pokeapi.co is reachable from this network.',
+        );
+    }
+    if (response.status === 404) {
+        throw new EmptyResultError(label, `PokéAPI has no ${kind} named "${resource}".`);
+    }
+    if (response.status === 429) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 429 (rate limited)`,
+            'Wait briefly before retrying the anonymous PokéAPI request.',
+        );
+    }
+    if (!response.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${response.status}`);
+    }
+    try {
+        return await response.json();
+    }
+    catch (error) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${error?.message ?? error}`);
+    }
+}
+
+export function names(items) {
+    return (Array.isArray(items) ? items : [])
+        .map((item) => item?.name ?? item?.type?.name ?? item?.ability?.name)
+        .filter(Boolean)
+        .join(', ');
+}
+
+export function englishEntry(entries, field) {
+    const list = Array.isArray(entries) ? entries : [];
+    return String(list.find((entry) => entry?.language?.name === 'en')?.[field] ?? '').replace(/\s+/g, ' ').trim();
+}

--- a/plugins/pokeapi/webcmd-plugin.json
+++ b/plugins/pokeapi/webcmd-plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "pokeapi",
+  "version": "0.1.0",
+  "description": "Read-only Pokémon data commands powered by PokéAPI",
+  "webcmd": ">=0.2.0",
+  "author": {
+    "name": "WebCMD Agent",
+    "handle": "agentrhq"
+  }
+}

--- a/webcmd-plugin.json
+++ b/webcmd-plugin.json
@@ -4,6 +4,16 @@
   "description": "Webcmd plugin collection",
   "webcmd": ">=0.2.0",
   "plugins": {
+    "pokeapi": {
+      "path": "plugins/pokeapi",
+      "version": "0.1.0",
+      "description": "Read-only Pokémon data commands powered by PokéAPI",
+      "webcmd": ">=0.2.0",
+      "author": {
+        "name": "WebCMD Agent",
+        "handle": "agentrhq"
+      }
+    },
     "skyscanner": {
       "path": "plugins/skyscanner",
       "version": "0.1.0",


### PR DESCRIPTION
Closes #150

Adds a read-only PokéAPI community plugin with commands for Pokémon, abilities, and types using public anonymous endpoints.

Checks were not run (operator review requested).