### PR TITLE
Fix District login modal handoff

### DIFF
--- a/clis/district/auth.js
+++ b/clis/district/auth.js
@@ -1,13 +1,30 @@
 import { CommandExecutionError } from '@agentrhq/webcmd/errors';
 import { registerSiteAuthCommands } from '../_shared/site-auth.js';
-import { BASE, profileProbe, safeGoto } from './_lib.js';
+import { BASE, profileProbe } from './_lib.js';
+
+async function navigateHome(page) {
+  await page.goto(BASE, { waitUntil: 'none', settleMs: 1000 }).catch((error) => {
+    const message = error?.message || String(error);
+    if (/net::ERR_ABORTED|timed out|Timeout/i.test(message)) return;
+    throw error;
+  });
+}
+
+async function waitFor(page, label, predicate, timeout = 15) {
+  const deadline = Date.now() + timeout * 1000;
+  while (Date.now() < deadline) {
+    const result = await page.evaluate(predicate);
+    if (result) return result;
+    await page.wait(0.25);
+  }
+  throw new CommandExecutionError(`Could not find the District ${label}`);
+}
 
 // District's login is an OTP modal opened from the header avatar, not a page.
 async function openLoginModal(page) {
-  await safeGoto(page, BASE);
-  await page.wait(1);
+  await navigateHome(page);
 
-  const clicked = await page.evaluate(`
+  await waitFor(page, 'user avatar login entry point', `
     (() => {
       const candidates = [
         ...document.querySelectorAll('[role="button"][aria-label="User Avatar"]'),
@@ -20,9 +37,9 @@ async function openLoginModal(page) {
     })()
   `);
 
-  if (!clicked) {
-    throw new CommandExecutionError('Could not find the District user avatar login entry point');
-  }
+  await waitFor(page, 'mobile number login modal', `
+    (() => Boolean(document.querySelector('input[name="mobileNumber"], input[placeholder*="mobile number" i]')))
+  `);
 }
 
 registerSiteAuthCommands({
@@ -33,12 +50,12 @@ registerSiteAuthCommands({
   columns: ['user_id', 'name', 'phone_number', 'email'],
   // Identity check needs a district.in page context for the profile fetch.
   verify: async (page) => {
-    await safeGoto(page, BASE);
-    await page.wait(1);
+    await navigateHome(page);
     return profileProbe(page);
   },
   quickCheck: async (page) => {
     try {
+      await navigateHome(page);
       return { logged_in: true, ...await profileProbe(page) };
     } catch {
       return false;

--- a/clis/district/auth.test.js
+++ b/clis/district/auth.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@agentrhq/webcmd/registry';
+import './auth.js';
+
+describe('district auth', () => {
+  it('opens the avatar login modal without waiting for full page load', async () => {
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn()
+        .mockResolvedValueOnce({ status: 401, text: '', data: null })
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true),
+    };
+
+    await expect(getRegistry().get('district/login').func(page, {}))
+      .resolves.toEqual([expect.objectContaining({ status: 'action_required' })]);
+
+    expect(page.goto).toHaveBeenCalledWith('https://www.district.in', {
+      waitUntil: 'none',
+      settleMs: 1000,
+    });
+    expect(page.evaluate.mock.calls[1][0]).toContain('User Avatar');
+    expect(page.evaluate.mock.calls[2][0]).toContain('mobileNumber');
+  });
+});


### PR DESCRIPTION
## Summary
- avoid waiting for District's full page load before opening login
- click the header user avatar and wait for the mobile number modal before returning the login handoff
- add a District auth adapter test for the handoff flow

## Test plan
- npx vitest run --project adapter clis/district/auth.test.js
- npx vitest run --project adapter clis/district
- npm run typecheck