### PR TITLE
feat: add hosted builder profile commands

### DIFF
--- a/docs/authentication-and-profiles.mdx
+++ b/docs/authentication-and-profiles.mdx
@@ -40,7 +40,7 @@ webcmd --profile profile_abc123 github whoami
 
 `userId` is your public external-user reference, not Webcmd's internal account ownership. A profile selector is one scalar value: an immutable ID, exact name, or exact `userId`. If one downstream user has several named profiles, their `userId` is ambiguous. Run `webcmd profile list` and use the returned immutable profile ID.
 
-Hosted `profile list`, `create`, `get`, and `delete` return public profile fields: `id`, `name`, `userId`, `default`, `status`, `createdAt`, `updatedAt`, and `lastUsedAt`. `status` is `pending` while the hosted profile is being provisioned and `available` once it is ready. Kernel identifiers and names are never Webcmd API fields.
+Hosted `profile list` returns profile rows; `create` and `get` each return one public profile with `id`, `name`, `userId`, `default`, `status`, `createdAt`, `updatedAt`, and `lastUsedAt`; `delete` returns `{ "ok": true, "deleted": true }`. `status` is `pending` while the hosted profile is being provisioned and `available` once it is ready. Kernel identifiers and names are never Webcmd API fields.
 
 Delete hosted profiles only by immutable ID:
 

--- a/docs/authentication-and-profiles.mdx
+++ b/docs/authentication-and-profiles.mdx
@@ -33,7 +33,7 @@ webcmd --profile Work github whoami
 Builders can attach a public external user reference when creating a profile:
 
 ```bash
-webcmd profile create customer --user-id user_64256 -f json
+webcmd profile create customer_name --user-id customer_email -f json
 # Retain the returned immutable ID, for example profile_abc123.
 webcmd --profile profile_abc123 github whoami
 ```

--- a/docs/authentication-and-profiles.mdx
+++ b/docs/authentication-and-profiles.mdx
@@ -17,6 +17,39 @@ Use Webcmd with my `work` profile to complete this task on Acme Billing. If the 
 
 Profiles separate browser identities and their login state. Use a named profile when work and personal accounts, customers, or environments must stay separate.
 
+## Hosted Profiles
+
+In Webcmd Cloud, no profile selector (or `--profile default`) lazily creates only the hosted default profile. Create every custom hosted profile explicitly. An unknown custom selector fails; it never creates a hosted profile.
+
+```bash
+# B2C: after choosing hosted mode and saving an account API key
+webcmd github whoami
+
+# Optional named identity
+webcmd profile create Work
+webcmd --profile Work github whoami
+```
+
+Builders can attach a public external user reference when creating a profile:
+
+```bash
+webcmd profile create customer --user-id user_64256 -f json
+# Retain the returned immutable ID, for example profile_abc123.
+webcmd --profile profile_abc123 github whoami
+```
+
+`userId` is your public external-user reference, not Webcmd's internal account ownership. A profile selector is one scalar value: an immutable ID, exact name, or exact `userId`. If one downstream user has several named profiles, their `userId` is ambiguous. Run `webcmd profile list` and use the returned immutable profile ID.
+
+Hosted `profile list`, `create`, `get`, and `delete` return public profile fields: `id`, `name`, `userId`, `default`, `status`, `createdAt`, `updatedAt`, and `lastUsedAt`. `status` is `pending` while the hosted profile is being provisioned and `available` once it is ready. Kernel identifiers and names are never Webcmd API fields.
+
+Delete hosted profiles only by immutable ID:
+
+```bash
+webcmd profile delete profile_abc123
+```
+
+Deletion permanently removes that hosted browser state and its saved sign-in state.
+
 ## When You Need to Sign In
 
 When a profile needs interactive sign-in, complete it directly in the browser; never share credentials through chat.
@@ -29,4 +62,4 @@ Credentials never belong in prompts or adapter code. Ask the agent to use an aut
 
 In local mode, `webcmd <site> login` opens the foreground Webcmd browser and returns `action_required` immediately. Complete sign-in in that browser, tell the agent when you are done, and let it run `webcmd <site> whoami` before retrying the original task. Never send credentials, OTPs, cookies, or recovery codes through chat.
 
-Hosted mode is a separate future-facing flow. It will return a Webcmd-owned live authentication view, where you complete the interactive sign-in before the agent continues.
+Hosted mode returns a Webcmd-owned live authentication view when interactive sign-in is required. Complete the sign-in there before the agent continues.

--- a/docs/authentication-and-profiles.mdx
+++ b/docs/authentication-and-profiles.mdx
@@ -33,7 +33,7 @@ webcmd --profile Work github whoami
 Builders can attach a public external user reference when creating a profile:
 
 ```bash
-webcmd profile create customer_name --user-id customer_email -f json
+webcmd profile create customer_name --user-id customer_id -f json
 # Retain the returned immutable ID, for example profile_abc123.
 webcmd --profile profile_abc123 github whoami
 ```

--- a/docs/cli-reference.mdx
+++ b/docs/cli-reference.mdx
@@ -65,12 +65,25 @@ Agents should use JSON unless they are presenting output to a human.
 
 ## Profiles
 
-Profiles keep login state separate:
+Profiles keep login state separate. The profile surface depends on the selected mode.
 
 ```bash
+# Local: existing local profile management
 webcmd profile list
+webcmd profile rename <context-id> work
 webcmd profile use work
+
+# Hosted: explicit custom profile creation and public profile management
+webcmd profile create Work
+webcmd profile create customer --user-id user_64256 -f json
+webcmd profile list
+webcmd profile get Work
+webcmd profile delete profile_abc123
 ```
+
+In local mode, arbitrary `--profile <name>` values lazily create separate local state; local `list`, `rename`, and `use` are unchanged. In hosted mode, only an omitted selector or `--profile default` lazily creates the default profile. Create custom hosted profiles first; unknown custom selectors fail.
+
+Hosted `get` and `--profile` accept one exact scalar selector: profile ID, name, or public `userId`. If it matches more than one profile, run `webcmd profile list` and use its immutable ID. Use that immutable ID for `delete` too: deletion permanently removes hosted browser state. Hosted output exposes only `id`, `name`, `userId`, `default`, `status`, `createdAt`, `updatedAt`, and `lastUsedAt`; `status` is `pending` or `available`. `userId` is an external reference, not internal ownership, and Kernel IDs or names are never exposed.
 
 Prompt example:
 

--- a/docs/cli-reference.mdx
+++ b/docs/cli-reference.mdx
@@ -75,7 +75,7 @@ webcmd profile use work
 
 # Hosted: explicit custom profile creation and public profile management
 webcmd profile create Work
-webcmd profile create customer --user-id user_64256 -f json
+webcmd profile create customer_name --user-id customer_email -f json
 webcmd profile list
 webcmd profile get Work
 webcmd profile delete profile_abc123

--- a/docs/cli-reference.mdx
+++ b/docs/cli-reference.mdx
@@ -83,7 +83,7 @@ webcmd profile delete profile_abc123
 
 In local mode, arbitrary `--profile <name>` values lazily create separate local state; local `list`, `rename`, and `use` are unchanged. In hosted mode, only an omitted selector or `--profile default` lazily creates the default profile. Create custom hosted profiles first; unknown custom selectors fail.
 
-Hosted `get` and `--profile` accept one exact scalar selector: profile ID, name, or public `userId`. If it matches more than one profile, run `webcmd profile list` and use its immutable ID. Use that immutable ID for `delete` too: deletion permanently removes hosted browser state. Hosted output exposes only `id`, `name`, `userId`, `default`, `status`, `createdAt`, `updatedAt`, and `lastUsedAt`; `status` is `pending` or `available`. `userId` is an external reference, not internal ownership, and Kernel IDs or names are never exposed.
+Hosted `get` and `--profile` accept one exact scalar selector: profile ID, name, or public `userId`. If it matches more than one profile, run `webcmd profile list` and use its immutable ID. Use that immutable ID for `delete` too: deletion permanently removes hosted browser state. `list` returns profile rows; `create` and `get` each return one public profile with `id`, `name`, `userId`, `default`, `status`, `createdAt`, `updatedAt`, and `lastUsedAt`; `delete` returns `{ "ok": true, "deleted": true }`. `status` is `pending` or `available`. `userId` is an external reference, not internal ownership, and Kernel IDs or names are never exposed.
 
 Prompt example:
 

--- a/docs/cli-reference.mdx
+++ b/docs/cli-reference.mdx
@@ -75,7 +75,7 @@ webcmd profile use work
 
 # Hosted: explicit custom profile creation and public profile management
 webcmd profile create Work
-webcmd profile create customer_name --user-id customer_email -f json
+webcmd profile create customer_name --user-id customer_id -f json
 webcmd profile list
 webcmd profile get Work
 webcmd profile delete profile_abc123

--- a/docs/local-or-cloud.mdx
+++ b/docs/local-or-cloud.mdx
@@ -27,13 +27,23 @@ Webcmd Cloud alpha is for supported commands and browser sessions on hosted infr
 2. Create and copy an API key from the account page.
 3. Run `webcmd setup`, choose hosted mode, and paste the key when prompted.
 
-Hosted browser tasks can use named profiles. When sign-in is required, Webcmd returns a Webcmd-owned live authentication view; complete sign-in there, then let the agent continue. See [Authentication and Profiles](/authentication-and-profiles).
+Hosted browser tasks can use named profiles. In Cloud, omitted `--profile` (and `--profile default`) is the only lazy profile: it creates the hosted default profile. Create a custom profile with `webcmd profile create <name>` before selecting it. Unknown custom selectors fail instead of creating browser state.
+
+```bash
+# Builder-created customer profile; retain the returned immutable profile ID.
+webcmd profile create customer --user-id user_64256 -f json
+webcmd --profile profile_abc123 github whoami
+```
+
+`userId` is a public external-user reference. It may match multiple profiles, so use `webcmd profile list` and the immutable ID when a selector is ambiguous. `webcmd profile delete <profile-id>` permanently removes hosted browser state. When sign-in is required, Webcmd returns a Webcmd-owned live authentication view; complete sign-in there, then let the agent continue. See [Authentication and Profiles](/authentication-and-profiles).
 
 View hosted usage on the account page.
 
 ## What Stays Separate
 
 Local and hosted profiles, adapters, site memory, and traces do not sync. Treat each mode as its own working environment.
+
+Local profile behavior is unchanged: an arbitrary `--profile <name>` lazily creates separate local browser state. Local `webcmd profile list`, `rename`, and `use` continue to manage that local state; they do not create or manage hosted profiles.
 
 ## Current Boundaries
 

--- a/docs/local-or-cloud.mdx
+++ b/docs/local-or-cloud.mdx
@@ -31,7 +31,7 @@ Hosted browser tasks can use named profiles. In Cloud, omitted `--profile` (and 
 
 ```bash
 # Builder-created customer profile; retain the returned immutable profile ID.
-webcmd profile create customer_name --user-id customer_email -f json
+webcmd profile create customer_name --user-id customer_id -f json
 webcmd --profile profile_abc123 github whoami
 ```
 

--- a/docs/local-or-cloud.mdx
+++ b/docs/local-or-cloud.mdx
@@ -31,7 +31,7 @@ Hosted browser tasks can use named profiles. In Cloud, omitted `--profile` (and 
 
 ```bash
 # Builder-created customer profile; retain the returned immutable profile ID.
-webcmd profile create customer --user-id user_64256 -f json
+webcmd profile create customer_name --user-id customer_email -f json
 webcmd --profile profile_abc123 github whoami
 ```
 

--- a/src/completion-shared.ts
+++ b/src/completion-shared.ts
@@ -43,6 +43,7 @@ export const HOSTED_ROOT_HELP: RootHelpPresentation = {
     { name: 'browser', description: 'Browser control through a hosted browser session' },
     { name: 'completion <shell>', description: 'Output a shell completion script' },
     { name: 'list', description: 'List all available hosted CLI commands' },
+    { name: 'profile', description: 'Manage hosted browser profiles' },
     { name: 'setup', description: 'Configure local or hosted mode' },
   ],
   localOnlyCommands: [
@@ -54,7 +55,6 @@ export const HOSTED_ROOT_HELP: RootHelpPresentation = {
     { name: 'doctor', description: 'Diagnose local browser bridge connectivity' },
     { name: 'external', description: 'Manage local CLI passthrough commands' },
     { name: 'plugin', description: 'Manage plugins installed on this computer' },
-    { name: 'profile', description: 'Manage profiles in the local browser runtime' },
     { name: 'skills', description: 'Manage bundled skills on this computer' },
     { name: 'validate', description: 'Validate local CLI definitions' },
     { name: 'verify', description: 'Validate and smoke-test local adapters' },

--- a/src/docs-sync-review.test.ts
+++ b/src/docs-sync-review.test.ts
@@ -120,6 +120,21 @@ describe('review context', () => {
     ]);
   });
 
+  it('selects profile documentation for hosted profile changes', () => {
+    expect(selectDocumentationPaths([changed('src/hosted/runner.ts')])).toEqual([
+      'README.md',
+      'docs/agent-prompts.mdx',
+      'docs/authentication-and-profiles.mdx',
+      'docs/browser-and-sitemap-memory.mdx',
+      'docs/cli-reference.mdx',
+      'docs/concepts.mdx',
+      'docs/local-or-cloud.mdx',
+      'skills/webcmd-browser-sitemap/SKILL.md',
+      'skills/webcmd-browser/SKILL.md',
+      'skills/webcmd-usage/SKILL.md',
+    ]);
+  });
+
   it('selects adapter and plugin documentation', () => {
     expect(selectDocumentationPaths([changed('clis/reddit/search.js')])).toEqual([
       'README.md',

--- a/src/docs-sync-review.test.ts
+++ b/src/docs-sync-review.test.ts
@@ -135,6 +135,15 @@ describe('review context', () => {
     ]);
   });
 
+  it('does not select profile documentation for unrelated hosted changes', () => {
+    expect(selectDocumentationPaths([changed('src/hosted/files.ts')])).toEqual([
+      'README.md',
+      'docs/cli-reference.mdx',
+      'docs/concepts.mdx',
+      'skills/webcmd-usage/SKILL.md',
+    ]);
+  });
+
   it('selects adapter and plugin documentation', () => {
     expect(selectDocumentationPaths([changed('clis/reddit/search.js')])).toEqual([
       'README.md',

--- a/src/docs-sync-review.test.ts
+++ b/src/docs-sync-review.test.ts
@@ -135,6 +135,21 @@ describe('review context', () => {
     ]);
   });
 
+  it('selects profile documentation for hosted root command changes', () => {
+    expect(selectDocumentationPaths([changed('src/completion-shared.ts')])).toEqual([
+      'README.md',
+      'docs/agent-prompts.mdx',
+      'docs/authentication-and-profiles.mdx',
+      'docs/browser-and-sitemap-memory.mdx',
+      'docs/cli-reference.mdx',
+      'docs/concepts.mdx',
+      'docs/local-or-cloud.mdx',
+      'skills/webcmd-browser-sitemap/SKILL.md',
+      'skills/webcmd-browser/SKILL.md',
+      'skills/webcmd-usage/SKILL.md',
+    ]);
+  });
+
   it('does not select profile documentation for unrelated hosted changes', () => {
     expect(selectDocumentationPaths([changed('src/hosted/files.ts')])).toEqual([
       'README.md',

--- a/src/docs-sync-review.ts
+++ b/src/docs-sync-review.ts
@@ -186,6 +186,8 @@ const HOSTED_DOCUMENTATION = [
   'docs/local-or-cloud.mdx',
 ];
 
+const HOSTED_PROFILE_PATHS = /^src\/hosted\/(?:browser-args|client|runner|types)\.ts$/;
+
 const ADAPTER_DOCUMENTATION = [
   'README.md',
   'docs/authoring.mdx',
@@ -199,7 +201,7 @@ export function selectDocumentationPaths(files: ChangedFile[]): string[] {
   const selected = new Set<string>();
 
   for (const file of files) {
-    const paths = /^src\/hosted\//.test(file.path)
+    const paths = HOSTED_PROFILE_PATHS.test(file.path)
       ? HOSTED_DOCUMENTATION
       : /^src\/browser\//.test(file.path)
       ? BROWSER_DOCUMENTATION

--- a/src/docs-sync-review.ts
+++ b/src/docs-sync-review.ts
@@ -186,7 +186,7 @@ const HOSTED_DOCUMENTATION = [
   'docs/local-or-cloud.mdx',
 ];
 
-const HOSTED_PROFILE_PATHS = /^src\/hosted\/(?:browser-args|client|runner|types)\.ts$/;
+const HOSTED_PROFILE_PATHS = /^(?:src\/completion-shared|src\/hosted\/(?:browser-args|client|runner|types))\.ts$/;
 
 const ADAPTER_DOCUMENTATION = [
   'README.md',

--- a/src/docs-sync-review.ts
+++ b/src/docs-sync-review.ts
@@ -180,6 +180,12 @@ const BROWSER_DOCUMENTATION = [
   'skills/webcmd-usage/SKILL.md',
 ];
 
+const HOSTED_DOCUMENTATION = [
+  ...BROWSER_DOCUMENTATION,
+  'docs/authentication-and-profiles.mdx',
+  'docs/local-or-cloud.mdx',
+];
+
 const ADAPTER_DOCUMENTATION = [
   'README.md',
   'docs/authoring.mdx',
@@ -193,7 +199,9 @@ export function selectDocumentationPaths(files: ChangedFile[]): string[] {
   const selected = new Set<string>();
 
   for (const file of files) {
-    const paths = /^(?:src\/browser\/|src\/hosted\/)/.test(file.path)
+    const paths = /^src\/hosted\//.test(file.path)
+      ? HOSTED_DOCUMENTATION
+      : /^src\/browser\//.test(file.path)
       ? BROWSER_DOCUMENTATION
       : /^(?:clis\/|plugins\/|src\/plugin)/.test(file.path)
         ? ADAPTER_DOCUMENTATION

--- a/src/generate-release-notes-cli.test.ts
+++ b/src/generate-release-notes-cli.test.ts
@@ -269,7 +269,7 @@ describe('runGenerateReleaseNotes', () => {
     expect(workflow).toContain('release_body_file="$RUNNER_TEMP/release-body.md"');
     expect(workflow).toContain('release_edit_args+=(--title "$release_title")');
     expect(workflow).toContain('release_edit_args+=(--notes-file "$release_body_file")');
-    expect(workflow).toContain('if gh release edit "${{ steps.release.outputs.tag_name }}" "${release_edit_args[@]}"; then');
+    expect(workflow).toContain('if gh release edit "${{ steps.release.outputs.tag_name || inputs.publish_tag }}" "${release_edit_args[@]}"; then');
     expect(workflow).toMatch(/Enhanced release notes could not be applied; keeping release-please notes\./);
   });
 });

--- a/src/hosted/client.test.ts
+++ b/src/hosted/client.test.ts
@@ -174,32 +174,87 @@ describe('HostedClient', () => {
     await expect(client.getManifest()).rejects.toMatchObject({ code: 'HOSTED_PROTOCOL' });
   });
 
-  it('parses hosted profile rows without provider identifiers', async () => {
+  it('manages public hosted profiles over the authenticated HTTP API', async () => {
+    const requests: Array<{ url: string; method: string; body?: string }> = [];
+    const profile = {
+      id: 'profile_work',
+      name: 'Work',
+      userId: 'user_64256',
+      default: false,
+      status: 'available',
+      createdAt: '2026-07-08T00:00:00.000Z',
+      updatedAt: '2026-07-08T00:00:00.000Z',
+      lastUsedAt: '2026-07-08T00:00:00.000Z',
+    };
     const client = new HostedClient({
       apiBaseUrl: 'https://api.example.com',
       apiKey: 'wcmd_live_test',
-      fetchImpl: async () => new Response(JSON.stringify({
-        ok: true,
-        profiles: [{
-          name: 'default',
-          default: true,
-          status: 'available',
-          createdAt: '2026-07-08T00:00:00.000Z',
-          lastUsedAt: '2026-07-08T00:00:00.000Z',
-        }],
-      }), { status: 200 }),
+      fetchImpl: async (url, init) => {
+        requests.push({
+          url: String(url),
+          method: init?.method ?? 'GET',
+          ...(init?.body ? { body: String(init.body) } : {}),
+        });
+        const path = new URL(String(url)).pathname;
+        if (path === '/v1/profiles' && init?.method === 'POST') {
+          return new Response(JSON.stringify({ ok: true, profile }), { status: 201 });
+        }
+        if (path.startsWith('/v1/profiles/') && init?.method === 'DELETE') {
+          return new Response(JSON.stringify({ ok: true, deleted: true }));
+        }
+        if (path.startsWith('/v1/profiles/')) {
+          return new Response(JSON.stringify({ ok: true, profile }));
+        }
+        return new Response(JSON.stringify({ ok: true, profiles: [profile] }));
+      },
     });
 
-    await expect(client.listProfiles()).resolves.toEqual({
-      ok: true,
-      profiles: [{
-        name: 'default',
-        default: true,
-        status: 'available',
-        createdAt: '2026-07-08T00:00:00.000Z',
-        lastUsedAt: '2026-07-08T00:00:00.000Z',
-      }],
+    await expect(client.listProfiles({ name: 'Work', userId: 'user_64256' }))
+      .resolves.toEqual({ ok: true, profiles: [profile] });
+    await expect(client.createProfile({ name: 'Work', userId: 'user_64256' }))
+      .resolves.toMatchObject({ profile: { id: 'profile_work', status: 'available' } });
+    await expect(client.getProfile('profile_work')).resolves.toMatchObject({
+      profile: { id: 'profile_work' },
     });
+    await expect(client.deleteProfile('profile/work')).resolves.toEqual({ ok: true, deleted: true });
+
+    expect(requests).toEqual([
+      { url: 'https://api.example.com/v1/profiles?name=Work&userId=user_64256', method: 'GET' },
+      {
+        url: 'https://api.example.com/v1/profiles',
+        method: 'POST',
+        body: JSON.stringify({ name: 'Work', userId: 'user_64256' }),
+      },
+      { url: 'https://api.example.com/v1/profiles/profile_work', method: 'GET' },
+      { url: 'https://api.example.com/v1/profiles/profile%2Fwork', method: 'DELETE' },
+    ]);
+  });
+
+  it.each([
+    { name: 'private provider field', change: { kernelProfileId: 'private' } },
+    { name: 'missing updatedAt', change: { updatedAt: undefined } },
+    { name: 'non-nullable name shape', change: { name: 7 } },
+    { name: 'non-nullable user ID shape', change: { userId: false } },
+  ])('rejects a hosted profile with $name', async ({ change }) => {
+    const profile: Record<string, unknown> = {
+      id: 'profile_work',
+      name: null,
+      userId: null,
+      default: false,
+      status: 'pending',
+      createdAt: '2026-07-08T00:00:00.000Z',
+      updatedAt: '2026-07-08T00:00:00.000Z',
+      lastUsedAt: '2026-07-08T00:00:00.000Z',
+      ...change,
+    };
+    if (change.updatedAt === undefined) delete profile.updatedAt;
+    const client = new HostedClient({
+      apiBaseUrl: 'https://api.example.com',
+      apiKey: 'key',
+      fetchImpl: async () => new Response(JSON.stringify({ ok: true, profiles: [profile] })),
+    });
+
+    await expect(client.listProfiles()).rejects.toMatchObject({ code: 'HOSTED_PROTOCOL' });
   });
 
   it('maps hosted error envelopes to CliError-compatible errors', async () => {

--- a/src/hosted/client.ts
+++ b/src/hosted/client.ts
@@ -13,6 +13,7 @@ import type {
   HostedExecution,
   HostedExecuteResponse,
   HostedPrepareExecutionResponse,
+  HostedProfileResponse,
   HostedProfilesResponse,
   HostedUploadArtifactResponse,
   HostedManifest,
@@ -66,12 +67,43 @@ export class HostedClient {
     return body.manifest;
   }
 
-  async listProfiles(): Promise<HostedProfilesResponse> {
-    const body = await this.request('/v1/profiles');
+  async listProfiles(filters: { name?: string; userId?: string } = {}): Promise<HostedProfilesResponse> {
+    const params = new URLSearchParams();
+    if (filters.name !== undefined) params.set('name', filters.name);
+    if (filters.userId !== undefined) params.set('userId', filters.userId);
+    const query = params.toString();
+    const body = await this.request(`/v1/profiles${query ? `?${query}` : ''}`);
     if (!isHostedProfilesResponse(body)) {
       throw protocolError('Webcmd Cloud returned an invalid profiles response.');
     }
     return body;
+  }
+
+  async createProfile(input: { name: string; userId?: string }): Promise<HostedProfileResponse> {
+    const body = await this.request('/v1/profiles', {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+    if (!isHostedProfileResponse(body)) {
+      throw protocolError('Webcmd Cloud returned an invalid profile response.');
+    }
+    return body;
+  }
+
+  async getProfile(profileId: string): Promise<HostedProfileResponse> {
+    const body = await this.request(`/v1/profiles/${encodeURIComponent(profileId)}`);
+    if (!isHostedProfileResponse(body)) {
+      throw protocolError('Webcmd Cloud returned an invalid profile response.');
+    }
+    return body;
+  }
+
+  async deleteProfile(profileId: string): Promise<{ ok: true; deleted: true }> {
+    const body = await this.request(`/v1/profiles/${encodeURIComponent(profileId)}`, { method: 'DELETE' });
+    if (!hasExactKeys(body, ['ok', 'deleted']) || body.ok !== true || body.deleted !== true) {
+      throw protocolError('Webcmd Cloud returned an invalid profile deletion response.');
+    }
+    return { ok: true, deleted: true };
   }
 
   async execute(input: {
@@ -374,12 +406,24 @@ function isHostedProfilesResponse(value: unknown): value is HostedProfilesRespon
     && value.profiles.every(isHostedPublicProfile);
 }
 
+function isHostedProfileResponse(value: unknown): value is HostedProfileResponse {
+  return hasExactKeys(value, ['ok', 'profile'])
+    && value.ok === true
+    && isHostedPublicProfile(value.profile);
+}
+
 function isHostedPublicProfile(value: unknown): boolean {
-  return hasExactKeys(value, ['name', 'default', 'status', 'createdAt', 'lastUsedAt'])
-    && typeof value.name === 'string'
+  return hasExactKeys(value, [
+    'id', 'name', 'userId', 'default', 'status',
+    'createdAt', 'updatedAt', 'lastUsedAt',
+  ])
+    && typeof value.id === 'string'
+    && (value.name === null || typeof value.name === 'string')
+    && (value.userId === null || typeof value.userId === 'string')
     && typeof value.default === 'boolean'
-    && value.status === 'available'
+    && (value.status === 'pending' || value.status === 'available')
     && typeof value.createdAt === 'string'
+    && typeof value.updatedAt === 'string'
     && typeof value.lastUsedAt === 'string';
 }
 

--- a/src/hosted/manifest.test.ts
+++ b/src/hosted/manifest.test.ts
@@ -122,6 +122,7 @@ describe('hosted manifest helpers', () => {
     expect(result).toEqual({ handled: true, exitCode: 0 });
     expect(stdout.text()).toBe(formatRootHelp(HOSTED_ROOT_HELP));
     expect(stdout.text()).toContain('completion');
+    expect(stdout.text()).toMatch(/profile\s+Manage hosted browser profiles/);
     expect(stdout.text()).toContain('--profile <name>');
     expect(stdout.text()).toContain('Local-only commands:');
     expect(stdout.text()).toContain('Run `webcmd setup` and choose local mode to use local-only commands.');
@@ -198,6 +199,6 @@ describe('hosted manifest helpers', () => {
       fetchImpl: async () => new Response(JSON.stringify({ ok: true, manifest }), { status: 200 }),
     });
 
-    expect(stdout.text().trim().split('\n')).toEqual(['browser', 'completion', 'github', 'list', 'setup']);
+    expect(stdout.text().trim().split('\n')).toEqual(['browser', 'completion', 'github', 'list', 'profile', 'setup']);
   });
 });

--- a/src/hosted/root-command-surface.test.ts
+++ b/src/hosted/root-command-surface.test.ts
@@ -173,6 +173,14 @@ const generatedTerminalCorpus = profileForms.flatMap(profile =>
 );
 
 describe('hosted root command surface', () => {
+  it('advertises hosted profile management as a root command, not a local-only namespace', () => {
+    expect(HOSTED_ROOT_HELP.commands).toContainEqual({
+      name: 'profile',
+      description: 'Manage hosted browser profiles',
+    });
+    expect(HOSTED_ROOT_HELP.localOnlyCommands?.some(command => command.name === 'profile')).toBe(false);
+  });
+
   it.each([
     { name: 'no args', argv: [], expected: { kind: 'help', exitCode: 1 } },
     { name: 'profile only', argv: ['--profile', 'work'], expected: { kind: 'help', exitCode: 1 } },

--- a/src/hosted/runner.test.ts
+++ b/src/hosted/runner.test.ts
@@ -11,7 +11,7 @@ import { createProgram } from '../cli.js';
 import { formatRootHelp } from '../command-presentation.js';
 import { HOSTED_ROOT_HELP } from '../completion-shared.js';
 import { PKG_VERSION } from '../version.js';
-import { makeHostedConfig } from './config.js';
+import { makeHostedConfig, makeLocalConfig } from './config.js';
 import { runHostedCli } from './runner.js';
 
 const [packageMajor, packageMinor] = PKG_VERSION.split('.');
@@ -248,6 +248,143 @@ function captureLocalBrowserStructure(argv: string[]): {
 }
 
 describe('runHostedCli', () => {
+  const publicProfile = {
+    id: 'profile_work',
+    name: 'Work',
+    userId: 'user_64256',
+    default: false,
+    status: 'available',
+    createdAt: '2026-07-24T00:00:00.000Z',
+    updatedAt: '2026-07-24T00:00:00.000Z',
+    lastUsedAt: '2026-07-24T00:00:00.000Z',
+  };
+
+  it('lists, creates, resolves, gets, and deletes hosted profiles without fetching the manifest', async () => {
+    const requests: Array<{ url: string; method: string; body?: unknown }> = [];
+    const fetchImpl = vi.fn<typeof fetch>(async (url, init) => {
+      const request = {
+        url: String(url),
+        method: init?.method ?? 'GET',
+        ...(init?.body ? { body: JSON.parse(String(init.body)) } : {}),
+      };
+      requests.push(request);
+      if (request.method === 'POST') {
+        return new Response(JSON.stringify({ ok: true, profile: publicProfile }), { status: 201 });
+      }
+      if (request.method === 'DELETE') {
+        return new Response(JSON.stringify({ ok: true, deleted: true }));
+      }
+      return new Response(JSON.stringify({ ok: true, profiles: [publicProfile] }));
+    });
+
+    for (const argv of [
+      ['profile', 'list', '-f', 'json'],
+      ['profile', 'create', 'Work', '--user-id', 'user_64256', '-f', 'json'],
+      ['profile', 'get', 'Work', '-f', 'json'],
+      ['profile', 'get', 'user_64256', '-f', 'json'],
+      ['profile', 'get', 'profile_work', '-f', 'json'],
+      ['profile', 'delete', 'profile_work', '-f', 'json'],
+    ]) {
+      const stdout = sink();
+      const stderr = sink();
+      const result = await runHostedCli(argv, {
+        config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
+        stdout: stdout.stream,
+        stderr: stderr.stream,
+        fetchImpl,
+      });
+      expect(result).toEqual({ handled: true, exitCode: 0 });
+      expect(stderr.text()).toBe('');
+      expect(stdout.text()).toContain(argv[1] === 'delete' ? '"deleted": true' : '"id": "profile_work"');
+    }
+
+    expect(requests).toEqual([
+      { url: 'https://api.example.com/v1/profiles', method: 'GET' },
+      {
+        url: 'https://api.example.com/v1/profiles',
+        method: 'POST',
+        body: { name: 'Work', userId: 'user_64256' },
+      },
+      { url: 'https://api.example.com/v1/profiles', method: 'GET' },
+      { url: 'https://api.example.com/v1/profiles', method: 'GET' },
+      { url: 'https://api.example.com/v1/profiles', method: 'GET' },
+      { url: 'https://api.example.com/v1/profiles/profile_work', method: 'DELETE' },
+    ]);
+    expect(requests.some(request => request.url.endsWith('/v1/manifest'))).toBe(false);
+  });
+
+  it('deduplicates universal profile matches and rejects missing or ambiguous selectors', async () => {
+    const cases = [
+      {
+        selector: 'same',
+        profiles: [{ ...publicProfile, id: 'profile_same', name: 'same', userId: 'same' }],
+        exitCode: 0,
+        stdout: '"id": "profile_same"',
+        stderr: '',
+      },
+      {
+        selector: 'missing',
+        profiles: [publicProfile],
+        exitCode: 66,
+        stdout: '',
+        stderr: 'code: PROFILE_NOT_FOUND',
+      },
+      {
+        selector: 'shared',
+        profiles: [
+          { ...publicProfile, id: 'profile_one', name: 'shared' },
+          { ...publicProfile, id: 'profile_two', name: 'Other', userId: 'shared' },
+        ],
+        exitCode: 75,
+        stdout: '',
+        stderr: 'code: AMBIGUOUS_PROFILE',
+      },
+    ];
+
+    for (const testCase of cases) {
+      const stdout = sink();
+      const stderr = sink();
+      const fetchImpl = vi.fn<typeof fetch>(async () =>
+        new Response(JSON.stringify({ ok: true, profiles: testCase.profiles })));
+      const result = await runHostedCli(['profile', 'get', testCase.selector, '-f', 'json'], {
+        config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
+        stdout: stdout.stream,
+        stderr: stderr.stream,
+        fetchImpl,
+      });
+
+      expect(result.exitCode).toBe(testCase.exitCode);
+      expect(stdout.text()).toContain(testCase.stdout);
+      expect(stderr.text()).toContain(testCase.stderr);
+      if (testCase.selector === 'shared') {
+        expect(stderr.text()).toContain('Use the immutable profile ID returned by webcmd profile list.');
+      }
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it.each(['rename', 'use'])('rejects local-only profile %s in hosted mode without an API call', async (command) => {
+    const stderr = sink();
+    const fetchImpl = vi.fn<typeof fetch>();
+    const result = await runHostedCli(['profile', command, 'value'], {
+      config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
+      stderr: stderr.stream,
+      fetchImpl,
+    });
+
+    expect(result).toEqual({ handled: true, exitCode: 78 });
+    expect(stderr.text()).toContain(`webcmd profile ${command} is not available in hosted mode.`);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it.each(['list', 'rename', 'use'])('leaves profile %s to the existing local command surface', async (command) => {
+    const result = await runHostedCli(['profile', command, 'value'], {
+      config: makeLocalConfig(),
+    });
+
+    expect(result).toEqual({ handled: false, exitCode: 0 });
+  });
+
   it.each([
     ['missing-site'],
     ['missing-site', 'child'],

--- a/src/hosted/runner.ts
+++ b/src/hosted/runner.ts
@@ -36,7 +36,12 @@ import {
 import { isHostedConfig, loadWebcmdConfig, type WebcmdConfig } from './config.js';
 import { resolveHostedApiKey, type HostedCredentialStore } from './credentials.js';
 import { parseHostedRootCommandSurface } from '../root-command-surface.js';
-import type { HostedBrowserActionName, HostedBrowserRunActionResponse, HostedManifest } from './types.js';
+import type {
+  HostedBrowserActionName,
+  HostedBrowserRunActionResponse,
+  HostedManifest,
+  HostedPublicProfile,
+} from './types.js';
 import type { HostedBrowserCommandContract } from './contract.js';
 
 export interface HostedRunnerOptions {
@@ -185,6 +190,22 @@ async function dispatchHosted(
     const manifest = await client.getManifest();
     validateManifestContractIdentity(manifest);
     await renderHostedList(manifest, parsed.format, parsed.formatExplicit, stdout);
+    return;
+  }
+
+  if (args[0] === 'profile') {
+    if (args[1] === 'rename' || args[1] === 'use') {
+      throw new ConfigError(
+        `webcmd profile ${args[1]} is not available in hosted mode.`,
+        'Hosted mode supports: webcmd profile list, create, get, and delete.',
+      );
+    }
+    const parsed = parseHostedProfileSurface(args.slice(1), normalized.literal);
+    if (parsed.kind === 'help') {
+      await writeToStream(stdout, parsed.output);
+      return;
+    }
+    await dispatchHostedProfile(parsed, client, stdout);
     return;
   }
 
@@ -689,6 +710,120 @@ function parseHostedListSurface(argv: readonly string[], literal: boolean): Pars
   }
   if (!actionRan) throw new CommanderStructuralError("error: command 'list' did not run\n", 1);
   return { kind: 'run', format: parsedFormat, formatExplicit };
+}
+
+type HostedProfileCommand = 'list' | 'create' | 'get' | 'delete';
+
+type ParsedHostedProfileSurface =
+  | { kind: 'help'; output: string }
+  | {
+      kind: 'run';
+      command: HostedProfileCommand;
+      format: string;
+      formatExplicit: boolean;
+      value?: string;
+      userId?: string;
+    };
+
+function parseHostedProfileSurface(
+  argv: readonly string[],
+  literal: boolean,
+): ParsedHostedProfileSurface {
+  let stdout = '';
+  let stderr = '';
+  let parsed: Exclude<ParsedHostedProfileSurface, { kind: 'help' }> | undefined;
+  const root = new Command('webcmd');
+  const profile = root.command('profile').description('Manage hosted browser profiles');
+  const output = {
+    writeOut: (value: string) => { stdout += value; },
+    writeErr: (value: string) => { stderr += value; },
+  };
+  root.exitOverride().configureOutput(output);
+  profile.exitOverride().configureOutput(output);
+
+  const configureFormat = (command: Command): Command =>
+    command.option('-f, --format <fmt>', 'Output format: table, json, yaml, md, csv', 'table');
+  const setParsed = (
+    command: HostedProfileCommand,
+    surface: Command,
+    value?: string,
+    userId?: string,
+  ): void => {
+    const options = surface.opts<{ format: string }>();
+    parsed = {
+      kind: 'run',
+      command,
+      format: options.format,
+      formatExplicit: surface.getOptionValueSource('format') === 'cli',
+      ...(value !== undefined ? { value } : {}),
+      ...(userId !== undefined ? { userId } : {}),
+    };
+  };
+
+  const list = configureFormat(profile.command('list'));
+  list.exitOverride().configureOutput(output).action(() => setParsed('list', list));
+  const create = configureFormat(profile.command('create').argument('<name>').option('--user-id <id>'));
+  create.exitOverride().configureOutput(output).action((name: string, options: { userId?: string }) =>
+    setParsed('create', create, name, options.userId));
+  const get = configureFormat(profile.command('get').argument('<profile>'));
+  get.exitOverride().configureOutput(output).action((selector: string) => setParsed('get', get, selector));
+  const remove = configureFormat(profile.command('delete').argument('<profile-id>'));
+  remove.exitOverride().configureOutput(output).action((profileId: string) => setParsed('delete', remove, profileId));
+
+  try {
+    root.parse(literal ? ['--', 'profile', ...argv] : ['profile', ...argv], { from: 'user' });
+  } catch (error) {
+    if (!(error instanceof CommanderError)) throw error;
+    if (error.code === 'commander.helpDisplayed') return { kind: 'help', output: stdout };
+    throw new CommanderStructuralError(stderr || `${error.message}\n`, error.exitCode);
+  }
+  if (!parsed) {
+    throw new CommanderStructuralError("error: command 'profile' did not run\n", 1);
+  }
+  return parsed;
+}
+
+async function dispatchHostedProfile(
+  parsed: Exclude<ParsedHostedProfileSurface, { kind: 'help' }>,
+  client: HostedClient,
+  stdout: NodeJS.WritableStream,
+): Promise<void> {
+  let result: unknown;
+  if (parsed.command === 'list') {
+    result = (await client.listProfiles()).profiles;
+  } else if (parsed.command === 'create') {
+    result = (await client.createProfile({
+      name: parsed.value!,
+      ...(parsed.userId !== undefined ? { userId: parsed.userId } : {}),
+    })).profile;
+  } else if (parsed.command === 'get') {
+    result = resolveHostedProfile((await client.listProfiles()).profiles, parsed.value!);
+  } else {
+    result = await client.deleteProfile(parsed.value!);
+  }
+  await renderOutput(result, {
+    fmt: parsed.format,
+    fmtExplicit: parsed.formatExplicit,
+    stdout,
+  });
+}
+
+function resolveHostedProfile(profiles: HostedPublicProfile[], selector: string): HostedPublicProfile {
+  const matches = profiles.filter(profile =>
+    profile.id === selector || profile.name === selector || profile.userId === selector);
+  const distinct = [...new Map(matches.map(profile => [profile.id, profile])).values()];
+  if (distinct.length === 0) {
+    throw new CliError('PROFILE_NOT_FOUND', 'Profile was not found.', undefined, EXIT_CODES.EMPTY_RESULT);
+  }
+  if (distinct.length > 1) {
+    throw new CliError(
+      'AMBIGUOUS_PROFILE',
+      'The profile selector matched multiple profiles.',
+      'Use the immutable profile ID returned by webcmd profile list.',
+      EXIT_CODES.TEMPFAIL,
+    );
+  }
+  return distinct[0]!;
 }
 
 type ParsedHostedCompletionSurface =

--- a/src/hosted/types.ts
+++ b/src/hosted/types.ts
@@ -45,16 +45,24 @@ export interface HostedManifest {
 }
 
 export interface HostedPublicProfile {
-  name: string;
+  id: string;
+  name: string | null;
+  userId: string | null;
   default: boolean;
-  status: 'available';
+  status: 'pending' | 'available';
   createdAt: string;
+  updatedAt: string;
   lastUsedAt: string;
 }
 
 export interface HostedProfilesResponse {
   ok: true;
   profiles: HostedPublicProfile[];
+}
+
+export interface HostedProfileResponse {
+  ok: true;
+  profile: HostedPublicProfile;
 }
 
 export interface HostedExecution {


### PR DESCRIPTION
## Summary

- add hosted profile list, create, get, and immutable-ID delete commands
- resolve profiles exactly by ID, name, or external user ID with ambiguity protection
- preserve local profile list, rename, use, and lazy-name behavior
- update completion and hosted profile documentation

## Verification

- 4,924 tests pass and 1 test is skipped
- typecheck and build pass
- one pre-existing release-notes workflow assertion still fails and is unchanged by this branch

## Release note

This PR must be published as the next `@agentrhq/webcmd` version before the cloud repository pins it.