### PR TITLE
feat: add Amazon India adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -288,6 +288,284 @@
     "siteSession": "persistent"
   },
   {
+    "site": "amazon-in",
+    "name": "checkout",
+    "description": "Prepare a guarded Amazon.in checkout with browser-only payment handoff",
+    "access": "write",
+    "domain": "amazon.in",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Amazon.in product URL or ASIN"
+      },
+      {
+        "name": "quantity",
+        "type": "int",
+        "default": 1,
+        "required": false,
+        "help": "Quantity (1-10)"
+      },
+      {
+        "name": "size",
+        "type": "str",
+        "required": false,
+        "help": "Exact visible size label"
+      },
+      {
+        "name": "colour",
+        "type": "str",
+        "required": false,
+        "help": "Exact visible colour label"
+      },
+      {
+        "name": "payment",
+        "type": "str",
+        "required": true,
+        "help": "Payment method; secrets remain browser-only",
+        "choices": [
+          "upi",
+          "saved-card",
+          "new-card",
+          "cod"
+        ]
+      },
+      {
+        "name": "card-last4",
+        "type": "str",
+        "required": false,
+        "help": "Saved-card selector: exactly four digits"
+      },
+      {
+        "name": "place-order",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Submit the final Amazon action once"
+      }
+    ],
+    "columns": [
+      "status",
+      "asin",
+      "title",
+      "size",
+      "colour",
+      "quantity",
+      "item_price",
+      "total",
+      "payment_method",
+      "delivery_date",
+      "action",
+      "verify_command"
+    ],
+    "type": "js",
+    "modulePath": "amazon-in/checkout.js",
+    "sourceFile": "amazon-in/checkout.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "freshPage": true,
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "amazon-in",
+    "name": "checkout-status",
+    "description": "Read the current Amazon.in checkout or payment state without clicking",
+    "access": "read",
+    "domain": "amazon.in",
+    "strategy": "ui",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "status",
+      "order_id",
+      "total",
+      "payment_method",
+      "action"
+    ],
+    "type": "js",
+    "modulePath": "amazon-in/checkout-status.js",
+    "sourceFile": "amazon-in/checkout-status.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "amazon-in",
+    "name": "login",
+    "description": "Open amazon-in login",
+    "access": "write",
+    "domain": "amazon.in",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_name",
+      "action",
+      "verify_command"
+    ],
+    "type": "js",
+    "modulePath": "amazon-in/auth.js",
+    "sourceFile": "amazon-in/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "amazon-in",
+    "name": "product",
+    "description": "Fetch the current Amazon.in price and selected product variant",
+    "access": "read",
+    "domain": "amazon.in",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Amazon.in product URL or ASIN"
+      }
+    ],
+    "columns": [
+      "asin",
+      "title",
+      "price",
+      "mrp",
+      "discount",
+      "availability",
+      "size",
+      "colour",
+      "image_url",
+      "product_url"
+    ],
+    "type": "js",
+    "modulePath": "amazon-in/product.js",
+    "sourceFile": "amazon-in/product.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "amazon-in",
+    "name": "search",
+    "description": "Search Amazon.in products with inclusive INR price bounds and images",
+    "access": "read",
+    "domain": "amazon.in",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Product search query"
+      },
+      {
+        "name": "min-price",
+        "type": "number",
+        "required": false,
+        "help": "Inclusive minimum price in rupees"
+      },
+      {
+        "name": "max-price",
+        "type": "number",
+        "required": false,
+        "help": "Inclusive maximum price in rupees"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Maximum results (1-50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "asin",
+      "title",
+      "price",
+      "mrp",
+      "rating",
+      "review_count",
+      "image_url",
+      "product_url",
+      "is_sponsored"
+    ],
+    "type": "js",
+    "modulePath": "amazon-in/search.js",
+    "sourceFile": "amazon-in/search.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "amazon-in",
+    "name": "whoami",
+    "description": "Show the current logged-in amazon-in account",
+    "access": "read",
+    "domain": "amazon.in",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_name"
+    ],
+    "type": "js",
+    "modulePath": "amazon-in/auth.js",
+    "sourceFile": "amazon-in/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "amazon-in",
+    "name": "wishlist",
+    "description": "Fetch current prices for products in the default Amazon.in wishlist",
+    "access": "read",
+    "domain": "amazon.in",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "filter",
+        "type": "str",
+        "default": "unpurchased",
+        "required": false,
+        "help": "Wishlist items to include",
+        "choices": [
+          "unpurchased",
+          "all"
+        ]
+      }
+    ],
+    "columns": [
+      "list_name",
+      "item_id",
+      "asin",
+      "title",
+      "price",
+      "mrp",
+      "availability",
+      "size",
+      "colour",
+      "image_url",
+      "product_url"
+    ],
+    "type": "js",
+    "modulePath": "amazon-in/wishlist.js",
+    "sourceFile": "amazon-in/wishlist.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
     "site": "antigravity",
     "name": "add-context",
     "description": "Click the Add context button in the composer (opens file/URL picker for context attachment).",

--- a/clis/amazon-in/auth.js
+++ b/clis/amazon-in/auth.js
@@ -1,0 +1,44 @@
+import { AuthRequiredError, CommandExecutionError } from '@agentrhq/webcmd/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+import { hasAmazonInAuthCookie } from './parsers.js';
+import { DOMAIN, HOME_URL, SITE } from './shared.js';
+
+async function hasAmazonInSessionCookies(page) {
+  const cookies = await page.getCookies({ url: HOME_URL });
+  return hasAmazonInAuthCookie(cookies.map((cookie) => cookie.name));
+}
+
+async function verifyAmazonInIdentity(page) {
+  if (!await hasAmazonInSessionCookies(page)) {
+    throw new AuthRequiredError(DOMAIN, 'Amazon.in authentication cookies are missing');
+  }
+  await page.goto(HOME_URL, { waitUntil: 'load' });
+  await page.wait(2);
+  const identity = await page.evaluate(`
+    (() => {
+      const greeting = (
+        document.querySelector('#nav-link-accountList-nav-line-1')?.textContent || ''
+      ).trim();
+      if (/sign\\s*in/i.test(greeting)) return { kind: 'auth' };
+      const match = greeting.match(/^Hello,?\\s+(.+)$/i);
+      return match ? { user_name: match[1].trim() } : null;
+    })()
+  `);
+  if (identity?.kind === 'auth') throw new AuthRequiredError(DOMAIN);
+  if (!identity?.user_name) {
+    throw new CommandExecutionError(
+      'Amazon.in account greeting could not be read',
+      'Open Amazon.in in the Webcmd browser and check for a robot challenge or layout change.',
+    );
+  }
+  return identity;
+}
+
+registerSiteAuthCommands({
+  site: SITE,
+  domain: DOMAIN,
+  loginUrl: 'https://www.amazon.in/ap/signin',
+  columns: ['user_name'],
+  quickCheck: hasAmazonInSessionCookies,
+  verify: verifyAmazonInIdentity,
+});

--- a/clis/amazon-in/checkout-status.js
+++ b/clis/amazon-in/checkout-status.js
@@ -1,0 +1,54 @@
+import { AuthRequiredError, CommandExecutionError } from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { classifyCheckoutSnapshot } from './parsers.js';
+import { DOMAIN, SITE } from './shared.js';
+
+cli({
+  site: SITE,
+  name: 'checkout-status',
+  access: 'read',
+  description: 'Read the current Amazon.in checkout or payment state without clicking',
+  domain: DOMAIN,
+  strategy: Strategy.UI,
+  browser: true,
+  navigateBefore: false,
+  siteSession: 'persistent',
+  args: [],
+  columns: ['status', 'order_id', 'total', 'payment_method', 'action'],
+  func: async (page) => {
+    const snapshot = await page.evaluate(`
+      (() => {
+        const body = document.body?.innerText || '';
+        const rows = [...document.querySelectorAll('#subtotals-marketplace-table li')];
+        const total = rows.find((node) => /^Order Total:/i.test((node.textContent || '').trim()));
+        const selectedPayment = document.querySelector('#selected-payment-methods-list-container');
+        const checkedPayment = document.querySelector(
+          '#checkout-paymentOptionPanel input[type="radio"]:checked, input[name*="payment"]:checked'
+        );
+        const payment = selectedPayment ||
+          checkedPayment?.closest('label, [data-testid*="payment"], .pmts-instrument-box');
+        const order = document.querySelector('[data-order-id], #orderDetails, .order-number');
+        return {
+          url: location.href,
+          paymentText: payment?.textContent || '',
+          text: [
+            total?.textContent || '',
+            order?.textContent || '',
+            body,
+          ].join('\\n'),
+        };
+      })()
+    `);
+    try {
+      const row = classifyCheckoutSnapshot(snapshot);
+      if (row.status === 'login_required') throw new AuthRequiredError(DOMAIN);
+      return [row];
+    } catch (error) {
+      if (error instanceof AuthRequiredError) throw error;
+      throw new CommandExecutionError(
+        `Amazon checkout status could not be classified: ${error.message}`,
+        'Keep the checkout or payment page open in the persistent Webcmd browser and retry.',
+      );
+    }
+  },
+});

--- a/clis/amazon-in/checkout.js
+++ b/clis/amazon-in/checkout.js
@@ -1,0 +1,479 @@
+import {
+  ArgumentError,
+  AuthRequiredError,
+  CommandExecutionError,
+} from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import {
+  buildProductUrl,
+  normalizeCheckoutReview,
+  totalsAreConsistent,
+  validateCheckoutArgs,
+} from './parsers.js';
+import { assertUsablePage, gotoAmazon, SITE } from './shared.js';
+
+const VERIFY_COMMAND = 'webcmd amazon-in checkout-status';
+
+function handoffRow({ status = 'action_required', asin, title, size, colour, quantity, payment, action }) {
+  return {
+    status,
+    asin,
+    title,
+    size,
+    colour,
+    quantity,
+    item_price: null,
+    total: null,
+    payment_method: payment,
+    delivery_date: '',
+    action,
+    verify_command: VERIFY_COMMAND,
+  };
+}
+
+async function selectVariant(page, dimension, requested) {
+  if (!requested) return '';
+  const result = await page.evaluateWithArgs(`
+    (() => {
+      const current = (document.querySelector(
+        '#inline-twister-expanded-dimension-text-' + dimension + '_name, ' +
+        '#variation_' + dimension + '_name .selection'
+      )?.textContent || '').trim();
+      if (current.toLowerCase() === requested.toLowerCase()) return { current, changed: false };
+      const options = [...document.querySelectorAll(
+        '#inline-twister-expander-content-' + dimension + '_name span[id^="' + dimension + '_name_"]:not([id$="-announce"])'
+      )].filter((node) => !node.classList.contains('aok-hidden'));
+      const matches = options.filter((node) => {
+        const label = dimension === 'color'
+          ? (node.querySelector('img')?.alt || '')
+          : (node.textContent || '').trim();
+        return label.toLowerCase() === requested.toLowerCase();
+      });
+      if (matches.length !== 1) return { current, changed: false, matches: matches.length };
+      (matches[0].querySelector('input') || matches[0]).click();
+      return { current, changed: true, matches: 1 };
+    })()
+  `, { dimension, requested });
+  if (!result?.changed && result?.current?.toLowerCase() !== requested.toLowerCase()) {
+    throw new ArgumentError(
+      `${dimension === 'color' ? 'colour' : dimension} "${requested}" is not uniquely available`,
+    );
+  }
+  if (result.changed) await page.sleep(2);
+  const selected = await page.evaluateWithArgs(`
+    (() => (document.querySelector(
+      '#inline-twister-expanded-dimension-text-' + dimension + '_name, ' +
+      '#variation_' + dimension + '_name .selection'
+    )?.textContent || '').trim())()
+  `, { dimension });
+  if (selected.toLowerCase() !== requested.toLowerCase()) {
+    throw new CommandExecutionError(`Amazon did not select ${dimension} "${requested}"`);
+  }
+  return selected;
+}
+
+async function readProductSelection(page) {
+  return page.evaluate(`
+    (() => ({
+      asin: (location.pathname.match(/\\/dp\\/([A-Z0-9]{10})/i)?.[1] || document.querySelector('#ASIN')?.value || '').toUpperCase(),
+      title: (document.querySelector('#productTitle')?.textContent || '').replace(/\\s+/g, ' ').trim(),
+      size: (document.querySelector('#inline-twister-expanded-dimension-text-size_name, #variation_size_name .selection')?.textContent || '').trim(),
+      colour: (document.querySelector('#inline-twister-expanded-dimension-text-color_name, #variation_color_name .selection')?.textContent || '').trim(),
+    }))()
+  `);
+}
+
+async function selectPayment(page, options) {
+  return page.evaluateWithArgs(`
+    (() => {
+      const radios = [...document.querySelectorAll('input[type="radio"]')];
+      radios.forEach((radio) => radio.removeAttribute('data-webcmd-payment-target'));
+      let matches = [];
+      if (payment === 'upi') {
+        matches = radios.filter((radio) => /paymentMethod=UnifiedPaymentsInterface/i.test(radio.value));
+      } else if (payment === 'cod') {
+        matches = radios.filter((radio) => /paymentMethod=COD/i.test(radio.value));
+      } else if (payment === 'new-card') {
+        matches = radios.filter((radio) => radio.value === 'SelectableAddCreditCard');
+      } else {
+        matches = radios.filter((radio) => {
+          const label = radio.closest('label')?.innerText || radio.parentElement?.innerText || '';
+          return new RegExp('ending in\\\\s+' + cardLast4 + '\\\\b', 'i').test(label);
+        });
+      }
+      if (matches.length !== 1) return { matches: matches.length };
+      matches[0].setAttribute('data-webcmd-payment-target', 'true');
+      return { matches: 1 };
+    })()
+  `, options);
+}
+
+async function waitForPaymentUi(page) {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    const ready = await page.evaluate(`
+      (() => {
+        const visible = (node) => {
+          const rect = node.getBoundingClientRect();
+          const style = getComputedStyle(node);
+          return rect.width > 0 && rect.height > 0 &&
+            style.display !== 'none' && style.visibility !== 'hidden';
+        };
+        const loaders = [...document.querySelectorAll('[aria-label^="acp-loading"]')];
+        return document.querySelectorAll('#checkout-paymentOptionPanel input[type="radio"]').length > 0 &&
+          Boolean(document.querySelector('[data-testid="bottom-continue-button"]')) &&
+          !loaders.some(visible);
+      })()
+    `);
+    if (ready) return;
+    await page.sleep(0.5);
+  }
+  throw new CommandExecutionError('Amazon payment interface did not finish initializing');
+}
+
+async function continueAfterPaymentSelection(page, options, selected, quantity) {
+  if (options.payment === 'new-card') {
+    return handoffRow({
+      ...selected,
+      quantity,
+      payment: options.payment,
+      action: 'Enter the new card details in the opened browser, then run checkout-status.',
+    });
+  }
+  if (options.payment === 'saved-card') {
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      const readiness = await page.evaluate(`
+        (() => {
+          const button = document.querySelector('[data-testid="bottom-continue-button"]');
+          return {
+            needsSecret: Boolean(document.querySelector(
+              'input[name*="verification"], input[autocomplete="cc-csc"], input[placeholder*="CVV" i]'
+            )),
+            continueEnabled: Boolean(button && !button.disabled),
+          };
+        })()
+      `);
+      if (readiness?.needsSecret) {
+        return handoffRow({
+          ...selected,
+          quantity,
+          payment: options.payment,
+          action: 'Enter the saved card CVV in the opened browser, then run checkout-status.',
+        });
+      }
+      if (readiness?.continueEnabled) {
+        await page.click('[data-testid="bottom-continue-button"]');
+        return null;
+      }
+      await page.sleep(0.25);
+    }
+    throw new CommandExecutionError('Amazon did not expose the saved-card CVV or enable Continue');
+  }
+  try {
+    await page.wait({
+      selector: '[data-testid="bottom-continue-button"]:not([disabled])',
+      timeout: 10,
+    });
+  } catch {
+    throw new CommandExecutionError('Amazon did not enable the selected payment method');
+  }
+  await page.click('[data-testid="bottom-continue-button"]');
+  return null;
+}
+
+async function waitForUrlChange(page, previousUrl) {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    try {
+      if (await page.evaluate('location.href') !== previousUrl) return;
+    } catch {
+      return;
+    }
+    await page.sleep(0.25);
+  }
+}
+
+async function advanceToReview(page) {
+  for (let step = 0; step < 4; step += 1) {
+    try {
+      await page.wait({
+        selector: '#placeOrder, #noThanksCtaButtonId a, a[href*="/spc"]',
+        timeout: 20,
+      });
+    } catch {
+      throw new CommandExecutionError('Amazon checkout did not expose a review transition');
+    }
+    const state = await page.evaluate(`
+      (() => {
+        if (document.querySelector('#placeOrder')) return { kind: 'review' };
+        const reviewLinks = [...document.querySelectorAll('a[href*="/spc"]')]
+          .filter((link) => (link.textContent || '').trim() === 'Review Order');
+        if (reviewLinks.length === 1) return { kind: 'review-link', href: reviewLinks[0].href };
+        const decline = document.querySelector('#noThanksCtaButtonId a');
+        if (decline && (decline.textContent || '').trim() === 'No Thanks') {
+          return { kind: 'decline', url: location.href };
+        }
+        return { kind: 'unknown' };
+      })()
+    `);
+    if (state.kind === 'review') return;
+    if (state.kind === 'review-link') {
+      await page.goto(state.href, { waitUntil: 'load' });
+      continue;
+    }
+    if (state.kind === 'decline') {
+      await page.click('#noThanksCtaButtonId a');
+      await waitForUrlChange(page, state.url);
+      continue;
+    }
+    throw new CommandExecutionError('Amazon checkout exposed an unsupported Prime offer state');
+  }
+  throw new CommandExecutionError('Amazon checkout did not reach final review');
+}
+
+async function waitForReviewUi(page) {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    const ready = await page.evaluate(`
+      (() => {
+        const total = [...document.querySelectorAll('#subtotals-marketplace-table li')]
+          .find((node) => /^Order Total:/i.test((node.textContent || '').trim()));
+        return Boolean(
+          document.querySelector('[data-csa-c-item-type="asin"][data-csa-c-item-id*="amzn1.asin."]') &&
+          document.querySelector('[data-a-component="stepper"]') &&
+          /₹|Rs\\.?/i.test(total?.textContent || '')
+        );
+      })()
+    `);
+    if (ready) return;
+    await page.sleep(0.5);
+  }
+  throw new CommandExecutionError('Amazon checkout review details did not finish loading');
+}
+
+async function readReview(page, selected, options) {
+  const snapshot = await page.evaluate(`
+    (() => {
+      const text = (node) => (node?.textContent || '').replace(/\\s+/g, ' ').trim();
+      const rows = [...document.querySelectorAll('#subtotals-marketplace-table li')];
+      const row = (pattern) => text(rows.find((node) => pattern.test(text(node))));
+      const amount = (type) => text(
+        [...document.querySelectorAll('input[name="subtotalLineType"]')]
+          .find((input) => input.value === type)?.parentElement
+      );
+      const asinMarkers = [...document.querySelectorAll(
+        '[data-csa-c-item-type="asin"][data-csa-c-item-id*="amzn1.asin."]'
+      )];
+      const asinMarker = asinMarkers[0];
+      const asin = asinMarker?.getAttribute('data-csa-c-item-id')?.match(/amzn1\\.asin\\.([A-Z0-9]{10})/)?.[1] || '';
+      const item = asinMarker?.closest('.product-description-column') || document.querySelector('.product-description-column');
+      const snapshot = {
+        itemCount: asinMarkers.length,
+        asin,
+        title: text(item?.querySelector('.lineitem-title-text')),
+        itemPriceText: text(item?.querySelector('.a-price .a-offscreen')),
+        deliveryFeeText: amount('SHIPPING_TAX_INCLUSIVE'),
+        deliveryDiscountText: row(/^Free Delivery/i),
+        marketplaceFeeText: amount('MARKETPLACE_FEE_TAX_INCLUSIVE'),
+        totalText: row(/^Order Total:/i),
+        quantity: Number(document.querySelector('[data-a-component="stepper"]')?.getAttribute('data-steppervalue') || 0),
+        deliveryDate: text(document.querySelector('.address-promise-text')),
+        bodyText: document.body?.innerText || '',
+      };
+      return snapshot;
+    })()
+  `);
+  assertSingleLineItem(snapshot, selected, options);
+  const totals = readCheckoutTotals(snapshot);
+  return {
+    status: 'review_ready',
+    asin: selected.asin,
+    title: snapshot.title || selected.title,
+    size: selected.size,
+    colour: selected.colour,
+    quantity: options.quantity,
+    item_price: totals.itemPrice,
+    total: totals.total,
+    payment_method: options.payment,
+    delivery_date: snapshot.deliveryDate,
+    action: '',
+    verify_command: VERIFY_COMMAND,
+  };
+}
+
+function assertSingleLineItem(snapshot, selected, options) {
+  if (snapshot.itemCount !== 1) {
+    throw new CommandExecutionError(
+      `Expected exactly one checkout line item; found ${snapshot.itemCount}`,
+    );
+  }
+  if (snapshot.asin !== selected.asin || snapshot.quantity !== options.quantity) {
+    throw new CommandExecutionError(
+      `Amazon checkout item or quantity mismatch: expected ${selected.asin} × ${options.quantity}, got ${snapshot.asin || '(missing ASIN)'} × ${snapshot.quantity}`,
+    );
+  }
+  if (options.size && !snapshot.title.toLowerCase().includes(options.size.toLowerCase())) {
+    throw new CommandExecutionError(`Amazon checkout review does not show size "${options.size}"`);
+  }
+  if (options.colour && !snapshot.title.toLowerCase().includes(options.colour.toLowerCase())) {
+    throw new CommandExecutionError(`Amazon checkout review does not show colour "${options.colour}"`);
+  }
+  const paymentPatterns = {
+    upi: /Pay by scanning the QR code|Pay with UPI/i,
+    cod: /Cash on Delivery|Pay on Delivery/i,
+    'saved-card': new RegExp(`ending in\\s+${options.cardLast4}\\b`, 'i'),
+    'new-card': /credit or debit card/i,
+  };
+  if (!paymentPatterns[options.payment].test(snapshot.bodyText)) {
+    throw new CommandExecutionError('Amazon checkout payment method does not match the requested method');
+  }
+}
+
+function readCheckoutTotals(snapshot) {
+  let totals;
+  try {
+    totals = normalizeCheckoutReview(snapshot);
+  } catch (error) {
+    throw new CommandExecutionError(`Amazon checkout totals could not be read: ${error.message}`);
+  }
+  if (!totalsAreConsistent(totals)) {
+    throw new CommandExecutionError('Amazon checkout total is inconsistent with item price and fees');
+  }
+  return totals;
+}
+
+async function submitOrder(page, enabled) {
+  if (!enabled) return false;
+  const placement = await page.evaluate(`
+    (() => {
+      window.scrollTo(0, 0);
+      const candidates = [...document.querySelectorAll('#placeOrder')]
+        .filter((button) => {
+          const rect = button.getBoundingClientRect();
+          const style = getComputedStyle(button);
+          return !button.disabled && rect.width > 0 && rect.height > 0 &&
+            rect.top >= 0 && rect.bottom <= innerHeight &&
+            style.display !== 'none' && style.visibility !== 'hidden';
+        });
+      if (candidates.length !== 1) return { clicked: false, matches: candidates.length };
+      candidates[0].click();
+      return { clicked: true, matches: 1 };
+    })()
+  `);
+  if (!placement?.clicked) {
+    throw new CommandExecutionError(
+      `Expected one visible final order control; found ${placement?.matches ?? 0}`,
+    );
+  }
+  return true;
+}
+
+cli({
+  site: SITE,
+  name: 'checkout',
+  access: 'write',
+  description: 'Prepare a guarded Amazon.in checkout with browser-only payment handoff',
+  domain: 'amazon.in',
+  strategy: Strategy.UI,
+  browser: true,
+  navigateBefore: false,
+  siteSession: 'persistent',
+  freshPage: true,
+  defaultWindowMode: 'foreground',
+  args: [
+    { name: 'input', required: true, positional: true, help: 'Amazon.in product URL or ASIN' },
+    { name: 'quantity', type: 'int', default: 1, help: 'Quantity (1-10)' },
+    { name: 'size', help: 'Exact visible size label' },
+    { name: 'colour', help: 'Exact visible colour label' },
+    {
+      name: 'payment',
+      required: true,
+      choices: ['upi', 'saved-card', 'new-card', 'cod'],
+      help: 'Payment method; secrets remain browser-only',
+    },
+    { name: 'card-last4', help: 'Saved-card selector: exactly four digits' },
+    { name: 'place-order', type: 'boolean', default: false, help: 'Submit the final Amazon action once' },
+  ],
+  columns: [
+    'status', 'asin', 'title', 'size', 'colour', 'quantity', 'item_price',
+    'total', 'payment_method', 'delivery_date', 'action', 'verify_command',
+  ],
+  func: async (page, args) => {
+    let url;
+    let options;
+    try {
+      url = buildProductUrl(args.input);
+      options = validateCheckoutArgs({
+        quantity: args.quantity,
+        size: args.size,
+        colour: args.colour,
+        payment: args.payment,
+        cardLast4: args['card-last4'],
+        placeOrder: args['place-order'],
+      });
+    } catch (error) {
+      throw new ArgumentError(error.message);
+    }
+
+    await gotoAmazon(page, url, 'checkout product');
+    await page.wait({ selector: '#productTitle', timeout: 15 });
+    await selectVariant(page, 'color', options.colour);
+    await selectVariant(page, 'size', options.size);
+    const selected = await readProductSelection(page);
+    if (!selected.asin || !selected.title) {
+      throw new CommandExecutionError('Amazon product selection could not be verified');
+    }
+
+    const quantitySet = await page.evaluateWithArgs(`
+      (() => {
+        const select = document.querySelector('#quantity');
+        if (!select) return quantity === 1;
+        if (![...select.options].some((option) => Number(option.value) === quantity)) return false;
+        select.value = String(quantity);
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+        return Number(select.value) === quantity;
+      })()
+    `, { quantity: options.quantity });
+    if (!quantitySet) throw new ArgumentError(`quantity ${options.quantity} is not available`);
+
+    await page.click('#buy-now-button');
+    await page.sleep(3);
+    await assertUsablePage(page, 'checkout payment page');
+    try {
+      await page.wait({ selector: '#checkout-paymentOptionPanel input[type="radio"]', timeout: 20 });
+    } catch {
+      throw new CommandExecutionError('Amazon payment methods did not appear');
+    }
+    await waitForPaymentUi(page);
+
+    const paymentResult = await selectPayment(page, options);
+    if (paymentResult?.matches !== 1) {
+      throw new ArgumentError(
+        options.payment === 'saved-card'
+          ? `card-last4 ${options.cardLast4} did not match exactly one saved card`
+          : `${options.payment} is not uniquely available for this checkout`,
+      );
+    }
+    await page.click('input[data-webcmd-payment-target="true"]');
+    const handoff = await continueAfterPaymentSelection(page, options, selected, options.quantity);
+    if (handoff) return [handoff];
+    await advanceToReview(page);
+    await waitForReviewUi(page);
+    await assertUsablePage(page, 'checkout review');
+    const review = await readReview(page, selected, options);
+    if (!await submitOrder(page, options.placeOrder)) return [review];
+    await page.sleep(3);
+    return [{
+      ...review,
+      status: options.payment === 'cod' ? 'submitted' : 'action_required',
+      action: options.payment === 'upi'
+        ? 'Scan Amazon’s QR code in the opened browser and approve the UPI payment, then run checkout-status.'
+        : options.payment === 'cod'
+          ? ''
+          : 'Complete the bank verification in the opened browser, then run checkout-status.',
+    }];
+  },
+});
+
+export const __test__ = {
+  assertSingleLineItem,
+  continueAfterPaymentSelection,
+  submitOrder,
+};

--- a/clis/amazon-in/parsers.js
+++ b/clis/amazon-in/parsers.js
@@ -1,0 +1,252 @@
+export const cleanText = (value) =>
+  typeof value === 'string'
+    ? value.replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim()
+    : '';
+
+export function classifyPageState(url, text) {
+  if (/\/(?:ap\/signin|signin)(?:[/?]|$)/i.test(url)) return 'login';
+  if (/enter the characters you see below|sorry, we just need to make sure you're not a robot/i.test(cleanText(text))) {
+    return 'robot';
+  }
+  return 'usable';
+}
+
+export function hasAmazonInAuthCookie(names) {
+  const cookies = new Set(names);
+  return cookies.has('at-acbin') || cookies.has('x-acbin');
+}
+
+export function extractAsin(input) {
+  const value = cleanText(input);
+  if (/^[A-Z0-9]{10}$/i.test(value)) return value.toUpperCase();
+  try {
+    const url = new URL(value);
+    if (!/(^|\.)amazon\.in$/i.test(url.hostname)) return null;
+    return url.pathname.match(/\/(?:dp|gp\/product)\/([A-Z0-9]{10})/i)?.[1]?.toUpperCase() ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function buildProductUrl(input) {
+  const asin = extractAsin(input);
+  if (!asin) throw new RangeError('Expected an Amazon.in product URL or 10-character ASIN');
+  return `https://www.amazon.in/dp/${asin}`;
+}
+
+export function parseMoney(text) {
+  const match = cleanText(text).match(/(?:₹|Rs\.?)\s*([\d,]+(?:\.\d{1,2})?)/i);
+  return match ? Number(match[1].replaceAll(',', '')) : null;
+}
+
+export function parseCompactCount(text) {
+  const match = cleanText(text).match(/([\d,.]+)\s*([KM])?/i);
+  if (!match) return null;
+  const scale = match[2]?.toUpperCase() === 'M' ? 1_000_000 : match[2] ? 1_000 : 1;
+  return Math.round(Number(match[1].replaceAll(',', '')) * scale);
+}
+
+export function validatePositiveInteger(value, name, maximum) {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number < 1 || number > maximum) {
+    throw new RangeError(`${name} must be an integer from 1 to ${maximum}`);
+  }
+  return number;
+}
+
+export function parseBoolean(value) {
+  if (typeof value === 'boolean') return value;
+  if (value === undefined || value === null || value === '') return false;
+  if (/^(true|1)$/i.test(String(value))) return true;
+  if (/^(false|0)$/i.test(String(value))) return false;
+  throw new RangeError('place-order must be true or false');
+}
+
+export function validatePriceBounds(minimum, maximum) {
+  const minPrice = minimum === undefined ? null : Number(minimum);
+  const maxPrice = maximum === undefined ? null : Number(maximum);
+  if (minPrice !== null && (!Number.isFinite(minPrice) || minPrice < 0)) {
+    throw new RangeError('minimum price must be zero or greater');
+  }
+  if (maxPrice !== null && (!Number.isFinite(maxPrice) || maxPrice < 0)) {
+    throw new RangeError('maximum price must be zero or greater');
+  }
+  if (minPrice !== null && maxPrice !== null && minPrice > maxPrice) {
+    throw new RangeError('minimum price cannot exceed maximum price');
+  }
+  return { minPrice, maxPrice };
+}
+
+export function buildSearchUrl(query, { minPrice, maxPrice }) {
+  const url = new URL('/s', 'https://www.amazon.in');
+  url.searchParams.set('k', cleanText(query));
+  if (minPrice !== null || maxPrice !== null) {
+    const low = Math.round((minPrice ?? 0) * 100);
+    const high = Math.round((maxPrice ?? 10_000_000) * 100);
+    url.searchParams.set('rh', `p_36:${low}-${high}`);
+  }
+  return url.href;
+}
+
+export function normalizeSearchCards(cards, { minPrice, maxPrice, limit }) {
+  return cards
+    .map((card) => {
+      const price = parseMoney(card.cardPriceText);
+      if (!card.cardAsin || !cleanText(card.cardTitle) || price === null) return null;
+      if (minPrice !== null && price < minPrice) return null;
+      if (maxPrice !== null && price > maxPrice) return null;
+      return {
+        rank: 0,
+        asin: card.cardAsin,
+        title: cleanText(card.cardTitle),
+        price,
+        mrp: parseMoney(card.cardMrpText),
+        rating: Number(cleanText(card.cardRatingText).match(/[\d.]+/)?.[0]) || null,
+        review_count: parseCompactCount(card.cardReviewText),
+        image_url: cleanText(card.cardImageUrl),
+        product_url: `https://www.amazon.in/dp/${card.cardAsin}`,
+        is_sponsored: card.cardSponsored === true,
+      };
+    })
+    .filter(Boolean)
+    .slice(0, limit)
+    .map((row, index) => ({ ...row, rank: index + 1 }));
+}
+
+export function normalizeProductSnapshot(snapshot) {
+  const asin = extractAsin(snapshot.href);
+  const title = cleanText(snapshot.title);
+  const availability = cleanText(snapshot.availabilityText);
+  if (!asin || !title || !availability) throw new Error('Amazon product details are incomplete');
+  const price = parseMoney(snapshot.priceText);
+  if (price === null && !/unavailable|out of stock|currently unavailable/i.test(availability)) {
+    throw new Error('Amazon product price is missing');
+  }
+  const discountMatch = cleanText(snapshot.discountText).match(/-?\s*(\d+(?:\.\d+)?)\s*%/);
+  return {
+    asin,
+    title,
+    price,
+    mrp: parseMoney(snapshot.mrpText),
+    discount: discountMatch ? Number(discountMatch[1]) : null,
+    availability,
+    size: cleanText(snapshot.sizeText),
+    colour: cleanText(snapshot.colourText),
+    image_url: cleanText(snapshot.imageUrl),
+    product_url: `https://www.amazon.in/dp/${asin}`,
+  };
+}
+
+export function normalizeWishlistRows(listName, cards) {
+  return cards.map((card) => {
+    const asin = extractAsin(card.cardHref);
+    const title = cleanText(card.cardTitle);
+    const itemId = cleanText(card.cardItemId);
+    const availability = cleanText(card.cardAvailabilityText);
+    const price = parseMoney(card.cardPriceText);
+    if (!asin || !title || !itemId) throw new Error('Amazon wishlist item details are incomplete');
+    if (price === null && !/unavailable|out of stock|currently unavailable/i.test(availability)) {
+      throw new Error(`Amazon wishlist price is missing for ${asin}`);
+    }
+    return {
+      list_name: cleanText(listName),
+      item_id: itemId,
+      asin,
+      title,
+      price,
+      mrp: parseMoney(card.cardMrpText),
+      availability,
+      size: cleanText(card.cardSizeText),
+      colour: cleanText(card.cardColourText),
+      image_url: cleanText(card.cardImageUrl),
+      product_url: `https://www.amazon.in/dp/${asin}`,
+    };
+  });
+}
+
+export function validateCheckoutArgs(args) {
+  const quantity = validatePositiveInteger(args.quantity ?? 1, 'quantity', 10);
+  const payment = cleanText(args.payment);
+  if (!['upi', 'saved-card', 'new-card', 'cod'].includes(payment)) {
+    throw new RangeError('payment must be upi, saved-card, new-card, or cod');
+  }
+  const cardLast4 = cleanText(args.cardLast4);
+  if (payment === 'saved-card' && !/^\d{4}$/.test(cardLast4)) {
+    throw new RangeError('card-last4 must contain exactly four digits for saved-card');
+  }
+  return {
+    quantity,
+    payment,
+    cardLast4,
+    size: cleanText(args.size),
+    colour: cleanText(args.colour),
+    placeOrder: parseBoolean(args.placeOrder),
+  };
+}
+
+export function normalizeCheckoutReview(snapshot) {
+  const itemPrice = parseMoney(snapshot.itemPriceText);
+  const total = parseMoney(snapshot.totalText);
+  if (itemPrice === null || total === null) throw new Error('Checkout item price or total is missing');
+  const deliveryFee = (parseMoney(snapshot.deliveryFeeText) ?? 0)
+    - (parseMoney(snapshot.deliveryDiscountText) ?? 0);
+  return {
+    itemPrice,
+    deliveryFee,
+    marketplaceFee: parseMoney(snapshot.marketplaceFeeText) ?? 0,
+    total,
+    quantity: Number(snapshot.quantity),
+  };
+}
+
+export function totalsAreConsistent(review) {
+  const expected = review.itemPrice * review.quantity + review.deliveryFee + review.marketplaceFee;
+  return Math.abs(expected - review.total) <= 0.011;
+}
+
+export function classifyCheckoutSnapshot(snapshot) {
+  const url = cleanText(snapshot.url);
+  const text = cleanText(snapshot.text);
+  const reviewReady = /\/checkout\/p\/.+\/spc/i.test(url) && /Order Total:/i.test(text);
+  const awaitingPayment = !reviewReady && (
+    /aips\/process-payment/i.test(url)
+    || /QR code|enter (?:your )?CVV|one.time password|3-D Secure/i.test(text)
+  );
+  const hasPaymentText = Object.hasOwn(snapshot, 'paymentText');
+  const explicitPaymentText = hasPaymentText ? cleanText(snapshot.paymentText) : '';
+  const paymentText = hasPaymentText
+    ? explicitPaymentText || (awaitingPayment ? text : '')
+    : text;
+  const paymentMethod = /UPI|QR code/i.test(paymentText)
+    ? 'upi'
+    : /Cash on Delivery|Pay on Delivery/i.test(paymentText)
+      ? 'cod'
+      : /ending in|credit card|debit card|CVV|3-D Secure/i.test(paymentText)
+        ? 'card'
+        : '';
+  const base = {
+    order_id: text.match(/\b\d{3}-\d{7}-\d{7}\b/)?.[0] ?? '',
+    total: parseMoney(text),
+    payment_method: paymentMethod,
+    action: '',
+  };
+  if (/\/(?:thankyou|buy\/thankyou)\//i.test(url) && /order (?:placed|confirmed)|thank you/i.test(text)) {
+    return { status: 'ordered', ...base };
+  }
+  if (/payment (?:failed|declined|unsuccessful)|transaction failed/i.test(text)) {
+    return { status: 'failed', ...base, action: 'Choose a payment method in the browser; do not retry a charge automatically.' };
+  }
+  if (/(?:QR|session|payment link).{0,30}expired|expired.{0,30}(?:QR|session|payment)/i.test(text)) {
+    return { status: 'expired', ...base, action: 'Return to checkout and create a new payment attempt.' };
+  }
+  if (reviewReady) {
+    return { status: 'review_ready', ...base };
+  }
+  if (awaitingPayment) {
+    return { status: 'awaiting_payment', ...base, action: 'Complete payment in the opened browser, then run checkout-status again.' };
+  }
+  if (/\/ap\/signin/i.test(url) || /enter your (?:email|mobile number)|sign in/i.test(text)) {
+    return { status: 'login_required', ...base, action: 'Sign in in the opened browser, then run checkout-status again.' };
+  }
+  throw new Error('Amazon checkout state is not recognized');
+}

--- a/clis/amazon-in/parsers.test.js
+++ b/clis/amazon-in/parsers.test.js
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest';
+import { __test__ as checkoutTest } from './checkout.js';
+import {
+  buildProductUrl,
+  classifyCheckoutSnapshot,
+  classifyPageState,
+  extractAsin,
+  hasAmazonInAuthCookie,
+  normalizeCheckoutReview,
+  normalizeProductSnapshot,
+  normalizeSearchCards,
+  normalizeWishlistRows,
+  parseCompactCount,
+  parseMoney,
+  totalsAreConsistent,
+  validateCheckoutArgs,
+  validatePositiveInteger,
+  validatePriceBounds,
+} from './parsers.js';
+
+describe('amazon-in parsers', () => {
+  it('normalizes ASINs and parses Indian prices and counts', () => {
+    expect(extractAsin('https://www.amazon.in/dp/B0D2QL339Z?psc=1')).toBe('B0D2QL339Z');
+    expect(buildProductUrl('B0D2QL339Z')).toBe('https://www.amazon.in/dp/B0D2QL339Z');
+    expect(extractAsin('https://amazon.com/dp/B0D2QL339Z')).toBeNull();
+    expect(parseMoney('₹1,499.00')).toBe(1499);
+    expect(parseMoney('Unavailable')).toBeNull();
+    expect(parseCompactCount('39.7K')).toBe(39700);
+    expect(parseCompactCount('3,564 ratings')).toBe(3564);
+  });
+
+  it('validates bounds without silently clamping', () => {
+    expect(validatePriceBounds('300', '500')).toEqual({ minPrice: 300, maxPrice: 500 });
+    expect(() => validatePriceBounds('500', '300')).toThrow(/minimum price/i);
+    expect(validatePositiveInteger('20', 'limit', 50)).toBe(20);
+    expect(() => validatePositiveInteger('51', 'limit', 50)).toThrow(/1 to 50/i);
+  });
+
+  it('classifies login and robot pages before DOM parsing', () => {
+    expect(classifyPageState('https://www.amazon.in/ap/signin', '')).toBe('login');
+    expect(classifyPageState('https://www.amazon.in/', 'Enter the characters you see below')).toBe('robot');
+    expect(classifyPageState('https://www.amazon.in/s?k=shirt', 'Results')).toBe('usable');
+    expect(hasAmazonInAuthCookie(['session-id', 'x-acbin'])).toBe(true);
+    expect(hasAmazonInAuthCookie(['session-id', 'i18n-prefs'])).toBe(false);
+  });
+
+  it('filters search cards inclusively and preserves images', () => {
+    const rows = normalizeSearchCards([
+      {
+        cardAsin: 'B000000001',
+        cardTitle: 'Low',
+        cardPriceText: '₹299',
+        cardImageUrl: 'https://m.media-amazon.com/low.jpg',
+      },
+      {
+        cardAsin: 'B000000002',
+        cardTitle: 'Match',
+        cardPriceText: '₹500',
+        cardImageUrl: 'https://m.media-amazon.com/match.jpg',
+      },
+      {
+        cardAsin: 'B000000003',
+        cardTitle: 'No price',
+        cardPriceText: '',
+        cardImageUrl: '',
+      },
+    ], { minPrice: 300, maxPrice: 500, limit: 10 });
+    expect(rows.map((row) => row.asin)).toEqual(['B000000002']);
+    expect(rows[0].image_url).toBe('https://m.media-amazon.com/match.jpg');
+    expect(rows[0].rank).toBe(1);
+  });
+
+  it('normalizes selected product and wishlist variants', () => {
+    expect(normalizeProductSnapshot({
+      href: 'https://www.amazon.in/dp/B0D2QL339Z?th=1&psc=1',
+      title: 'Besix shirt',
+      priceText: '₹395.00',
+      mrpText: '₹1,499.00',
+      discountText: '-74%',
+      availabilityText: 'In stock',
+      sizeText: 'L',
+      colourText: 'Red',
+      imageUrl: 'https://m.media-amazon.com/image.jpg',
+    })).toEqual({
+      asin: 'B0D2QL339Z',
+      title: 'Besix shirt',
+      price: 395,
+      mrp: 1499,
+      discount: 74,
+      availability: 'In stock',
+      size: 'L',
+      colour: 'Red',
+      image_url: 'https://m.media-amazon.com/image.jpg',
+      product_url: 'https://www.amazon.in/dp/B0D2QL339Z',
+    });
+
+    const [row] = normalizeWishlistRows('Shopping List', [{
+      cardItemId: 'item-1',
+      cardHref: 'https://www.amazon.in/dp/B0D2QL339Z',
+      cardTitle: 'Besix shirt',
+      cardPriceText: '₹395.00',
+      cardMrpText: '₹1,499.00',
+      cardAvailabilityText: 'In stock',
+      cardSizeText: 'L',
+      cardColourText: 'Red',
+      cardImageUrl: 'https://m.media-amazon.com/image.jpg',
+    }]);
+    expect(row).toMatchObject({
+      asin: 'B0D2QL339Z',
+      price: 395,
+      list_name: 'Shopping List',
+    });
+  });
+
+  it('validates checkout payment selectors and totals', () => {
+    expect(validateCheckoutArgs({
+      quantity: 1,
+      payment: 'saved-card',
+      cardLast4: '6764',
+      placeOrder: false,
+    }).payment).toBe('saved-card');
+    expect(validateCheckoutArgs({ quantity: 1, payment: 'upi' }).placeOrder).toBe(false);
+    expect(() => validateCheckoutArgs({
+      quantity: 1,
+      payment: 'saved-card',
+      cardLast4: '',
+    })).toThrow(/card-last4/i);
+    expect(() => validateCheckoutArgs({
+      quantity: 1,
+      payment: 'card-number',
+    })).toThrow(/upi, saved-card, new-card, or cod/i);
+
+    const review = normalizeCheckoutReview({
+      itemPriceText: '₹395',
+      deliveryFeeText: '₹40',
+      deliveryDiscountText: '-₹40',
+      marketplaceFeeText: '₹5',
+      totalText: '₹400',
+      quantity: 1,
+    });
+    expect(review.deliveryFee).toBe(0);
+    expect(totalsAreConsistent(review)).toBe(true);
+    expect(totalsAreConsistent({ ...review, total: 500 })).toBe(false);
+  });
+
+  it('classifies checkout state without submitting', () => {
+    expect(classifyCheckoutSnapshot({
+      url: 'https://www.amazon.in/aips/process-payment',
+      text: 'Complete your payment Payment of ₹ 400.00 QR code is valid',
+    })).toMatchObject({ status: 'awaiting_payment', payment_method: 'upi', total: 400 });
+    expect(classifyCheckoutSnapshot({
+      url: 'https://www.amazon.in/gp/buy/thankyou/handlers/display.html',
+      text: 'Order placed, thank you',
+    }).status).toBe('ordered');
+    expect(classifyCheckoutSnapshot({
+      url: 'https://www.amazon.in/checkout/p/example/spc',
+      text: 'Order Total: ₹400 Pay with UPI',
+    }).status).toBe('review_ready');
+    expect(classifyCheckoutSnapshot({
+      url: 'https://www.amazon.in/checkout/p/example/spc',
+      paymentText: 'Pay by scanning the QR code',
+      text: 'Order Total: ₹400 A UPI QR code will appear on the next page',
+    }).status).toBe('review_ready');
+    expect(classifyCheckoutSnapshot({
+      url: 'https://www.amazon.in/checkout/p/example/spc',
+      paymentText: 'Visa ending in 6764',
+      text: 'Order Total: ₹400 Other methods: Pay with UPI',
+    }).payment_method).toBe('card');
+    expect(classifyCheckoutSnapshot({
+      url: 'https://www.amazon.in/aips/process-payment',
+      paymentText: '',
+      text: 'Complete your payment Payment of ₹400 Scan the QR code',
+    }).payment_method).toBe('upi');
+  });
+
+  it('hands secret entry to the browser before trying Continue', async () => {
+    const page = {
+      wait: () => { throw new Error('must not wait'); },
+      click: () => { throw new Error('must not click Continue'); },
+      evaluate: () => { throw new Error('must not inspect new-card secrets'); },
+    };
+    const row = await checkoutTest.continueAfterPaymentSelection(
+      page,
+      { payment: 'new-card' },
+      { asin: 'B0D2QL339Z', title: 'Shirt', size: 'L', colour: 'Red' },
+      1,
+    );
+    expect(row).toMatchObject({ status: 'action_required', payment_method: 'new-card' });
+
+    let clicks = 0;
+    const savedCardRow = await checkoutTest.continueAfterPaymentSelection({
+      evaluate: async () => ({ needsSecret: true, continueEnabled: false }),
+      click: async () => { clicks += 1; },
+      sleep: () => { throw new Error('must not sleep after finding CVV'); },
+    }, {
+      payment: 'saved-card',
+    }, {
+      asin: 'B0D2QL339Z',
+      title: 'Shirt',
+      size: 'L',
+      colour: 'Red',
+    }, 1);
+    expect(savedCardRow).toMatchObject({ status: 'action_required', payment_method: 'saved-card' });
+    expect(clicks).toBe(0);
+  });
+
+  it('requires one matching line item and never clicks Place Order by default', async () => {
+    expect(() => checkoutTest.assertSingleLineItem({
+      itemCount: 2,
+      asin: 'B0D2QL339Z',
+      quantity: 1,
+    }, {
+      asin: 'B0D2QL339Z',
+    }, {
+      quantity: 1,
+    })).toThrow(/exactly one checkout line item/i);
+
+    let placements = 0;
+    const page = {
+      evaluate: async () => {
+        placements += 1;
+        return { clicked: true, matches: 1 };
+      },
+    };
+    expect(await checkoutTest.submitOrder(page, false)).toBe(false);
+    expect(placements).toBe(0);
+    expect(await checkoutTest.submitOrder(page, true)).toBe(true);
+    expect(placements).toBe(1);
+  });
+});

--- a/clis/amazon-in/product.js
+++ b/clis/amazon-in/product.js
@@ -1,0 +1,72 @@
+import { ArgumentError, CommandExecutionError } from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { buildProductUrl, normalizeProductSnapshot } from './parsers.js';
+import { gotoAmazon, SITE } from './shared.js';
+
+cli({
+  site: SITE,
+  name: 'product',
+  access: 'read',
+  description: 'Fetch the current Amazon.in price and selected product variant',
+  domain: 'amazon.in',
+  strategy: Strategy.UI,
+  browser: true,
+  navigateBefore: false,
+  siteSession: 'persistent',
+  args: [
+    {
+      name: 'input',
+      required: true,
+      positional: true,
+      help: 'Amazon.in product URL or ASIN',
+    },
+  ],
+  columns: [
+    'asin', 'title', 'price', 'mrp', 'discount', 'availability',
+    'size', 'colour', 'image_url', 'product_url',
+  ],
+  func: async (page, args) => {
+    let url;
+    try {
+      url = buildProductUrl(args.input);
+    } catch (error) {
+      throw new ArgumentError(error.message);
+    }
+    await gotoAmazon(page, url, 'product page');
+    try {
+      await page.wait({ selector: '#productTitle', timeout: 15 });
+    } catch {
+      throw new CommandExecutionError(
+        'Amazon.in product title did not appear',
+        'The product may be unavailable or the page layout may have changed.',
+      );
+    }
+    const snapshot = await page.evaluate(`
+      (() => {
+        const text = (selector) => (document.querySelector(selector)?.textContent || '')
+          .replace(/\\s+/g, ' ').trim();
+        const image = document.querySelector('#landingImage');
+        const snapshot = {
+          href: location.href,
+          title: text('#productTitle'),
+          priceText: text('#corePrice_feature_div .a-price:not(.a-text-price) .a-offscreen, #priceblock_ourprice, #priceblock_dealprice'),
+          mrpText: text('#corePrice_feature_div .a-price.a-text-price .a-offscreen, .basisPrice .a-offscreen'),
+          discountText: text('#corePrice_feature_div .savingsPercentage, .savingsPercentage'),
+          availabilityText: text('#availability'),
+          sizeText: text('#inline-twister-expanded-dimension-text-size_name, #variation_size_name .selection, #variation_size_name li.swatchSelect .a-button-text'),
+          colourText: text('#inline-twister-expanded-dimension-text-color_name, #variation_color_name .selection, #variation_color_name li.swatchSelect .a-button-text'),
+          imageUrl: image?.getAttribute('data-old-hires') || image?.currentSrc || image?.src || '',
+        };
+        return snapshot;
+      })()
+    `);
+    try {
+      return [normalizeProductSnapshot(snapshot)];
+    } catch (error) {
+      throw new CommandExecutionError(
+        `Amazon.in product details could not be normalized: ${error.message}`,
+        'Check the visible product page for an unavailable item or changed layout.',
+      );
+    }
+  },
+});

--- a/clis/amazon-in/search.js
+++ b/clis/amazon-in/search.js
@@ -1,0 +1,76 @@
+import {
+  ArgumentError,
+  CommandExecutionError,
+  EmptyResultError,
+} from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import {
+  buildSearchUrl,
+  cleanText,
+  normalizeSearchCards,
+  validatePositiveInteger,
+  validatePriceBounds,
+} from './parsers.js';
+import { argumentValue, gotoAmazon, SITE } from './shared.js';
+
+cli({
+  site: SITE,
+  name: 'search',
+  access: 'read',
+  description: 'Search Amazon.in products with inclusive INR price bounds and images',
+  domain: 'amazon.in',
+  strategy: Strategy.UI,
+  browser: true,
+  navigateBefore: false,
+  siteSession: 'persistent',
+  args: [
+    { name: 'query', required: true, positional: true, help: 'Product search query' },
+    { name: 'min-price', type: 'number', help: 'Inclusive minimum price in rupees' },
+    { name: 'max-price', type: 'number', help: 'Inclusive maximum price in rupees' },
+    { name: 'limit', type: 'int', default: 20, help: 'Maximum results (1-50)' },
+  ],
+  columns: [
+    'rank', 'asin', 'title', 'price', 'mrp', 'rating',
+    'review_count', 'image_url', 'product_url', 'is_sponsored',
+  ],
+  func: async (page, args) => {
+    const query = cleanText(args.query);
+    if (!query) throw new ArgumentError('query must not be empty');
+    const bounds = argumentValue(() => validatePriceBounds(args['min-price'], args['max-price']));
+    const limit = argumentValue(() => validatePositiveInteger(args.limit ?? 20, 'limit', 50));
+    await gotoAmazon(page, buildSearchUrl(query, bounds), 'product search');
+
+    const payload = await page.evaluate(`
+      (() => {
+        const text = (node) => (node?.textContent || '').replace(/\\s+/g, ' ').trim();
+        const cards = [...document.querySelectorAll('[data-component-type="s-search-result"]')]
+          .map((card) => ({
+            cardAsin: (card.getAttribute('data-asin') || '').trim().toUpperCase(),
+            cardTitle: text(card.querySelector('a.a-text-normal.s-line-clamp-2')),
+            cardPriceText: text(card.querySelector('.a-price:not(.a-text-price) .a-offscreen, .a-price .a-offscreen')),
+            cardMrpText: text(card.querySelector('.a-price.a-text-price .a-offscreen')),
+            cardRatingText: text(card.querySelector('[aria-label*="out of 5 stars"], .a-icon-alt')),
+            cardReviewText: text(card.querySelector('a[href*="#customerReviews"], [aria-label*="ratings"]')),
+            cardImageUrl: card.querySelector('img.s-image')?.currentSrc || card.querySelector('img.s-image')?.src || '',
+            cardSponsored: /sponsored/i.test(text(card.querySelector('.puis-sponsored-label-text, [data-component-type="sp-sponsored-result"]'))),
+          }));
+        return {
+          cards,
+          noResults: /no results for|did not match any products/i.test(document.body?.innerText || ''),
+        };
+      })()
+    `);
+    if (!payload || !Array.isArray(payload.cards)) {
+      throw new CommandExecutionError('Amazon.in search returned an unsupported page shape');
+    }
+    const rows = normalizeSearchCards(payload.cards, { ...bounds, limit });
+    if (rows.length === 0) {
+      if (payload.noResults || payload.cards.length > 0) throw new EmptyResultError('amazon-in search');
+      throw new CommandExecutionError(
+        'Amazon.in search exposed no result cards',
+        'The page layout may have changed or a robot challenge may be visible.',
+      );
+    }
+    return rows;
+  },
+});

--- a/clis/amazon-in/shared.js
+++ b/clis/amazon-in/shared.js
@@ -1,0 +1,40 @@
+import {
+  ArgumentError,
+  AuthRequiredError,
+  CommandExecutionError,
+} from '@agentrhq/webcmd/errors';
+import { classifyPageState } from './parsers.js';
+
+export const SITE = 'amazon-in';
+export const DOMAIN = 'amazon.in';
+export const HOME_URL = 'https://www.amazon.in/';
+export const WISHLIST_URL = 'https://www.amazon.in/hz/wishlist/ls';
+
+export function argumentValue(fn) {
+  try {
+    return fn();
+  } catch (error) {
+    if (error instanceof RangeError) throw new ArgumentError(error.message);
+    throw error;
+  }
+}
+
+export async function assertUsablePage(page, context) {
+  const snapshot = await page.evaluate(`
+    (() => ({ url: location.href, text: document.body?.innerText || '' }))()
+  `);
+  const state = classifyPageState(snapshot.url, snapshot.text);
+  if (state === 'login') throw new AuthRequiredError(DOMAIN);
+  if (state === 'robot') {
+    throw new CommandExecutionError(
+      `Amazon robot check blocked ${context}`,
+      'Complete the visible challenge in the Webcmd browser, then retry.',
+    );
+  }
+}
+
+export async function gotoAmazon(page, url, context) {
+  await page.goto(url, { waitUntil: 'load' });
+  await page.wait(2);
+  await assertUsablePage(page, context);
+}

--- a/clis/amazon-in/wishlist.js
+++ b/clis/amazon-in/wishlist.js
@@ -1,0 +1,98 @@
+import {
+  CommandExecutionError,
+  EmptyResultError,
+  TimeoutError,
+} from '@agentrhq/webcmd/errors';
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import { normalizeWishlistRows } from './parsers.js';
+import { gotoAmazon, SITE, WISHLIST_URL } from './shared.js';
+
+cli({
+  site: SITE,
+  name: 'wishlist',
+  access: 'read',
+  description: 'Fetch current prices for products in the default Amazon.in wishlist',
+  domain: 'amazon.in',
+  strategy: Strategy.UI,
+  browser: true,
+  navigateBefore: false,
+  siteSession: 'persistent',
+  args: [
+    {
+      name: 'filter',
+      default: 'unpurchased',
+      choices: ['unpurchased', 'all'],
+      help: 'Wishlist items to include',
+    },
+  ],
+  columns: [
+    'list_name', 'item_id', 'asin', 'title', 'price', 'mrp',
+    'availability', 'size', 'colour', 'image_url', 'product_url',
+  ],
+  func: async (page, args) => {
+    const url = new URL(WISHLIST_URL);
+    url.searchParams.set('type', 'wishlist');
+    url.searchParams.set('filter', args.filter ?? 'unpurchased');
+    url.searchParams.set('sort', 'date-added');
+    url.searchParams.set('viewType', 'list');
+    await gotoAmazon(page, url.href, 'wishlist');
+
+    let reachedEnd = false;
+    for (let step = 0; step < 100; step += 1) {
+      reachedEnd = await page.evaluate(`
+        (() => Boolean(document.querySelector('#endOfListMarker')))()
+      `);
+      if (reachedEnd) break;
+      await page.scroll('down', 700);
+      await page.sleep(0.25);
+    }
+    if (!reachedEnd) {
+      throw new TimeoutError(
+        'Amazon.in wishlist loading',
+        25,
+        'Open the wishlist in the Webcmd browser and check whether Amazon is still loading items.',
+      );
+    }
+
+    const payload = await page.evaluate(`
+      (() => {
+        const text = (node) => (node?.textContent || '').replace(/\\s+/g, ' ').trim();
+        const cards = [...document.querySelectorAll('#g-items li.g-item-sortable')].map((card) => {
+          const productLinks = [...card.querySelectorAll('a[href*="/dp/"]')];
+          const productLink = productLinks.find((link) => link.title) || productLinks[0];
+          const variants = [...card.querySelectorAll('#twisterText')].map((node) => text(node));
+          return {
+            cardItemId: card.getAttribute('data-itemid') || '',
+            cardHref: productLink?.href || '',
+            cardTitle: productLink?.title || text(productLink),
+            cardPriceText: text(card.querySelector('.price-section .a-price .a-offscreen, .a-price .a-offscreen')),
+            cardMrpText: text(card.querySelector('.wl-deal-price.a-text-strike, .a-price.a-text-price .a-offscreen')),
+            cardAvailabilityText: text(card.querySelector('[id^="availability-"], .itemAvailability, .a-color-price')),
+            cardSizeText: variants.find((value) => /^size\\s*:/i.test(value))?.replace(/^size\\s*:\\s*/i, '') || '',
+            cardColourText: variants.find((value) => /^colou?r\\s*:/i.test(value))?.replace(/^colou?r\\s*:\\s*/i, '') || '',
+            cardImageUrl: card.querySelector('img[alt]')?.currentSrc || card.querySelector('img[alt]')?.src || '',
+          };
+        });
+        return {
+          listName: text(document.querySelector('#profile-list-name')),
+          cards,
+          empty: /no items|this list is empty/i.test(document.body?.innerText || ''),
+        };
+      })()
+    `);
+    if (!payload?.listName) {
+      throw new CommandExecutionError('Amazon.in wishlist name could not be read');
+    }
+    if (!payload.cards?.length) {
+      if (payload.empty) throw new EmptyResultError('amazon-in wishlist');
+      throw new CommandExecutionError('Amazon.in wishlist exposed no item cards');
+    }
+    try {
+      return normalizeWishlistRows(payload.listName, payload.cards);
+    } catch (error) {
+      throw new CommandExecutionError(
+        `Amazon.in wishlist details could not be normalized: ${error.message}`,
+      );
+    }
+  },
+});


### PR DESCRIPTION
## Description

Adds a browser-backed `amazon-in` adapter with:

- product search with inclusive INR bounds and image URLs
- current product and default-wishlist prices
- login and identity handoff through the visible browser
- guarded UPI, saved-card, new-card, and COD checkout
- read-only checkout status verification

Checkout defaults to `--place-order false`, verifies exactly one matching line item and consistent totals, never accepts payment secrets as arguments, and hands card, CVV, OTP, UPI PIN, and CAPTCHA steps to the foreground browser.

Related issue: none

## Type of Change

- [x] ✨ New feature
- [x] 🌐 New site adapter
- [ ] 🐛 Bug fix
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Adapter Notes

- [x] Updated generated or lean docs when command discoverability changed
- [x] Used positional args for the command primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Verified live against Amazon.in:

- `search "red shirt" --min-price 300 --max-price 500 --limit 3` returned three in-range products with images
- `product B0D2QL339Z` returned the selected Red/L variant at ₹395
- `wishlist --filter all` returned the signed-in default wishlist price
- UPI checkout returned `review_ready` with a ₹400 total using `--place-order false`
- new-card checkout returned `action_required` before card entry or Continue

Checks:

- `npm run typecheck`
- `npm run build`
- `npm test` — 4,945 passed, 1 skipped
- strict convention audit — 0 violations
- silent-column-drop and typed-error gates — no new findings