### PR TITLE
feat(hosted): workspace-scoped profiles CLI transport

### DIFF
--- a/docs/authentication-and-profiles.mdx
+++ b/docs/authentication-and-profiles.mdx
@@ -19,28 +19,34 @@ Profiles separate browser identities and their login state. Use a named profile 
 
 ## Hosted Profiles
 
-In Webcmd Cloud, no profile selector (or `--profile default`) lazily creates only the hosted default profile. Create every custom hosted profile explicitly. An unknown custom selector fails; it never creates a hosted profile.
+Webcmd Cloud scopes every hosted profile to a workspace. A workspace is an ambient container the CLI resolves once per invocation: the `--workspace <id>` flag if present, otherwise the `WEBCMD_WORKSPACE` environment variable, otherwise an implicit default workspace. Within that workspace, `--profile <name>` selects a persona; an unset or default profile lazily creates that workspace's own `default` profile the first time it is used.
+
+### B2C
+
+A single end user runs hosted commands with no setup. The implicit default workspace and its `default` profile are created lazily on first use:
 
 ```bash
-# B2C: after choosing hosted mode and saving an account API key
 webcmd github whoami
-
-# Optional named identity
-webcmd profile create Work
-webcmd --profile Work github whoami
 ```
 
-Builders can attach a public external user reference when creating a profile:
+Named personas inside that same workspace are also lazy:
 
 ```bash
-webcmd profile create customer_name --user-id customer_id -f json
-# Retain the returned immutable ID, for example profile_abc123.
-webcmd --profile profile_abc123 github whoami
+webcmd --profile work github whoami
 ```
 
-`userId` is your public external-user reference, not Webcmd's internal account ownership. A profile selector is one scalar value: an immutable ID, exact name, or exact `userId`. If one downstream user has several named profiles, their `userId` is ambiguous. Run `webcmd profile list` and use the returned immutable profile ID.
+### B2B2C
 
-Hosted `profile list` returns profile rows; `create` and `get` each return one public profile with `id`, `name`, `userId`, `default`, `status`, `createdAt`, `updatedAt`, and `lastUsedAt`; `delete` returns `{ "ok": true, "deleted": true }`. `status` is `pending` while the hosted profile is being provisioned and `available` once it is ready. Kernel identifiers and names are never Webcmd API fields.
+An enterprise backend puts each downstream user in their own workspace by setting `WEBCMD_WORKSPACE` per invocation. Each workspace gets its own lazily created profiles, including its own `default`, isolated from every other workspace:
+
+```bash
+WEBCMD_WORKSPACE=user_64256 webcmd github whoami
+WEBCMD_WORKSPACE=user_64256 webcmd --profile work github whoami
+```
+
+`--profile <name>` still selects a persona within the ambient workspace; it never crosses workspace boundaries.
+
+Hosted `profile list` returns profile rows; `delete` returns `{ "ok": true, "deleted": true }`. Public profile fields are `id`, `name`, `workspace`, `default`, `status`, `createdAt`, `updatedAt`, and `lastUsedAt`. `status` is `pending` while the hosted profile is being provisioned and `available` once it is ready. Kernel identifiers are never exposed as Webcmd API fields.
 
 Delete hosted profiles only by immutable ID:
 

--- a/docs/cli-reference.mdx
+++ b/docs/cli-reference.mdx
@@ -63,6 +63,15 @@ webcmd hackernews top -f csv
 
 Agents should use JSON unless they are presenting output to a human.
 
+## Global Flags
+
+| Flag / Env | Purpose |
+| --- | --- |
+| `--workspace <id>` | Hosted mode only. Sets the ambient workspace for this invocation. |
+| `WEBCMD_WORKSPACE` | Hosted mode only. Sets the ambient workspace when `--workspace` is not passed. |
+
+Workspace resolution precedence is `--workspace` flag, then `WEBCMD_WORKSPACE` env var, then an implicit default workspace. The CLI sends the resolved workspace as the `X-Webcmd-Workspace` header on hosted requests. Local mode has no workspace concept.
+
 ## Profiles
 
 Profiles keep login state separate. The profile surface depends on the selected mode.
@@ -73,17 +82,15 @@ webcmd profile list
 webcmd profile rename <context-id> work
 webcmd profile use work
 
-# Hosted: explicit custom profile creation and public profile management
-webcmd profile create Work
-webcmd profile create customer_name --user-id customer_id -f json
+# Hosted: profile management within the ambient workspace
 webcmd profile list
-webcmd profile get Work
+webcmd --workspace user_64256 profile list
 webcmd profile delete profile_abc123
 ```
 
-In local mode, arbitrary `--profile <name>` values lazily create separate local state; local `list`, `rename`, and `use` are unchanged. In hosted mode, only an omitted selector or `--profile default` lazily creates the default profile. Create custom hosted profiles first; unknown custom selectors fail.
+In local mode, arbitrary `--profile <name>` values lazily create separate local state; local `list`, `rename`, and `use` are unchanged. In hosted mode, `--profile <name>` selects a persona within the ambient workspace; an omitted selector or `--profile default` lazily creates that workspace's `default` profile.
 
-Hosted `get` and `--profile` accept one exact scalar selector: profile ID, name, or public `userId`. If it matches more than one profile, run `webcmd profile list` and use its immutable ID. Use that immutable ID for `delete` too: deletion permanently removes hosted browser state. `list` returns profile rows; `create` and `get` each return one public profile with `id`, `name`, `userId`, `default`, `status`, `createdAt`, `updatedAt`, and `lastUsedAt`; `delete` returns `{ "ok": true, "deleted": true }`. `status` is `pending` or `available`. `userId` is an external reference, not internal ownership, and Kernel IDs or names are never exposed.
+Hosted `list` returns profile rows scoped to the ambient workspace; `delete` takes an immutable profile ID and returns `{ "ok": true, "deleted": true }`, permanently removing that hosted browser state. Each profile row has `id`, `name`, `workspace`, `default`, `status`, `createdAt`, `updatedAt`, and `lastUsedAt`. `status` is `pending` or `available`. Kernel identifiers are never exposed.
 
 Prompt example:
 

--- a/docs/local-or-cloud.mdx
+++ b/docs/local-or-cloud.mdx
@@ -27,15 +27,15 @@ Webcmd Cloud alpha is for supported commands and browser sessions on hosted infr
 2. Create and copy an API key from the account page.
 3. Run `webcmd setup`, choose hosted mode, and paste the key when prompted.
 
-Hosted browser tasks can use named profiles. In Cloud, omitted `--profile` (and `--profile default`) is the only lazy profile: it creates the hosted default profile. Create a custom profile with `webcmd profile create <name>` before selecting it. Unknown custom selectors fail instead of creating browser state.
+Hosted browser tasks are scoped to a workspace. Set `--workspace <id>` or the `WEBCMD_WORKSPACE` env var per invocation (flag wins, then env, then an implicit default workspace); the CLI sends it as the `X-Webcmd-Workspace` header. Within a workspace, `--profile <name>` selects a persona; an omitted selector or `--profile default` lazily creates that workspace's own `default` profile.
 
 ```bash
-# Builder-created customer profile; retain the returned immutable profile ID.
-webcmd profile create customer_name --user-id customer_id -f json
-webcmd --profile profile_abc123 github whoami
+# Each downstream user gets their own workspace and its own lazy profiles.
+WEBCMD_WORKSPACE=user_64256 webcmd github whoami
+WEBCMD_WORKSPACE=user_64256 webcmd --profile work github whoami
 ```
 
-`userId` is a public external-user reference. It may match multiple profiles, so use `webcmd profile list` and the immutable ID when a selector is ambiguous. `webcmd profile delete <profile-id>` permanently removes hosted browser state. When sign-in is required, Webcmd returns a Webcmd-owned live authentication view; complete sign-in there, then let the agent continue. See [Authentication and Profiles](/authentication-and-profiles).
+`webcmd profile list` returns profile rows scoped to the ambient workspace. `webcmd profile delete <profile-id>` permanently removes hosted browser state. When sign-in is required, Webcmd returns a Webcmd-owned live authentication view; complete sign-in there, then let the agent continue. See [Authentication and Profiles](/authentication-and-profiles).
 
 View hosted usage on the account page.
 
@@ -43,7 +43,7 @@ View hosted usage on the account page.
 
 Local and hosted profiles, adapters, site memory, and traces do not sync. Treat each mode as its own working environment.
 
-Local profile behavior is unchanged: an arbitrary `--profile <name>` lazily creates separate local browser state. Local `webcmd profile list`, `rename`, and `use` continue to manage that local state; they do not create or manage hosted profiles.
+Local mode has no workspace concept. Local profile behavior is unchanged: an arbitrary `--profile <name>` lazily creates separate local browser state. Local `webcmd profile list`, `rename`, and `use` continue to manage that local state; they do not create or manage hosted profiles.
 
 ## Current Boundaries
 

--- a/src/hosted/client.test.ts
+++ b/src/hosted/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { HostedClient, HostedClientError } from './client.js';
+import { HostedClient, HostedClientError, resolveWorkspace } from './client.js';
 
 const invalidTraceUrlCases = [
   {
@@ -179,7 +179,7 @@ describe('HostedClient', () => {
     const profile = {
       id: 'profile_work',
       name: 'Work',
-      userId: 'user_64256',
+      workspace: 'user_64256',
       default: false,
       status: 'available',
       createdAt: '2026-07-08T00:00:00.000Z',
@@ -234,12 +234,12 @@ describe('HostedClient', () => {
     { name: 'private provider field', change: { kernelProfileId: 'private' } },
     { name: 'missing updatedAt', change: { updatedAt: undefined } },
     { name: 'non-nullable name shape', change: { name: 7 } },
-    { name: 'non-nullable user ID shape', change: { userId: false } },
+    { name: 'non-nullable workspace shape', change: { workspace: false } },
   ])('rejects a hosted profile with $name', async ({ change }) => {
     const profile: Record<string, unknown> = {
       id: 'profile_work',
       name: null,
-      userId: null,
+      workspace: null,
       default: false,
       status: 'pending',
       createdAt: '2026-07-08T00:00:00.000Z',
@@ -895,5 +895,68 @@ describe('HostedClient', () => {
         },
       },
     ]);
+  });
+
+  it('attaches the workspace header when a workspace is configured', async () => {
+    const requests: Array<{ workspace: string | null }> = [];
+    const client = new HostedClient({
+      apiBaseUrl: 'https://api.example.com',
+      apiKey: 'key',
+      workspace: resolveWorkspace([], { WEBCMD_WORKSPACE: 'user_64256' }),
+      fetchImpl: async (_url, init) => {
+        requests.push({ workspace: new Headers(init?.headers).get('x-webcmd-workspace') });
+        return new Response(JSON.stringify({
+          ok: true,
+          result: [],
+          execution: { id: 'exec_1', command: 'github/whoami', status: 'succeeded' },
+        }), { status: 200 });
+      },
+    });
+
+    await client.execute({ command: 'github/whoami', args: {} });
+
+    expect(requests).toEqual([{ workspace: 'user_64256' }]);
+  });
+
+  it('omits the workspace header when no workspace is configured', async () => {
+    const requests: Array<{ workspace: string | null }> = [];
+    const client = new HostedClient({
+      apiBaseUrl: 'https://api.example.com',
+      apiKey: 'key',
+      fetchImpl: async (_url, init) => {
+        requests.push({ workspace: new Headers(init?.headers).get('x-webcmd-workspace') });
+        return new Response(JSON.stringify({
+          ok: true,
+          result: [],
+          execution: { id: 'exec_1', command: 'github/whoami', status: 'succeeded' },
+        }), { status: 200 });
+      },
+    });
+
+    await client.execute({ command: 'github/whoami', args: {} });
+
+    expect(requests).toEqual([{ workspace: null }]);
+  });
+});
+
+describe('resolveWorkspace', () => {
+  it('returns the --workspace flag value when present', () => {
+    expect(resolveWorkspace(['--workspace', 'flagws'], {})).toBe('flagws');
+  });
+
+  it('--workspace overrides the env var', () => {
+    expect(resolveWorkspace(['--workspace', 'flagws'], { WEBCMD_WORKSPACE: 'envws' })).toBe('flagws');
+  });
+
+  it('falls back to WEBCMD_WORKSPACE when no flag is present', () => {
+    expect(resolveWorkspace([], { WEBCMD_WORKSPACE: 'envws' })).toBe('envws');
+  });
+
+  it('trims WEBCMD_WORKSPACE', () => {
+    expect(resolveWorkspace([], { WEBCMD_WORKSPACE: '  envws  ' })).toBe('envws');
+  });
+
+  it('returns undefined when neither --workspace nor WEBCMD_WORKSPACE is set', () => {
+    expect(resolveWorkspace([], {})).toBeUndefined();
   });
 });

--- a/src/hosted/client.test.ts
+++ b/src/hosted/client.test.ts
@@ -196,36 +196,18 @@ describe('HostedClient', () => {
           ...(init?.body ? { body: String(init.body) } : {}),
         });
         const path = new URL(String(url)).pathname;
-        if (path === '/v1/profiles' && init?.method === 'POST') {
-          return new Response(JSON.stringify({ ok: true, profile }), { status: 201 });
-        }
         if (path.startsWith('/v1/profiles/') && init?.method === 'DELETE') {
           return new Response(JSON.stringify({ ok: true, deleted: true }));
-        }
-        if (path.startsWith('/v1/profiles/')) {
-          return new Response(JSON.stringify({ ok: true, profile }));
         }
         return new Response(JSON.stringify({ ok: true, profiles: [profile] }));
       },
     });
 
-    await expect(client.listProfiles({ name: 'Work', userId: 'user_64256' }))
-      .resolves.toEqual({ ok: true, profiles: [profile] });
-    await expect(client.createProfile({ name: 'Work', userId: 'user_64256' }))
-      .resolves.toMatchObject({ profile: { id: 'profile_work', status: 'available' } });
-    await expect(client.getProfile('profile_work')).resolves.toMatchObject({
-      profile: { id: 'profile_work' },
-    });
+    await expect(client.listProfiles()).resolves.toEqual({ ok: true, profiles: [profile] });
     await expect(client.deleteProfile('profile/work')).resolves.toEqual({ ok: true, deleted: true });
 
     expect(requests).toEqual([
-      { url: 'https://api.example.com/v1/profiles?name=Work&userId=user_64256', method: 'GET' },
-      {
-        url: 'https://api.example.com/v1/profiles',
-        method: 'POST',
-        body: JSON.stringify({ name: 'Work', userId: 'user_64256' }),
-      },
-      { url: 'https://api.example.com/v1/profiles/profile_work', method: 'GET' },
+      { url: 'https://api.example.com/v1/profiles', method: 'GET' },
       { url: 'https://api.example.com/v1/profiles/profile%2Fwork', method: 'DELETE' },
     ]);
   });
@@ -918,6 +900,27 @@ describe('HostedClient', () => {
     expect(requests).toEqual([{ workspace: 'user_64256' }]);
   });
 
+  it('attaches the workspace header for the --workspace=<value> equals form', async () => {
+    const requests: Array<{ workspace: string | null }> = [];
+    const client = new HostedClient({
+      apiBaseUrl: 'https://api.example.com',
+      apiKey: 'key',
+      workspace: resolveWorkspace(['--workspace=user_64256'], {}),
+      fetchImpl: async (_url, init) => {
+        requests.push({ workspace: new Headers(init?.headers).get('x-webcmd-workspace') });
+        return new Response(JSON.stringify({
+          ok: true,
+          result: [],
+          execution: { id: 'exec_1', command: 'github/whoami', status: 'succeeded' },
+        }), { status: 200 });
+      },
+    });
+
+    await client.execute({ command: 'github/whoami', args: {} });
+
+    expect(requests).toEqual([{ workspace: 'user_64256' }]);
+  });
+
   it('omits the workspace header when no workspace is configured', async () => {
     const requests: Array<{ workspace: string | null }> = [];
     const client = new HostedClient({
@@ -942,6 +945,10 @@ describe('HostedClient', () => {
 describe('resolveWorkspace', () => {
   it('returns the --workspace flag value when present', () => {
     expect(resolveWorkspace(['--workspace', 'flagws'], {})).toBe('flagws');
+  });
+
+  it('returns the --workspace=<value> flag value when present', () => {
+    expect(resolveWorkspace(['--workspace=user_64256'], {})).toBe('user_64256');
   });
 
   it('--workspace overrides the env var', () => {

--- a/src/hosted/client.ts
+++ b/src/hosted/client.ts
@@ -13,7 +13,6 @@ import type {
   HostedExecution,
   HostedExecuteResponse,
   HostedPrepareExecutionResponse,
-  HostedProfileResponse,
   HostedProfilesResponse,
   HostedUploadArtifactResponse,
   HostedManifest,
@@ -33,6 +32,11 @@ export interface HostedClientOptions {
 export function resolveWorkspace(argv: readonly string[], env: NodeJS.ProcessEnv): string | undefined {
   const idx = argv.indexOf('--workspace');
   if (idx >= 0 && argv[idx + 1]) return argv[idx + 1];
+  const equalsForm = argv.find(arg => arg.startsWith('--workspace='));
+  if (equalsForm !== undefined) {
+    const value = equalsForm.slice('--workspace='.length).trim();
+    if (value) return value;
+  }
   const fromEnv = env.WEBCMD_WORKSPACE?.trim();
   return fromEnv ? fromEnv : undefined;
 }
@@ -80,33 +84,10 @@ export class HostedClient {
     return body.manifest;
   }
 
-  async listProfiles(filters: { name?: string; userId?: string } = {}): Promise<HostedProfilesResponse> {
-    const params = new URLSearchParams();
-    if (filters.name !== undefined) params.set('name', filters.name);
-    if (filters.userId !== undefined) params.set('userId', filters.userId);
-    const query = params.toString();
-    const body = await this.request(`/v1/profiles${query ? `?${query}` : ''}`);
+  async listProfiles(): Promise<HostedProfilesResponse> {
+    const body = await this.request('/v1/profiles');
     if (!isHostedProfilesResponse(body)) {
       throw protocolError('Webcmd Cloud returned an invalid profiles response.');
-    }
-    return body;
-  }
-
-  async createProfile(input: { name: string; userId?: string }): Promise<HostedProfileResponse> {
-    const body = await this.request('/v1/profiles', {
-      method: 'POST',
-      body: JSON.stringify(input),
-    });
-    if (!isHostedProfileResponse(body)) {
-      throw protocolError('Webcmd Cloud returned an invalid profile response.');
-    }
-    return body;
-  }
-
-  async getProfile(profileId: string): Promise<HostedProfileResponse> {
-    const body = await this.request(`/v1/profiles/${encodeURIComponent(profileId)}`);
-    if (!isHostedProfileResponse(body)) {
-      throw protocolError('Webcmd Cloud returned an invalid profile response.');
     }
     return body;
   }
@@ -419,12 +400,6 @@ function isHostedProfilesResponse(value: unknown): value is HostedProfilesRespon
     && value.ok === true
     && Array.isArray(value.profiles)
     && value.profiles.every(isHostedPublicProfile);
-}
-
-function isHostedProfileResponse(value: unknown): value is HostedProfileResponse {
-  return hasExactKeys(value, ['ok', 'profile'])
-    && value.ok === true
-    && isHostedPublicProfile(value.profile);
 }
 
 function isHostedPublicProfile(value: unknown): boolean {

--- a/src/hosted/client.ts
+++ b/src/hosted/client.ts
@@ -23,7 +23,18 @@ import type {
 export interface HostedClientOptions {
   apiBaseUrl: string;
   apiKey: string;
+  workspace?: string;
   fetchImpl?: typeof fetch;
+}
+
+/**
+ * Resolves the active workspace from CLI flags/env, precedence: --workspace flag > WEBCMD_WORKSPACE env > undefined.
+ */
+export function resolveWorkspace(argv: readonly string[], env: NodeJS.ProcessEnv): string | undefined {
+  const idx = argv.indexOf('--workspace');
+  if (idx >= 0 && argv[idx + 1]) return argv[idx + 1];
+  const fromEnv = env.WEBCMD_WORKSPACE?.trim();
+  return fromEnv ? fromEnv : undefined;
 }
 
 export class HostedClientError extends CliError {
@@ -47,11 +58,13 @@ export class HostedClientError extends CliError {
 export class HostedClient {
   private readonly apiBaseUrl: string;
   private readonly apiKey: string;
+  private readonly workspace: string | undefined;
   private readonly fetchImpl: typeof fetch;
 
   constructor(options: HostedClientOptions) {
     this.apiBaseUrl = options.apiBaseUrl.replace(/\/+$/, '');
     this.apiKey = options.apiKey;
+    this.workspace = options.workspace;
     this.fetchImpl = options.fetchImpl ?? fetch;
   }
 
@@ -192,6 +205,7 @@ export class HostedClient {
         headers: {
           accept: 'application/octet-stream',
           authorization: `Bearer ${this.apiKey}`,
+          ...(this.workspace ? { 'x-webcmd-workspace': this.workspace } : {}),
         },
       },
     );
@@ -281,6 +295,7 @@ export class HostedClient {
         accept: 'application/json',
         ...(init.body ? { 'content-type': 'application/json' } : {}),
         authorization: `Bearer ${this.apiKey}`,
+        ...(this.workspace ? { 'x-webcmd-workspace': this.workspace } : {}),
         ...(init.headers ?? {}),
       },
     });
@@ -414,12 +429,12 @@ function isHostedProfileResponse(value: unknown): value is HostedProfileResponse
 
 function isHostedPublicProfile(value: unknown): boolean {
   return hasExactKeys(value, [
-    'id', 'name', 'userId', 'default', 'status',
+    'id', 'name', 'workspace', 'default', 'status',
     'createdAt', 'updatedAt', 'lastUsedAt',
   ])
     && typeof value.id === 'string'
     && (value.name === null || typeof value.name === 'string')
-    && (value.userId === null || typeof value.userId === 'string')
+    && (value.workspace === null || typeof value.workspace === 'string')
     && typeof value.default === 'boolean'
     && (value.status === 'pending' || value.status === 'available')
     && typeof value.createdAt === 'string'

--- a/src/hosted/runner.test.ts
+++ b/src/hosted/runner.test.ts
@@ -251,7 +251,7 @@ describe('runHostedCli', () => {
   const publicProfile = {
     id: 'profile_work',
     name: 'Work',
-    userId: 'user_64256',
+    workspace: 'ws_demo',
     default: false,
     status: 'available',
     createdAt: '2026-07-24T00:00:00.000Z',
@@ -259,7 +259,7 @@ describe('runHostedCli', () => {
     lastUsedAt: '2026-07-24T00:00:00.000Z',
   };
 
-  it('lists, creates, resolves, gets, and deletes hosted profiles without fetching the manifest', async () => {
+  it('lists and deletes hosted profiles without fetching the manifest', async () => {
     const requests: Array<{ url: string; method: string; body?: unknown }> = [];
     const fetchImpl = vi.fn<typeof fetch>(async (url, init) => {
       const request = {
@@ -268,9 +268,6 @@ describe('runHostedCli', () => {
         ...(init?.body ? { body: JSON.parse(String(init.body)) } : {}),
       };
       requests.push(request);
-      if (request.method === 'POST') {
-        return new Response(JSON.stringify({ ok: true, profile: publicProfile }), { status: 201 });
-      }
       if (request.method === 'DELETE') {
         return new Response(JSON.stringify({ ok: true, deleted: true }));
       }
@@ -279,10 +276,6 @@ describe('runHostedCli', () => {
 
     for (const argv of [
       ['profile', 'list', '-f', 'json'],
-      ['profile', 'create', 'Work', '--user-id', 'user_64256', '-f', 'json'],
-      ['profile', 'get', 'Work', '-f', 'json'],
-      ['profile', 'get', 'user_64256', '-f', 'json'],
-      ['profile', 'get', 'profile_work', '-f', 'json'],
       ['profile', 'delete', 'profile_work', '-f', 'json'],
     ]) {
       const stdout = sink();
@@ -300,66 +293,50 @@ describe('runHostedCli', () => {
 
     expect(requests).toEqual([
       { url: 'https://api.example.com/v1/profiles', method: 'GET' },
-      {
-        url: 'https://api.example.com/v1/profiles',
-        method: 'POST',
-        body: { name: 'Work', userId: 'user_64256' },
-      },
-      { url: 'https://api.example.com/v1/profiles', method: 'GET' },
-      { url: 'https://api.example.com/v1/profiles', method: 'GET' },
-      { url: 'https://api.example.com/v1/profiles', method: 'GET' },
       { url: 'https://api.example.com/v1/profiles/profile_work', method: 'DELETE' },
     ]);
     expect(requests.some(request => request.url.endsWith('/v1/manifest'))).toBe(false);
   });
 
-  it('deduplicates universal profile matches and rejects missing or ambiguous selectors', async () => {
-    const cases = [
-      {
-        selector: 'same',
-        profiles: [{ ...publicProfile, id: 'profile_same', name: 'same', userId: 'same' }],
-        exitCode: 0,
-        stdout: '"id": "profile_same"',
-        stderr: '',
-      },
-      {
-        selector: 'missing',
-        profiles: [publicProfile],
-        exitCode: 66,
-        stdout: '',
-        stderr: 'code: PROFILE_NOT_FOUND',
-      },
-      {
-        selector: 'shared',
-        profiles: [
-          { ...publicProfile, id: 'profile_one', name: 'shared' },
-          { ...publicProfile, id: 'profile_two', name: 'Other', userId: 'shared' },
-        ],
-        exitCode: 75,
-        stdout: '',
-        stderr: 'code: AMBIGUOUS_PROFILE',
-      },
+  it.each(['create', 'get'])('rejects the removed profile %s subcommand', async (command) => {
+    const stderr = sink();
+    const fetchImpl = vi.fn<typeof fetch>();
+    const result = await runHostedCli(['profile', command, 'Work'], {
+      config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
+      stderr: stderr.stream,
+      fetchImpl,
+    });
+
+    expect(result.handled).toBe(true);
+    expect(stderr.text()).toMatch(/unknown command|not supported/i);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('threads the ambient workspace onto hosted profile requests', async () => {
+    const cases: Array<{ name: string; argv: string[]; env: NodeJS.ProcessEnv; expected: string }> = [
+      { name: 'from WEBCMD_WORKSPACE env', argv: ['profile', 'list', '-f', 'json'], env: { WEBCMD_WORKSPACE: 'ws1' }, expected: 'ws1' },
+      { name: 'from --workspace flag', argv: ['--workspace', 'ws2', 'profile', 'list', '-f', 'json'], env: {}, expected: 'ws2' },
     ];
 
     for (const testCase of cases) {
+      let capturedHeader: string | null = null;
+      const fetchImpl = vi.fn<typeof fetch>(async (_url, init) => {
+        capturedHeader = new Headers(init?.headers).get('x-webcmd-workspace');
+        return new Response(JSON.stringify({ ok: true, profiles: [publicProfile] }));
+      });
       const stdout = sink();
       const stderr = sink();
-      const fetchImpl = vi.fn<typeof fetch>(async () =>
-        new Response(JSON.stringify({ ok: true, profiles: testCase.profiles })));
-      const result = await runHostedCli(['profile', 'get', testCase.selector, '-f', 'json'], {
+      const result = await runHostedCli(testCase.argv, {
         config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
         stdout: stdout.stream,
         stderr: stderr.stream,
         fetchImpl,
+        env: testCase.env,
       });
 
-      expect(result.exitCode).toBe(testCase.exitCode);
-      expect(stdout.text()).toContain(testCase.stdout);
-      expect(stderr.text()).toContain(testCase.stderr);
-      if (testCase.selector === 'shared') {
-        expect(stderr.text()).toContain('Use the immutable profile ID returned by webcmd profile list.');
-      }
-      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ handled: true, exitCode: 0 });
+      expect(stderr.text()).toBe('');
+      expect(capturedHeader).toBe(testCase.expected);
     }
   });
 

--- a/src/hosted/runner.ts
+++ b/src/hosted/runner.ts
@@ -19,7 +19,7 @@ import { StreamWriteError, writeToStream } from '../stream-write.js';
 import { PKG_VERSION } from '../version.js';
 import { getCompletionScriptFast } from '../completion-fast.js';
 import { browserCommandCatalog } from '../browser/command-catalog.js';
-import { HostedClient, HostedClientError } from './client.js';
+import { HostedClient, HostedClientError, resolveWorkspace } from './client.js';
 import { parseHostedInvocation } from './args.js';
 import { HostedBrowserHelp, parseHostedBrowserStructure } from './browser-args.js';
 import { materializeHostedOutputs, prepareHostedFiles, rewriteHostedOutputResultPaths } from './files.js';
@@ -40,7 +40,6 @@ import type {
   HostedBrowserActionName,
   HostedBrowserRunActionResponse,
   HostedManifest,
-  HostedPublicProfile,
 } from './types.js';
 import type { HostedBrowserCommandContract } from './contract.js';
 
@@ -92,6 +91,7 @@ export async function runHostedCli(argv: string[], opts: HostedRunnerOptions = {
     const client = new HostedClient({
       apiBaseUrl: config.hosted.apiBaseUrl,
       apiKey: credential.apiKey,
+      workspace: resolveWorkspace(argv, opts.env ?? process.env),
       fetchImpl: opts.fetchImpl,
     });
     await dispatchHosted(argv, client, stdout, stderr, opts.now ?? Date.now);
@@ -197,7 +197,7 @@ async function dispatchHosted(
     if (args[1] === 'rename' || args[1] === 'use') {
       throw new ConfigError(
         `webcmd profile ${args[1]} is not available in hosted mode.`,
-        'Hosted mode supports: webcmd profile list, create, get, and delete.',
+        'Hosted mode supports: webcmd profile list and delete.',
       );
     }
     const parsed = parseHostedProfileSurface(args.slice(1), normalized.literal);
@@ -712,7 +712,7 @@ function parseHostedListSurface(argv: readonly string[], literal: boolean): Pars
   return { kind: 'run', format: parsedFormat, formatExplicit };
 }
 
-type HostedProfileCommand = 'list' | 'create' | 'get' | 'delete';
+type HostedProfileCommand = 'list' | 'delete';
 
 type ParsedHostedProfileSurface =
   | { kind: 'help'; output: string }
@@ -722,7 +722,6 @@ type ParsedHostedProfileSurface =
       format: string;
       formatExplicit: boolean;
       value?: string;
-      userId?: string;
     };
 
 function parseHostedProfileSurface(
@@ -747,7 +746,6 @@ function parseHostedProfileSurface(
     command: HostedProfileCommand,
     surface: Command,
     value?: string,
-    userId?: string,
   ): void => {
     const options = surface.opts<{ format: string }>();
     parsed = {
@@ -756,17 +754,11 @@ function parseHostedProfileSurface(
       format: options.format,
       formatExplicit: surface.getOptionValueSource('format') === 'cli',
       ...(value !== undefined ? { value } : {}),
-      ...(userId !== undefined ? { userId } : {}),
     };
   };
 
   const list = configureFormat(profile.command('list'));
   list.exitOverride().configureOutput(output).action(() => setParsed('list', list));
-  const create = configureFormat(profile.command('create').argument('<name>').option('--user-id <id>'));
-  create.exitOverride().configureOutput(output).action((name: string, options: { userId?: string }) =>
-    setParsed('create', create, name, options.userId));
-  const get = configureFormat(profile.command('get').argument('<profile>'));
-  get.exitOverride().configureOutput(output).action((selector: string) => setParsed('get', get, selector));
   const remove = configureFormat(profile.command('delete').argument('<profile-id>'));
   remove.exitOverride().configureOutput(output).action((profileId: string) => setParsed('delete', remove, profileId));
 
@@ -788,42 +780,14 @@ async function dispatchHostedProfile(
   client: HostedClient,
   stdout: NodeJS.WritableStream,
 ): Promise<void> {
-  let result: unknown;
-  if (parsed.command === 'list') {
-    result = (await client.listProfiles()).profiles;
-  } else if (parsed.command === 'create') {
-    result = (await client.createProfile({
-      name: parsed.value!,
-      ...(parsed.userId !== undefined ? { userId: parsed.userId } : {}),
-    })).profile;
-  } else if (parsed.command === 'get') {
-    result = resolveHostedProfile((await client.listProfiles()).profiles, parsed.value!);
-  } else {
-    result = await client.deleteProfile(parsed.value!);
-  }
+  const result = parsed.command === 'list'
+    ? (await client.listProfiles()).profiles
+    : await client.deleteProfile(parsed.value!);
   await renderOutput(result, {
     fmt: parsed.format,
     fmtExplicit: parsed.formatExplicit,
     stdout,
   });
-}
-
-function resolveHostedProfile(profiles: HostedPublicProfile[], selector: string): HostedPublicProfile {
-  const matches = profiles.filter(profile =>
-    profile.id === selector || profile.name === selector || profile.userId === selector);
-  const distinct = [...new Map(matches.map(profile => [profile.id, profile])).values()];
-  if (distinct.length === 0) {
-    throw new CliError('PROFILE_NOT_FOUND', 'Profile was not found.', undefined, EXIT_CODES.EMPTY_RESULT);
-  }
-  if (distinct.length > 1) {
-    throw new CliError(
-      'AMBIGUOUS_PROFILE',
-      'The profile selector matched multiple profiles.',
-      'Use the immutable profile ID returned by webcmd profile list.',
-      EXIT_CODES.TEMPFAIL,
-    );
-  }
-  return distinct[0]!;
 }
 
 type ParsedHostedCompletionSurface =

--- a/src/hosted/types.ts
+++ b/src/hosted/types.ts
@@ -47,7 +47,7 @@ export interface HostedManifest {
 export interface HostedPublicProfile {
   id: string;
   name: string | null;
-  userId: string | null;
+  workspace: string | null;
   default: boolean;
   status: 'pending' | 'available';
   createdAt: string;

--- a/src/hosted/types.ts
+++ b/src/hosted/types.ts
@@ -60,11 +60,6 @@ export interface HostedProfilesResponse {
   profiles: HostedPublicProfile[];
 }
 
-export interface HostedProfileResponse {
-  ok: true;
-  profile: HostedPublicProfile;
-}
-
 export interface HostedExecution {
   id: string;
   command: string;

--- a/src/root-command-surface.ts
+++ b/src/root-command-surface.ts
@@ -46,6 +46,11 @@ export function parseHostedRootCommandSurface(argv: readonly string[]): HostedRo
   let stderr = '';
   const boundary = findRootCommandBoundary(input);
   const root = configureRootCommandSurface(new Command('webcmd'))
+    // Hosted-only: registered here (not in the shared configureRootCommandSurface)
+    // so the local CLI surface is unaffected. Lets Commander's structural parse
+    // consume `--workspace <id>` before the site/command token instead of
+    // throwing an unknown-option error.
+    .option('--workspace <id>', 'Hosted workspace id/slug for the request')
     .exitOverride()
     .configureOutput({
       writeOut: value => { stdout += value; },
@@ -104,13 +109,16 @@ interface RootCommandBoundary {
 function findRootCommandBoundary(argv: readonly string[]): RootCommandBoundary {
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index]!;
-    if (token === '--profile') {
+    if (token === '--profile' || token === '--workspace') {
       // Commander requires and consumes the next token even when it is `--` or
       // starts with a dash. Structural failures have already been reported.
+      // `--workspace` is hosted-only (not a registered Commander option here)
+      // but must still be skipped as a value pair so it and its value are not
+      // mistaken for the site/command token and forwarded to the server.
       index += 1;
       continue;
     }
-    if (token.startsWith('--profile=')) continue;
+    if (token.startsWith('--profile=') || token.startsWith('--workspace=')) continue;
     if (token === '--') return { separatorIndex: index };
     if (!token.startsWith('-') || token === '-') return { commandIndex: index };
   }


### PR DESCRIPTION
## Summary

Hosted thin-client half of **workspace-scoped profiles**. Adds workspace transport and trims the hosted profile CLI to match the new server contract. B2C and B2B2C become the same grammar — profile creation and `--profile` selection are unchanged; the downstream user is an ambient workspace, not a profile field.

## What's included

- **Transport** — `WEBCMD_WORKSPACE=<id>` env var (primary, per-invocation) and `--workspace <id>` flag (precedence: flag ▸ env ▸ implicit `''`), resolved and sent as the `X-Webcmd-Workspace` header on hosted requests. Both `--workspace ws` and `--workspace=ws` forms supported; the flag is stripped from the forwarded command argv and is hosted-only (no local-mode leak).
- **CLI trim** — hosted `profile` reduced to `list` / `delete` (removed `create`, `get`, and `--user-id`); `--profile` selects a persona name **within** the ambient workspace.
- `HostedPublicProfile` drops `userId`, adds `workspace`.
- **Docs** rewritten (`authentication-and-profiles`, `cli-reference`, `local-or-cloud`) for the B2C lazy-default and B2B2C `WEBCMD_WORKSPACE`-per-downstream-user model.
- Local mode untouched (no workspace concept). No backward-compat shim — the builder CLI release was unused.

## Testing

- `npx tsc --noEmit`: **0 errors**.
- `npm test` (unit + adapter): **4936 passed / 0 failed**; docs-sync review **49/0**.

## Coordinated cutover

⚠️ Ships **together** with the `webcmd-cloud` server PR — **companion: agentrhq/webcmd-cloud#21**. Publish this new `webcmd` npm release together with the cloud deploy.

## Follow-ups (non-blocking)

- Remove the now-dead `HostedProfileResponse` type export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
