### PR TITLE
fix: keep background tabs from stealing focus

### DIFF
--- a/src/browser/runtime/local-cloak/session-manager.test.ts
+++ b/src/browser/runtime/local-cloak/session-manager.test.ts
@@ -6,7 +6,7 @@ import { dispatchCloakAction } from './actions.js';
 
 function fakeContext() {
   const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
-  const page = {
+  const fakePage = () => ({
     goto: vi.fn().mockResolvedValue(undefined),
     evaluate: vi.fn().mockResolvedValue('ok'),
     title: vi.fn().mockResolvedValue('Title'),
@@ -14,14 +14,19 @@ function fakeContext() {
     screenshot: vi.fn().mockResolvedValue(Buffer.from('png')),
     isClosed: vi.fn().mockReturnValue(false),
     close: vi.fn().mockResolvedValue(undefined),
-  };
-  const backgroundPage = { ...page };
+  });
+  const page = fakePage();
+  const backgroundPages: ReturnType<typeof fakePage>[] = [];
   const emit = (event: string, ...args: unknown[]) => {
     for (const listener of listeners.get(event) ?? []) listener(...args);
   };
   const cdp = {
     send: vi.fn(async (command: string) => {
-      if (command === 'Target.createTarget') queueMicrotask(() => emit('page', backgroundPage));
+      if (command === 'Target.createTarget') {
+        const backgroundPage = fakePage();
+        backgroundPages.push(backgroundPage);
+        queueMicrotask(() => emit('page', backgroundPage));
+      }
     }),
     detach: vi.fn().mockResolvedValue(undefined),
   };
@@ -43,6 +48,7 @@ function fakeContext() {
       close: vi.fn().mockResolvedValue(undefined),
     },
     page,
+    backgroundPages,
     cdp,
   };
 }
@@ -176,6 +182,32 @@ describe('CloakSessionManager', () => {
 
     expect(launched.context.newPage).toHaveBeenCalledOnce();
     expect(launched.cdp.send).not.toHaveBeenCalled();
+  });
+
+  it('gives concurrent background tabs distinct pages', async () => {
+    const launched = fakeContext();
+    const manager = new CloakSessionManager({
+      baseDir: '/tmp/webcmd-test',
+      launchPersistentContext: vi.fn().mockResolvedValue(launched.context),
+    });
+
+    await manager.getPage({ profileId: 'default', session: 'warm', surface: 'browser' });
+    const firstRequest = manager.newPage({
+      profileId: 'default',
+      session: 'first',
+      surface: 'browser',
+      windowMode: 'background',
+    });
+    const secondRequest = manager.newPage({
+      profileId: 'default',
+      session: 'second',
+      surface: 'browser',
+      windowMode: 'background',
+    });
+    const [first, second] = await Promise.all([firstRequest, secondRequest]);
+
+    expect(first.page).not.toBe(second.page);
+    expect(launched.backgroundPages).toEqual([first.page, second.page]);
   });
 
   it('coalesces concurrent persistent context launches for the same profile', async () => {

--- a/src/browser/runtime/local-cloak/session-manager.test.ts
+++ b/src/browser/runtime/local-cloak/session-manager.test.ts
@@ -5,7 +5,7 @@ import { CloakSessionManager } from './session-manager.js';
 import { dispatchCloakAction } from './actions.js';
 
 function fakeContext() {
-  const listeners = new Map<string, Set<() => void>>();
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
   const page = {
     goto: vi.fn().mockResolvedValue(undefined),
     evaluate: vi.fn().mockResolvedValue('ok'),
@@ -15,22 +15,35 @@ function fakeContext() {
     isClosed: vi.fn().mockReturnValue(false),
     close: vi.fn().mockResolvedValue(undefined),
   };
+  const backgroundPage = { ...page };
+  const emit = (event: string, ...args: unknown[]) => {
+    for (const listener of listeners.get(event) ?? []) listener(...args);
+  };
+  const cdp = {
+    send: vi.fn(async (command: string) => {
+      if (command === 'Target.createTarget') queueMicrotask(() => emit('page', backgroundPage));
+    }),
+    detach: vi.fn().mockResolvedValue(undefined),
+  };
   return {
     context: {
-      on(event: string, listener: () => void) {
+      on(event: string, listener: (...args: unknown[]) => void) {
         const bucket = listeners.get(event) ?? new Set();
         bucket.add(listener);
         listeners.set(event, bucket);
       },
-      emit(event: string) {
-        for (const listener of listeners.get(event) ?? []) listener();
+      emit,
+      waitForEvent(event: string) {
+        return new Promise((resolve) => this.on(event, resolve));
       },
       pages: vi.fn().mockReturnValue([page]),
       newPage: vi.fn().mockResolvedValue(page),
+      browser: vi.fn().mockReturnValue({ newBrowserCDPSession: vi.fn().mockResolvedValue(cdp) }),
       cookies: vi.fn().mockResolvedValue([{ name: 'sid', value: '1', domain: 'example.com', path: '/' }]),
       close: vi.fn().mockResolvedValue(undefined),
     },
     page,
+    cdp,
   };
 }
 
@@ -99,6 +112,70 @@ describe('CloakSessionManager', () => {
     await manager.selectPage({ profileId: 'default', pageId: lease.pageId, windowMode: 'foreground' });
 
     expect(activateBackgroundContext).toHaveBeenCalledWith(launched.context);
+  });
+
+  it('creates a warm background lease tab without focusing Chromium', async () => {
+    const launched = fakeContext();
+    const manager = new CloakSessionManager({
+      baseDir: '/tmp/webcmd-test',
+      launchPersistentContext: vi.fn().mockResolvedValue(launched.context),
+    });
+
+    await manager.getPage({ profileId: 'default', session: 'first', surface: 'adapter' });
+    await manager.getPage({
+      profileId: 'default',
+      session: 'second',
+      surface: 'adapter',
+      windowMode: 'background',
+    });
+
+    expect(launched.cdp.send).toHaveBeenCalledWith('Target.createTarget', {
+      url: 'about:blank',
+      background: true,
+      focus: false,
+    });
+    expect(launched.context.newPage).not.toHaveBeenCalled();
+  });
+
+  it('creates an explicit background tab without focusing Chromium', async () => {
+    const launched = fakeContext();
+    const manager = new CloakSessionManager({
+      baseDir: '/tmp/webcmd-test',
+      launchPersistentContext: vi.fn().mockResolvedValue(launched.context),
+    });
+
+    await manager.getPage({ profileId: 'default', session: 'first', surface: 'browser' });
+    await manager.newPage({
+      profileId: 'default',
+      session: 'background',
+      surface: 'browser',
+      windowMode: 'background',
+    });
+
+    expect(launched.cdp.send).toHaveBeenCalledWith('Target.createTarget', {
+      url: 'about:blank',
+      background: true,
+      focus: false,
+    });
+    expect(launched.context.newPage).not.toHaveBeenCalled();
+  });
+
+  it('creates an explicit foreground tab through Playwright', async () => {
+    const launched = fakeContext();
+    const manager = new CloakSessionManager({
+      baseDir: '/tmp/webcmd-test',
+      launchPersistentContext: vi.fn().mockResolvedValue(launched.context),
+    });
+
+    await manager.newPage({
+      profileId: 'default',
+      session: 'foreground',
+      surface: 'browser',
+      windowMode: 'foreground',
+    });
+
+    expect(launched.context.newPage).toHaveBeenCalledOnce();
+    expect(launched.cdp.send).not.toHaveBeenCalled();
   });
 
   it('coalesces concurrent persistent context launches for the same profile', async () => {

--- a/src/browser/runtime/local-cloak/session-manager.test.ts
+++ b/src/browser/runtime/local-cloak/session-manager.test.ts
@@ -210,8 +210,9 @@ describe('CloakSessionManager', () => {
     expect(launched.backgroundPages).toEqual([first.page, second.page]);
   });
 
-  it('coalesces concurrent persistent context launches for the same profile', async () => {
+  it('coalesces concurrent same-lease page acquisition', async () => {
     const launched = fakeContext();
+    launched.context.newPage.mockResolvedValue(fakeContext().page);
     let resolveLaunch!: (context: BrowserContext) => void;
     const launchPersistentContext = vi.fn(() => new Promise<BrowserContext>((resolve) => {
       resolveLaunch = resolve;
@@ -232,6 +233,9 @@ describe('CloakSessionManager', () => {
     expect(first.context).toBe(launched.context);
     expect(second.context).toBe(launched.context);
     expect(first.page).toBe(second.page);
+    expect(first.pageId).toBe(second.pageId);
+    expect(launched.context.newPage).not.toHaveBeenCalled();
+    expect(launched.cdp.send).not.toHaveBeenCalled();
   });
 
   it('evicts a closed runtime and clears every tracked page resource', async () => {

--- a/src/browser/runtime/local-cloak/session-manager.ts
+++ b/src/browser/runtime/local-cloak/session-manager.ts
@@ -161,7 +161,7 @@ export class CloakSessionManager {
         // freshPage must never adopt a leftover tab — its whole point is a clean DOM.
         return !freshPage && existingPages[0] && candidate.pages.size === 0
           ? existingPages[0]
-          : candidate.context.newPage();
+          : this.createPage(candidate.context, input.windowMode);
       },
       (candidate, page) => {
         const pageId = nextPageId();
@@ -238,7 +238,7 @@ export class CloakSessionManager {
     const acquired = await this.createPageWithRecovery(
       profileId,
       input.windowMode,
-      (candidate) => candidate.context.newPage(),
+      (candidate) => this.createPage(candidate.context, input.windowMode),
       (runtime, page) => ({ runtime, page }),
     );
     if (input.url) {
@@ -439,6 +439,27 @@ export class CloakSessionManager {
       throw new Error('Target page, context or browser has been closed');
     }
     return commitPage(runtime, page);
+  }
+
+  private async createPage(context: BrowserContext, windowMode?: BrowserWindowMode): Promise<PlaywrightPage> {
+    if (windowMode !== 'background') return context.newPage();
+
+    const browser = context.browser();
+    if (!browser) throw new Error('Background page creation requires a Chromium browser connection.');
+    const cdp = await browser.newBrowserCDPSession();
+    try {
+      const [page] = await Promise.all([
+        context.waitForEvent('page'),
+        cdp.send('Target.createTarget', {
+          url: 'about:blank',
+          background: true,
+          focus: false,
+        }),
+      ]);
+      return page;
+    } finally {
+      await cdp.detach().catch(() => {});
+    }
   }
 
   private openEntries(runtime: ProfileRuntime): [string, PageEntry][] {

--- a/src/browser/runtime/local-cloak/session-manager.ts
+++ b/src/browser/runtime/local-cloak/session-manager.ts
@@ -138,42 +138,44 @@ export class CloakSessionManager {
     const session = requireSession(input.session);
     const surface = normalizeSurface(input.surface);
     const leaseKey = resolveLeaseKey(input);
-    const runtime = await this.getProfileRuntime(profileId, input.windowMode);
     const freshPage = input.freshPage === true;
-    const existing = runtime.pages.get(leaseKey);
-    if (existing && !pageIsClosed(existing.page) && !freshPage) {
-      runtime.lastSeenAt = Date.now();
-      existing.idleTimeout = input.idleTimeout;
-      this.refreshIdleTimer(runtime, leaseKey, existing);
-      return { profileId, leaseKey, context: runtime.context, page: existing.page, pageId: existing.pageId };
-    }
-    if (existing && freshPage) {
-      runtime.pages.delete(leaseKey);
-      this.clearIdleTimer(existing);
-      if (runtime.selectedPageId === existing.pageId) runtime.selectedPageId = undefined;
-      if (!pageIsClosed(existing.page)) await existing.page.close().catch(() => {});
-    }
+    return this.withPageCreationLock(profileId, async () => {
+      const runtime = await this.getProfileRuntime(profileId, input.windowMode);
+      const existing = runtime.pages.get(leaseKey);
+      if (existing && !pageIsClosed(existing.page) && !freshPage) {
+        runtime.lastSeenAt = Date.now();
+        existing.idleTimeout = input.idleTimeout;
+        this.refreshIdleTimer(runtime, leaseKey, existing);
+        return { profileId, leaseKey, context: runtime.context, page: existing.page, pageId: existing.pageId };
+      }
+      if (existing && freshPage) {
+        runtime.pages.delete(leaseKey);
+        this.clearIdleTimer(existing);
+        if (runtime.selectedPageId === existing.pageId) runtime.selectedPageId = undefined;
+        if (!pageIsClosed(existing.page)) await existing.page.close().catch(() => {});
+      }
 
-    return this.createPageWithRecovery(
-      profileId,
-      input.windowMode,
-      (candidate) => {
-        const existingPages = candidate.context.pages();
-        // freshPage must never adopt a leftover tab — its whole point is a clean DOM.
-        return !freshPage && existingPages[0] && candidate.pages.size === 0
-          ? existingPages[0]
-          : this.createPage(candidate.context, input.windowMode);
-      },
-      (candidate, page) => {
-        const pageId = nextPageId();
-        const entry: PageEntry = { page, pageId, session, surface, siteSession: input.siteSession, idleTimeout: input.idleTimeout };
-        candidate.pages.set(leaseKey, entry);
-        this.refreshIdleTimer(candidate, leaseKey, entry);
-        candidate.selectedPageId = pageId;
-        candidate.lastSeenAt = Date.now();
-        return { profileId, leaseKey, context: candidate.context, page, pageId };
-      },
-    );
+      return this.createPageWithRecoveryAttempt(
+        profileId,
+        input.windowMode,
+        (candidate) => {
+          const existingPages = candidate.context.pages();
+          // freshPage must never adopt a leftover tab — its whole point is a clean DOM.
+          return !freshPage && existingPages[0] && candidate.pages.size === 0
+            ? existingPages[0]
+            : this.createPage(candidate.context, input.windowMode);
+        },
+        (candidate, page) => {
+          const pageId = nextPageId();
+          const entry: PageEntry = { page, pageId, session, surface, siteSession: input.siteSession, idleTimeout: input.idleTimeout };
+          candidate.pages.set(leaseKey, entry);
+          this.refreshIdleTimer(candidate, leaseKey, entry);
+          candidate.selectedPageId = pageId;
+          candidate.lastSeenAt = Date.now();
+          return { profileId, leaseKey, context: candidate.context, page, pageId };
+        },
+      );
+    });
   }
 
   findPageById(pageId: string, opts: Pick<SessionKeyInput, 'idleTimeout'> = {}): CloakPageLease | null {

--- a/src/browser/runtime/local-cloak/session-manager.ts
+++ b/src/browser/runtime/local-cloak/session-manager.ts
@@ -109,6 +109,7 @@ export class CloakSessionManager {
   private readonly recoverLockedProfile: RecoverLockedProfile;
   private readonly profiles = new Map<string, ProfileRuntime>();
   private readonly profileLaunches = new Map<string, Promise<ProfileRuntime>>();
+  private readonly pageCreationQueues = new Map<string, Promise<void>>();
 
   constructor(private readonly opts: CloakSessionManagerOptions = {}) {
     this.launchPersistentContext = opts.launchPersistentContext ?? cloakLaunchPersistentContext;
@@ -423,6 +424,20 @@ export class CloakSessionManager {
     windowMode: BrowserWindowMode | undefined,
     createPage: (runtime: ProfileRuntime) => PlaywrightPage | Promise<PlaywrightPage>,
     commitPage: (runtime: ProfileRuntime, page: PlaywrightPage) => T,
+  ): Promise<T> {
+    return this.withPageCreationLock(profileId, () => this.createPageWithRecoveryAttempt(
+      profileId,
+      windowMode,
+      createPage,
+      commitPage,
+    ));
+  }
+
+  private async createPageWithRecoveryAttempt<T>(
+    profileId: string,
+    windowMode: BrowserWindowMode | undefined,
+    createPage: (runtime: ProfileRuntime) => PlaywrightPage | Promise<PlaywrightPage>,
+    commitPage: (runtime: ProfileRuntime, page: PlaywrightPage) => T,
     attempt = 0,
   ): Promise<T> {
     const runtime = await this.getProfileRuntime(profileId, windowMode);
@@ -432,13 +447,30 @@ export class CloakSessionManager {
     } catch (error) {
       if (attempt !== 0 || !isClosedContextError(error)) throw error;
       this.invalidateProfileRuntime(profileId, runtime);
-      return this.createPageWithRecovery(profileId, windowMode, createPage, commitPage, 1);
+      return this.createPageWithRecoveryAttempt(profileId, windowMode, createPage, commitPage, 1);
     }
     if (this.profiles.get(profileId) !== runtime) {
       if (!pageIsClosed(page)) await page.close().catch(() => {});
       throw new Error('Target page, context or browser has been closed');
     }
     return commitPage(runtime, page);
+  }
+
+  private async withPageCreationLock<T>(profileId: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.pageCreationQueues.get(profileId) ?? Promise.resolve();
+    let release!: () => void;
+    const released = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const queue = previous.then(() => released);
+    this.pageCreationQueues.set(profileId, queue);
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this.pageCreationQueues.get(profileId) === queue) this.pageCreationQueues.delete(profileId);
+    }
   }
 
   private async createPage(context: BrowserContext, windowMode?: BrowserWindowMode): Promise<PlaywrightPage> {


### PR DESCRIPTION
## Description

Prevent background Webcmd commands from activating the headed Chromium window when they need a new tab.

- Create background tabs through Chromium CDP with `background: true` and `focus: false`.
- Serialize page creation per profile so concurrent requests cannot bind to the same tab.
- Coalesce concurrent requests for the same lease so no page becomes untracked.

Related issue: N/A

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Adapter Notes

Not applicable; this changes the shared local Cloak runtime rather than an adapter.

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```text
npm test
Test Files  410 passed (410)
Tests       5162 passed | 1 skipped (5163)

npm run typecheck
exit 0

npm run build
exit 0
```

Live macOS verification used authenticated Twitter timeline commands against the branch-built daemon:

```text
cold_front=ChatGPT
warm_concurrent_front=ChatGPT
statuses=0,0,0
```

Chromium never became the frontmost application during cold, warm, or concurrent background execution.
