### PR TITLE
feat: add PyPI community plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Webcmd Cloud can run supported commands and browser sessions on hosted infrastru
 | Plugin | Description | Author |
 | --- | --- | --- |
 | [`bmwblog`](./plugins/bmwblog/) | BMWBLOG article discovery commands for Webcmd | [WebCMD Agent](https://github.com/agentrhq) |
+| [`pypi`](./plugins/pypi/) | Inspect public Python package metadata and releases from PyPI | [Kemal Kaya](https://github.com/yoldaolmak) |
 | [`skyscanner`](./plugins/skyscanner/) | Skyscanner flight search commands for Webcmd | [Rishabh](https://github.com/rishabhraj36) |
 | [`techcrunch`](./plugins/techcrunch/) | Search and read TechCrunch stories from its public API | [WebCMD Agent](https://github.com/agentrhq) |
 | [`ycombinator`](./plugins/ycombinator/) | Read-only Y Combinator startup directory commands for WebCMD | [WebCMD Agent](https://github.com/agentrhq) |

--- a/plugins/pypi/README.md
+++ b/plugins/pypi/README.md
@@ -1,0 +1,27 @@
+# webcmd-plugin-pypi
+
+Inspect public Python package metadata and releases from PyPI. No login or API
+key is required.
+
+## Install
+
+```bash
+webcmd plugin install github:agentrhq/webcmd/plugins/pypi
+```
+
+## Commands
+
+| Command | Description |
+| --- | --- |
+| `webcmd pypi package <name>` | Show current project metadata for a package |
+| `webcmd pypi releases <name>` | List recent release files for a package |
+
+## Examples
+
+```bash
+webcmd pypi package django
+webcmd pypi releases pictovap --limit 5
+```
+
+Use this plugin when an agent needs deterministic package metadata before
+installing, upgrading, or comparing Python tools.

--- a/plugins/pypi/lib/api.js
+++ b/plugins/pypi/lib/api.js
@@ -1,0 +1,129 @@
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
+
+const PYPI_BASE_URL = 'https://pypi.org/pypi';
+const PACKAGE_URL_BASE = 'https://pypi.org/project';
+const MAX_RELEASE_LIMIT = 50;
+
+export function normalizePackageName(raw) {
+    const name = String(raw ?? '').trim();
+    if (!name) {
+        throw new ArgumentError('package name is required');
+    }
+    if (name.length > 214 || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(name)) {
+        throw new ArgumentError('package name must contain only letters, numbers, dots, underscores, and hyphens');
+    }
+    return name;
+}
+
+export function parseLimit(raw, fallback = 10) {
+    const value = raw === undefined || raw === null || raw === '' ? fallback : Number(raw);
+    if (!Number.isInteger(value) || value < 1 || value > MAX_RELEASE_LIMIT) {
+        throw new ArgumentError(`--limit must be an integer between 1 and ${MAX_RELEASE_LIMIT}`);
+    }
+    return value;
+}
+
+export async function fetchPackageJson(name, request = fetch) {
+    const packageName = normalizePackageName(name);
+    const url = `${PYPI_BASE_URL}/${encodeURIComponent(packageName)}/json`;
+
+    let response;
+    try {
+        response = await request(url, {
+            headers: {
+                Accept: 'application/json',
+                'User-Agent': 'webcmd/0.4 (+https://github.com/agentrhq/webcmd)',
+            },
+        });
+    } catch (error) {
+        throw new CommandExecutionError(`PyPI request failed: ${error.message}`);
+    }
+
+    if (response.status === 404) {
+        throw new EmptyResultError('pypi package', `PyPI has no project named "${packageName}".`);
+    }
+    if (!response.ok) {
+        throw new CommandExecutionError(`PyPI request failed with HTTP ${response.status}`);
+    }
+
+    let payload;
+    try {
+        payload = await response.json();
+    } catch (error) {
+        throw new CommandExecutionError(`PyPI returned malformed JSON: ${error.message}`);
+    }
+    if (!payload || typeof payload !== 'object' || !payload.info) {
+        throw new CommandExecutionError('PyPI returned an unexpected response.');
+    }
+    return payload;
+}
+
+function projectUrl(info, label) {
+    const urls = info?.project_urls;
+    if (!urls || typeof urls !== 'object') return null;
+    const match = Object.entries(urls).find(([name]) => name.toLowerCase() === label);
+    return match ? match[1] : null;
+}
+
+function releaseFiles(payload, version) {
+    const releases = payload?.releases;
+    const files = releases && typeof releases === 'object' ? releases[version] : [];
+    return Array.isArray(files) ? files : [];
+}
+
+function latestUploadTime(files) {
+    return files
+        .map(file => file?.upload_time_iso_8601 || file?.upload_time || null)
+        .filter(Boolean)
+        .sort()
+        .at(-1) || null;
+}
+
+export function summarizePackage(payload) {
+    const info = payload.info || {};
+    const name = String(info.name || '').trim();
+    const version = String(info.version || '').trim();
+    if (!name || !version) {
+        throw new CommandExecutionError('PyPI package metadata is missing a name or version.');
+    }
+
+    const files = releaseFiles(payload, version);
+    return [{
+        name,
+        version,
+        summary: info.summary || null,
+        author: info.author || null,
+        license: info.license || null,
+        requiresPython: info.requires_python || null,
+        uploadedAt: latestUploadTime(files),
+        projectUrl: `${PACKAGE_URL_BASE}/${encodeURIComponent(name)}/`,
+        homepage: projectUrl(info, 'homepage') || info.home_page || null,
+        repository: projectUrl(info, 'repository') || projectUrl(info, 'source') || null,
+    }];
+}
+
+export function summarizeReleases(payload, limit) {
+    const info = payload.info || {};
+    const name = String(info.name || '').trim();
+    const releases = payload.releases && typeof payload.releases === 'object' ? payload.releases : {};
+    const rows = Object.entries(releases)
+        .map(([version, files]) => {
+            const releaseFiles = Array.isArray(files) ? files : [];
+            return {
+                version,
+                uploadedAt: latestUploadTime(releaseFiles),
+                fileCount: releaseFiles.length,
+                pythonVersions: [...new Set(releaseFiles.map(file => file?.python_version).filter(Boolean))].join(', ') || null,
+                yanked: releaseFiles.length > 0 && releaseFiles.every(file => file?.yanked === true),
+                url: `${PACKAGE_URL_BASE}/${encodeURIComponent(name)}/${encodeURIComponent(version)}/`,
+            };
+        })
+        .filter(row => row.uploadedAt)
+        .sort((a, b) => String(b.uploadedAt).localeCompare(String(a.uploadedAt)))
+        .slice(0, limit);
+
+    if (!rows.length) {
+        throw new EmptyResultError('pypi releases', `PyPI returned no release files for "${name}".`);
+    }
+    return rows;
+}

--- a/plugins/pypi/package.js
+++ b/plugins/pypi/package.js
@@ -1,0 +1,23 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+
+import { fetchPackageJson, summarizePackage } from './lib/api.js';
+
+export async function packagePyPI(args, request = fetch) {
+    const payload = await fetchPackageJson(args.name, request);
+    return summarizePackage(payload);
+}
+
+cli({
+    site: 'pypi',
+    name: 'package',
+    access: 'read',
+    description: 'Inspect public PyPI package metadata',
+    domain: 'pypi.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'name', positional: true, required: true, type: 'string', help: 'Python package name, for example django' },
+    ],
+    columns: ['name', 'version', 'summary', 'author', 'license', 'requiresPython', 'uploadedAt', 'projectUrl', 'homepage', 'repository'],
+    func: args => packagePyPI(args),
+});

--- a/plugins/pypi/package.json
+++ b/plugins/pypi/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "webcmd-plugin-pypi",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Inspect public Python package metadata and releases from PyPI",
+  "peerDependencies": {
+    "@agentrhq/webcmd": ">=0.2.0"
+  }
+}

--- a/plugins/pypi/releases.js
+++ b/plugins/pypi/releases.js
@@ -1,0 +1,24 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+
+import { fetchPackageJson, parseLimit, summarizeReleases } from './lib/api.js';
+
+export async function releasesPyPI(args, request = fetch) {
+    const payload = await fetchPackageJson(args.name, request);
+    return summarizeReleases(payload, parseLimit(args.limit));
+}
+
+cli({
+    site: 'pypi',
+    name: 'releases',
+    access: 'read',
+    description: 'List recent public PyPI package releases',
+    domain: 'pypi.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'name', positional: true, required: true, type: 'string', help: 'Python package name, for example django' },
+        { name: 'limit', type: 'int', default: 10, help: 'Maximum releases to return (1-50)' },
+    ],
+    columns: ['version', 'uploadedAt', 'fileCount', 'pythonVersions', 'yanked', 'url'],
+    func: args => releasesPyPI(args),
+});

--- a/plugins/pypi/test/pypi.test.js
+++ b/plugins/pypi/test/pypi.test.js
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test, { after } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const pluginRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = path.resolve(pluginRoot, '..', '..');
+const peerScopeDir = path.join(pluginRoot, 'node_modules', '@agentrhq');
+const peerLink = path.join(peerScopeDir, 'webcmd');
+
+let createdPeerLink = false;
+if (!fs.existsSync(peerLink)) {
+    fs.mkdirSync(peerScopeDir, { recursive: true });
+    fs.symlinkSync(repoRoot, peerLink, 'dir');
+    createdPeerLink = true;
+}
+
+after(() => {
+    if (!createdPeerLink) return;
+    fs.rmSync(peerLink, { force: true, recursive: true });
+    for (const dir of [peerScopeDir, path.dirname(peerScopeDir)]) {
+        try {
+            fs.rmdirSync(dir);
+        } catch {
+            // Directory is not empty; leave unrelated local state alone.
+        }
+    }
+});
+
+const [{ getRegistry }, { packagePyPI }, { releasesPyPI }] = await Promise.all([
+    import('@agentrhq/webcmd/registry'),
+    import('../package.js'),
+    import('../releases.js'),
+]);
+
+const payload = {
+    info: {
+        name: 'pictovap',
+        version: '0.7.14',
+        summary: 'Visual finishing engine for publishers',
+        author: 'Kemal Kaya',
+        license: 'MIT',
+        requires_python: '>=3.10',
+        home_page: 'https://github.com/yoldaolmak/Pictovap',
+        project_urls: {
+            Homepage: 'https://github.com/yoldaolmak/Pictovap',
+            Repository: 'https://github.com/yoldaolmak/Pictovap',
+        },
+    },
+    releases: {
+        '0.7.14': [
+            {
+                upload_time_iso_8601: '2026-07-26T06:12:00.000Z',
+                python_version: 'py3',
+                yanked: false,
+            },
+            {
+                upload_time_iso_8601: '2026-07-26T06:13:00.000Z',
+                python_version: 'source',
+                yanked: false,
+            },
+        ],
+        '0.7.13': [
+            {
+                upload_time_iso_8601: '2026-07-26T05:22:00.000Z',
+                python_version: 'py3',
+                yanked: false,
+            },
+        ],
+    },
+};
+
+function fakeRequest(responsePayload = payload, { ok = true, status = 200 } = {}) {
+    const request = async (url, options) => {
+        request.calls.push({ url: String(url), options });
+        return {
+            ok,
+            status,
+            json: async () => responsePayload,
+        };
+    };
+    request.calls = [];
+    return request;
+}
+
+test('package returns public PyPI project metadata', async () => {
+    const request = fakeRequest();
+
+    const rows = await packagePyPI({ name: 'pictovap' }, request);
+
+    assert.deepEqual(rows, [{
+        name: 'pictovap',
+        version: '0.7.14',
+        summary: 'Visual finishing engine for publishers',
+        author: 'Kemal Kaya',
+        license: 'MIT',
+        requiresPython: '>=3.10',
+        uploadedAt: '2026-07-26T06:13:00.000Z',
+        projectUrl: 'https://pypi.org/project/pictovap/',
+        homepage: 'https://github.com/yoldaolmak/Pictovap',
+        repository: 'https://github.com/yoldaolmak/Pictovap',
+    }]);
+    assert.equal(request.calls[0].url, 'https://pypi.org/pypi/pictovap/json');
+    assert.match(request.calls[0].options.headers['User-Agent'], /^webcmd\//);
+});
+
+test('releases returns recent release rows newest first', async () => {
+    const rows = await releasesPyPI({ name: 'pictovap', limit: 2 }, fakeRequest());
+
+    assert.deepEqual(rows, [
+        {
+            version: '0.7.14',
+            uploadedAt: '2026-07-26T06:13:00.000Z',
+            fileCount: 2,
+            pythonVersions: 'py3, source',
+            yanked: false,
+            url: 'https://pypi.org/project/pictovap/0.7.14/',
+        },
+        {
+            version: '0.7.13',
+            uploadedAt: '2026-07-26T05:22:00.000Z',
+            fileCount: 1,
+            pythonVersions: 'py3',
+            yanked: false,
+            url: 'https://pypi.org/project/pictovap/0.7.13/',
+        },
+    ]);
+});
+
+test('rejects invalid package names and limits', async () => {
+    await assert.rejects(
+        () => packagePyPI({ name: '../secret' }, fakeRequest()),
+        /package name/,
+    );
+    await assert.rejects(
+        () => releasesPyPI({ name: 'pictovap', limit: 51 }, fakeRequest()),
+        /integer between 1 and 50/,
+    );
+});
+
+test('reports missing packages as empty results', async () => {
+    await assert.rejects(
+        () => packagePyPI({ name: 'missing-package' }, fakeRequest({}, { ok: false, status: 404 })),
+        error => error.code === 'EMPTY_RESULT'
+            && /no project named/.test(error.hint),
+    );
+});
+
+test('registered handlers do not require a browser', async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+        globalThis.fetch = fakeRequest();
+        const registry = getRegistry();
+
+        const packageCommand = registry.get('pypi/package');
+        const releasesCommand = registry.get('pypi/releases');
+        assert.ok(packageCommand?.func);
+        assert.ok(releasesCommand?.func);
+        assert.equal(packageCommand.browser, false);
+        assert.equal(releasesCommand.browser, false);
+        await packageCommand.func({ name: 'pictovap' }, false);
+        await releasesCommand.func({ name: 'pictovap', limit: 1 }, false);
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});

--- a/plugins/pypi/webcmd-plugin.json
+++ b/plugins/pypi/webcmd-plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "pypi",
+  "version": "0.1.0",
+  "description": "Inspect public Python package metadata and releases from PyPI",
+  "webcmd": ">=0.2.0",
+  "author": {
+    "name": "Kemal Kaya",
+    "handle": "yoldaolmak"
+  }
+}

--- a/webcmd-plugin.json
+++ b/webcmd-plugin.json
@@ -14,6 +14,16 @@
         "handle": "agentrhq"
       }
     },
+    "pypi": {
+      "path": "plugins/pypi",
+      "version": "0.1.0",
+      "description": "Inspect public Python package metadata and releases from PyPI",
+      "webcmd": ">=0.2.0",
+      "author": {
+        "name": "Kemal Kaya",
+        "handle": "yoldaolmak"
+      }
+    },
     "skyscanner": {
       "path": "plugins/skyscanner",
       "version": "0.1.0",


### PR DESCRIPTION
## Summary

- Adds a read-only `pypi` community plugin for public Python package metadata.
- Provides `webcmd pypi package <name>` for current package metadata.
- Provides `webcmd pypi releases <name>` for recent release rows.
- Includes mocked node tests for package metadata, release ordering, argument validation, missing-package handling, and non-browser command registration.
- Regenerates the community plugin catalog and README table with repository tooling.

## Why

PyPI metadata is a useful deterministic surface for agents before installing, upgrading, comparing, or auditing Python tools. The plugin uses PyPI's public JSON API, requires no credentials, and avoids browser automation.

## Validation

- `npm run check-community-plugins`
- `node --test plugins/pypi/test/pypi.test.js`
- `npm run typecheck`
- `npm test` — 403 files passed, 5090 tests passed, 1 skipped
