### PR TITLE
fix(doctor): honor background window mode

### DIFF
--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -37,7 +37,7 @@ vi.mock('./adapter-shadow.js', async () => {
   };
 });
 
-import { renderBrowserDoctorReport, runBrowserDoctor } from './doctor.js';
+import { checkConnectivity, renderBrowserDoctorReport, runBrowserDoctor } from './doctor.js';
 
 describe('doctor report rendering', () => {
   const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
@@ -399,5 +399,32 @@ describe('doctor report rendering', () => {
     expect(report.issues).toEqual(expect.arrayContaining([
       expect.stringContaining('Multiple Chrome profiles are connected'),
     ]));
+  });
+});
+
+describe('doctor window mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    mockConnect.mockResolvedValue({
+      evaluate: vi.fn().mockResolvedValue(2),
+      closeWindow: vi.fn().mockResolvedValue(undefined),
+    });
+    mockClose.mockResolvedValue(undefined);
+  });
+
+  // Omitting windowMode leaves it undefined, which skips the darwin `open -g`
+  // launcher and trips the explicit bringToFront() in the session manager —
+  // doctor steals focus while every other command stays backgrounded.
+  it('connects in background by default', async () => {
+    await checkConnectivity();
+    expect(mockConnect).toHaveBeenCalledWith(expect.objectContaining({ windowMode: 'background' }));
+  });
+
+  it('honors WEBCMD_WINDOW=foreground', async () => {
+    vi.stubEnv('WEBCMD_WINDOW', 'foreground');
+    await checkConnectivity();
+    expect(mockConnect).toHaveBeenCalledWith(expect.objectContaining({ windowMode: 'foreground' }));
+    vi.unstubAllEnvs();
   });
 });

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -59,6 +59,10 @@ export async function checkConnectivity(opts?: { timeout?: number }): Promise<Co
       timeout: timeoutSeconds,
       session: DOCTOR_SESSION,
       surface: 'browser',
+      // Without this, windowMode is undefined, which skips the darwin `open -g`
+      // launcher AND trips the explicit bringToFront() in the session manager —
+      // so doctor steals focus while every other command stays backgrounded.
+      windowMode: process.env.WEBCMD_WINDOW === 'foreground' ? 'foreground' : 'background',
     });
     try {
       // Try a simple eval to verify end-to-end connectivity.


### PR DESCRIPTION
## Problem

`webcmd doctor` brings the Cloak browser to the foreground on a cold start, while every other command stays backgrounded.

`checkConnectivity` is the only `bridge.connect()` call site that omits `windowMode` — `cli.ts:632` passes `opts.windowMode ?? getBrowserWindowMode()`, and `cli.ts:1117` threads it explicitly. Doctor never routes through `executeCommand`, so it also bypasses `resolveBrowserWindowMode`'s `background` default.

`undefined` then fails **both** guards in the local-cloak session manager, each in the foreground direction:

- `session-manager.ts:390` — `platform === 'darwin' && windowMode === 'background'` is false, so it skips `launchDarwinBackgroundPersistentContext` (the `/usr/bin/open -g` launcher) and uses the normal foregrounding launch.
- `session-manager.ts:279,315` — `windowMode !== 'background'` is true, so it calls `bringToFront()` and `activateBackgroundContext()`.

## Fix

Pass `windowMode` in `checkConnectivity`, resolved from `WEBCMD_WINDOW` with a `background` default.

Env var only, not a `--window` flag, since `doctor` defines none. An invalid value falls back to background here rather than throwing as `getBrowserWindowMode` does — matching the strict behavior would mean exporting a shared resolver and touching three call sites, which felt out of scope for a diagnostic path. Happy to do that instead if preferred.

## Verification

A/B on darwin with a frontmost-app sampler (`lsappinfo`, 150ms), browser killed before each run, no manual input:

| Run | Focus |
|---|---|
| cold doctor, installed v0.4.3 | Chromium takes focus |
| cold doctor, this branch | zero focus transitions |

Two unit tests added to `doctor.test.ts` covering the default and `WEBCMD_WINDOW=foreground`. Mutation-checked: with the fix line removed both fail, restored 22/22 pass. `tsc --noEmit` clean.

## Note

A separate, unexplained focus steal remains: the first adapter command after an idle gap can raise the window even with `windowMode: 'background'` correctly plumbed. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)