### PR TITLE
Add postgraduate course export plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,18 @@ Webcmd Cloud can run supported commands and browser sessions on hosted infrastru
 | Plugin | Description | Author |
 | --- | --- | --- |
 | [`bmwblog`](./plugins/bmwblog/) | BMWBLOG article discovery commands for Webcmd | [WebCMD Agent](https://github.com/agentrhq) |
+| [`cincinnati`](./plugins/cincinnati/) | University of Cincinnati postgraduate course export adapter | [WebCMD Agent](https://github.com/agentrhq) |
+| [`concordia`](./plugins/concordia/) | Concordia University Montréal postgraduate course export adapter | [WebCMD Agent](https://github.com/agentrhq) |
+| [`goettingen`](./plugins/goettingen/) | University of Göttingen postgraduate course export adapter | [WebCMD Agent](https://github.com/agentrhq) |
+| [`heidelberg`](./plugins/heidelberg/) | Heidelberg University postgraduate course export adapter | [WebCMD Agent](https://github.com/agentrhq) |
+| [`hft`](./plugins/hft/) | HFT Stuttgart postgraduate course export adapter | [WebCMD Agent](https://github.com/agentrhq) |
+| [`iit`](./plugins/iit/) | Illinois Institute of Technology postgraduate course export adapter | [WebCMD Agent](https://github.com/agentrhq) |
+| [`jhu`](./plugins/jhu/) | Johns Hopkins University postgraduate course export adapter | [WebCMD Agent](https://github.com/agentrhq) |
 | [`pypi`](./plugins/pypi/) | Inspect public Python package metadata and releases from PyPI | [Kemal Kaya](https://github.com/yoldaolmak) |
 | [`skyscanner`](./plugins/skyscanner/) | Skyscanner flight search commands for Webcmd | [Rishabh](https://github.com/rishabhraj36) |
 | [`techcrunch`](./plugins/techcrunch/) | Search and read TechCrunch stories from its public API | [WebCMD Agent](https://github.com/agentrhq) |
+| [`ualberta`](./plugins/ualberta/) | University of Alberta postgraduate course export adapter | [WebCMD Agent](https://github.com/agentrhq) |
+| [`yale`](./plugins/yale/) | Yale University postgraduate course export adapter | [WebCMD Agent](https://github.com/agentrhq) |
 | [`ycombinator`](./plugins/ycombinator/) | Read-only Y Combinator startup directory commands for WebCMD | [WebCMD Agent](https://github.com/agentrhq) |
 <!-- webcmd-community-plugins:end -->
 

--- a/plugins/cincinnati/README.md
+++ b/plugins/cincinnati/README.md
@@ -1,0 +1,22 @@
+# webcmd-plugin-cincinnati
+
+University of Cincinnati postgraduate course export adapter.
+
+## Install
+
+```bash
+webcmd plugin install github:agentrhq/webcmd/plugins/cincinnati
+```
+
+## Command
+
+| Command | Description |
+| --- | --- |
+| `webcmd cincinnati export-postgraduate-courses --count 10 -f csv` | Export postgraduate courses in the shared 52-column CSV schema |
+
+## Examples
+
+```bash
+webcmd cincinnati export-postgraduate-courses --count 10 -f json
+webcmd cincinnati export-postgraduate-courses --degree-level masters -f csv
+```

--- a/plugins/cincinnati/export-postgraduate-courses.js
+++ b/plugins/cincinnati/export-postgraduate-courses.js
@@ -1,0 +1,296 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import {
+  ArgumentError,
+  CommandExecutionError,
+} from '@agentrhq/webcmd/errors';
+
+const BASE = 'https://www.grad.uc.edu';
+const UNIVERSITY = 'University of Cincinnati';
+const CHECKED_DATE = '2026-08-03';
+const PROGRAM_FINDER = `${BASE}/`;
+const PROGRAM_JSON = `${BASE}/content/grad/jcr:content/main/responsive_section_2/par/program-finder.ListAllPrograms.json`;
+const REQUIREMENTS = 'https://www.admissions.uc.edu/apply/graduate/requirements.html';
+const GRAD_ADMISSION = 'https://www.admissions.uc.edu/apply/graduate.html';
+const DEGREE_LEVELS = new Set(['all', 'masters', 'certificate', 'diploma', 'professional', 'doctorate']);
+const REQUEST_TIMEOUT_MS = 25000;
+
+const COLUMNS = [
+  'Course Name',
+  'Course URL',
+  'University \nname',
+  'Intake Month',
+  'Substream/\nSpecialisation',
+  'App fees',
+  'Degree Level',
+  'Study Level',
+  'Duration\n(in months)',
+  'Study option',
+  'Program Type',
+  'Partner',
+  'Tution fees \n(per year)',
+  'Total Tution \nFees',
+  'IELTS \n(Overall & Subscores)',
+  'ielts_reading_score',
+  'ielts_writing_score',
+  'ielts_listening_score',
+  'ielts_speaking_score',
+  'TOEFL\n(Overall & Subscores)',
+  'toefl_reading_score',
+  'toefl_writing_score',
+  'toefl_listening_score',
+  'toefl_speaking_score',
+  'PTE\n(Overall & Subscores)',
+  'pte_reading_score',
+  'pte_writing_score',
+  'pte_listening_score',
+  'pte_speaking_score',
+  'Duolingo\n(Overall & Subscores)',
+  'duolingo_comprehension_score',
+  'duolingo_literacy_score',
+  'duolingo_conversation_score',
+  'duolingo_production_score',
+  'Is Waiver \nProvided?',
+  'Waiver Info',
+  'Is MOI \naccepted?',
+  'Share list, if any',
+  'GRE Required',
+  'GMAT Required',
+  'GRE/GMAT Scores',
+  '12th scores',
+  'Min UG score',
+  '15 years of\nEducation Allowed?',
+  'Gap Years',
+  'Backlogs',
+  'Work \nExperience \nRequired?',
+  'Main Entry \nRequirements',
+  'Status',
+  'Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)',
+  'Remarks (if any)',
+  'Reference Links (if any)',
+];
+
+const CSV_OUTPUT = process.argv.some((arg, index, argv) =>
+  /^(?:-f|--format)=csv$/.test(arg) || ((arg === '-f' || arg === '--format') && argv[index + 1] === 'csv')
+);
+const OUTPUT_COLUMNS = CSV_OUTPUT
+  ? COLUMNS.map((column) => /[,"\r\n]/.test(column) ? `"${column.replace(/"/g, '""')}"` : column)
+  : COLUMNS;
+
+function decodeHtml(value = '') {
+  return String(value)
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([\da-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&apos;|&#0*39;|&rsquo;/gi, "'")
+    .replace(/&lsquo;/gi, "'")
+    .replace(/&ndash;|&mdash;/gi, '-')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>');
+}
+
+function text(value = '') {
+  return decodeHtml(String(value)
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' '))
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function parseOptions(args) {
+  const degreeLevel = String(args['degree-level'] ?? 'all').toLowerCase();
+  if (!DEGREE_LEVELS.has(degreeLevel)) {
+    throw new ArgumentError(`--degree-level must be one of: ${[...DEGREE_LEVELS].join(', ')}`);
+  }
+  if (args.count === undefined || args.count === null || args.count === '') return { degreeLevel, count: null };
+  const count = Number(args.count);
+  if (!Number.isInteger(count) || count <= 0) throw new ArgumentError('--count must be a positive integer');
+  return { degreeLevel, count };
+}
+
+function canonicalUrl(value) {
+  const url = new URL(value, BASE);
+  if (!/(^|\.)uc\.edu$/i.test(url.hostname)) return '';
+  url.protocol = 'https:';
+  url.hash = '';
+  return url.href;
+}
+
+function durationMonths(duration, unit) {
+  const n = Number(duration);
+  if (!Number.isFinite(n) || n <= 0) return '';
+  const u = String(unit || '').toLowerCase();
+  if (u.startsWith('year')) return String(Math.round(n * 12));
+  if (u.startsWith('month')) return String(Math.round(n));
+  if (u.startsWith('semester')) return String(Math.round(n * 4));
+  return '';
+}
+
+function degreeTags(program) {
+  const degree = String(program.degree || '').toUpperCase();
+  const bucket = String(program.degreeBucket || '').toLowerCase();
+  const name = String(program.planDescription || '').toLowerCase();
+  const tags = new Set();
+
+  if (bucket.includes('master') || /^M/.test(degree) || ['EDS', 'LLM'].includes(degree)) tags.add('masters');
+  if (bucket.includes('certificate') || ['GC', 'GCM', 'PB', 'MC'].includes(degree)) tags.add('certificate');
+  if (bucket.includes('doctoral') || /doctor/.test(name) || ['PHD', 'EDD', 'DNP', 'DMA', 'DCLS', 'OTD', 'PHARMD', 'DPT', 'SLPD'].includes(degree)) tags.add('doctorate');
+  if (degree === 'AD' || /diploma/.test(name)) tags.add('diploma');
+  if (['AUD', 'DNP', 'DPT', 'JD', 'LLM', 'MBA', 'MHA', 'MPH', 'MSN', 'MSW', 'OTD', 'PHARMD', 'SLPD'].includes(degree)) tags.add('professional');
+
+  return [...tags];
+}
+
+function applicationFee(program) {
+  const org = String(program.organizationDescription || '');
+  if (program.degreeBucket === 'Graduate Certificate') return 'USD 20 domestic / USD 25 international for Graduate Certificates';
+  if (org.includes('Engineering')) return 'USD 75 domestic / USD 80 international for CEAS';
+  if (/Physiology/i.test(program.planDescription || '') && program.degree === 'MS') return 'USD 140 for Physiology (MS)';
+  return 'USD 65 domestic / USD 70 international for most graduate degree programs';
+}
+
+async function fetchPrograms() {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(PROGRAM_JSON, {
+      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; Webcmd Cincinnati public data export)' },
+      redirect: 'follow',
+      signal: controller.signal,
+    });
+    if (!response.ok) throw new CommandExecutionError(`UC program finder request failed: HTTP ${response.status}`);
+    const data = await response.json();
+    const programs = data?.summaryArray;
+    if (!Array.isArray(programs) || programs.length < 300) {
+      throw new CommandExecutionError(`UC program finder JSON shape changed: rows=${programs?.length ?? 'missing'}`);
+    }
+    return programs
+      .map((item) => ({ ...(item.baseInfo || {}), generalInterestAreas: item.generalInterestAreas || [] }))
+      .filter((item) => ['Graduate', 'Law'].includes(item.career));
+  } catch (error) {
+    if (error instanceof CommandExecutionError) throw error;
+    throw new CommandExecutionError(`UC program finder request failed: ${error.message}`);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function normalizeRecord(program) {
+  const row = Object.fromEntries(COLUMNS.map((column) => [column, '']));
+  const url = canonicalUrl(program.learnMorePath);
+  const interestAreas = (program.generalInterestAreas || []).map((area) => area.name).filter(Boolean);
+  const degree = [program.degreeBucket, program.degree ? `(${program.degree})` : ''].filter(Boolean).join(' ');
+  const references = [
+    `Course: ${url}`,
+    `Graduate Program Finder: ${PROGRAM_FINDER}`,
+    `Program JSON: ${PROGRAM_JSON}`,
+    `Graduate Admission: ${GRAD_ADMISSION}`,
+    `Graduate Requirements: ${REQUIREMENTS}`,
+  ];
+
+  row['Course Name'] = text(program.planDescription);
+  row['Course URL'] = url;
+  row['University \nname'] = UNIVERSITY;
+  row['Substream/\nSpecialisation'] = interestAreas.join(' | ');
+  row['App fees'] = applicationFee(program);
+  row['Degree Level'] = degree;
+  row['Study Level'] = 'PG';
+  row['Duration\n(in months)'] = durationMonths(program.duration, program.durationUnit);
+  row['Study option'] = text(program.location);
+  row['Program Type'] = text(program.organizationDescription);
+  row['Tution fees \n(per year)'] = 'Not available as a single value in official UC program data';
+  row['Total Tution \nFees'] = 'Not available as an official total in UC program data';
+  row['IELTS \n(Overall & Subscores)'] = '6.5 overall band';
+  row['TOEFL\n(Overall & Subscores)'] = '80 iBT or 4.5 on TOEFL 1-6 scale';
+  row['PTE\n(Overall & Subscores)'] = '54';
+  row['Duolingo\n(Overall & Subscores)'] = '110';
+  row['Is Waiver \nProvided?'] = 'Yes';
+  row['Waiver Info'] = 'Automatic English-proficiency waiver for listed English-speaking countries; additional waiver options include qualifying English-instructing institution documentation.';
+  row['Is MOI \naccepted?'] = 'Yes, with documentation that the institution is entirely English-instructing';
+  row['Share list, if any'] = 'Bermuda | Botswana | Cameroon | Canada (except Quebec) | Cayman Islands | Denmark | Dominica | Fiji | Finland | Gambia | Ghana | Gibraltar | Grenada | Guyana | Ireland | Jamaica | Kenya | Lesotho | Liberia | Malawi | Malta | Mauritius | Montserrat | Namibia | Netherlands | New Zealand | Nigeria | Norway | Papua New Guinea | Rwanda | Scotland | Seychelles | Sierra Leone | Singapore | Solomon Islands | South Africa | St. Kitts and Nevis | St. Lucia | St. Vincent and the Grenadines | Swaziland | Sweden | Tanzania | Tonga | Trinidad and Tobago | Turks and Caicos Islands | Uganda | United States | United Kingdom | Vanuatu | Virgin Islands | Wales | Zambia | Zimbabwe';
+  row['GRE Required'] = 'Not available as a single value on official program page';
+  row['GMAT Required'] = 'Not available as a single value on official program page';
+  row['GRE/GMAT Scores'] = 'Not available as a single value on official program page';
+  row['12th scores'] = 'Not applicable (graduate admission)';
+  row['Min UG score'] = "Bachelor's degree or higher; at least a B average is recommended";
+  row['15 years of\nEducation Allowed?'] = 'Reduced-credit bachelor’s degrees may be accepted; determination is at the program level';
+  row['Work \nExperience \nRequired?'] = 'Not available as a single value on official program page';
+  row['Main Entry \nRequirements'] = "Bachelor's degree or higher from an accredited institution or international equivalent | Application and fee | Transcripts | Program-specific requirements and deadlines";
+  row['Status'] = 'Active';
+  row['Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)'] = 'Not available as a single value on official program page';
+  const notPublished = 'Not available on official UC program page';
+  for (const column of [
+    'Substream/\nSpecialisation',
+    'Intake Month',
+    'Partner',
+    'ielts_reading_score',
+    'ielts_writing_score',
+    'ielts_listening_score',
+    'ielts_speaking_score',
+    'toefl_reading_score',
+    'toefl_writing_score',
+    'toefl_listening_score',
+    'toefl_speaking_score',
+    'pte_reading_score',
+    'pte_writing_score',
+    'pte_listening_score',
+    'pte_speaking_score',
+    'duolingo_comprehension_score',
+    'duolingo_literacy_score',
+    'duolingo_conversation_score',
+    'duolingo_production_score',
+    'Gap Years',
+    'Backlogs',
+  ]) {
+    if (!row[column]) row[column] = column === 'Partner' ? 'Not applicable unless listed by official program source' : notPublished;
+  }
+  row['Remarks (if any)'] = `Checked ${CHECKED_DATE}; official UC program-finder JSON plus UC graduate admissions requirements. Exact test subscores, intake months, gap years, and backlogs are not available university-wide.`;
+  row['Reference Links (if any)'] = references.join(' | ');
+  return row;
+}
+
+function validateRecord(row) {
+  for (const column of ['Course Name', 'Course URL', 'University \nname', 'Degree Level', 'Study Level', 'Reference Links (if any)']) {
+    if (!row[column]?.trim()) throw new CommandExecutionError(`UC row is missing required field: ${column}`);
+  }
+  if (row['Study Level'] !== 'PG') throw new CommandExecutionError('UC row Study Level must be PG');
+  if (!/^https:\/\/(?:www\.)?.*uc\.edu\//i.test(row['Course URL'])) {
+    throw new CommandExecutionError(`UC row has invalid Course URL: ${row['Course URL']}`);
+  }
+  return row;
+}
+
+cli({
+  site: 'cincinnati',
+  name: 'export-postgraduate-courses',
+  description: 'Export University of Cincinnati graduate and professional programs from official public sources.',
+  access: 'read',
+  example: 'webcmd cincinnati export-postgraduate-courses --degree-level masters --count 10 -f csv',
+  domain: 'www.grad.uc.edu',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'degree-level', type: 'string', default: 'all', help: 'all, masters, certificate, diploma, professional, or doctorate' },
+    { name: 'count', type: 'int', required: false, help: 'Positive maximum number of programs after filtering and deduplication' },
+  ],
+  columns: OUTPUT_COLUMNS,
+  func: async (args) => {
+    const { degreeLevel, count } = parseOptions(args);
+    const selected = [];
+    const seen = new Set();
+    for (const program of await fetchPrograms()) {
+      const tags = degreeTags(program);
+      if (!tags.length || (degreeLevel !== 'all' && !tags.includes(degreeLevel))) continue;
+      const row = validateRecord(normalizeRecord(program));
+      if (seen.has(row['Course URL'])) continue;
+      seen.add(row['Course URL']);
+      selected.push(CSV_OUTPUT
+        ? Object.fromEntries(COLUMNS.map((column, index) => [OUTPUT_COLUMNS[index], row[column]]))
+        : row);
+      if (count !== null && selected.length >= count) break;
+    }
+    return selected;
+  },
+});

--- a/plugins/cincinnati/export-postgraduate-courses.js
+++ b/plugins/cincinnati/export-postgraduate-courses.js
@@ -13,6 +13,8 @@ const REQUIREMENTS = 'https://www.admissions.uc.edu/apply/graduate/requirements.
 const GRAD_ADMISSION = 'https://www.admissions.uc.edu/apply/graduate.html';
 const DEGREE_LEVELS = new Set(['all', 'masters', 'certificate', 'diploma', 'professional', 'doctorate']);
 const REQUEST_TIMEOUT_MS = 25000;
+const DETAIL_CONCURRENCY = 10;
+const UC_ENGLISH_WAIVER_COUNTRIES = 'Anguilla | Antigua and Barbuda | Australia | Bahamas | Barbados | Belize | Bermuda | Botswana | Cameroon | Canada (except Quebec) | Cayman Islands | Denmark | Dominica | Fiji | Finland | Gambia | Ghana | Gibraltar | Grenada | Guyana | Ireland | Jamaica | Kenya | Lesotho | Liberia | Malawi | Malta | Mauritius | Montserrat | Namibia | Netherlands | New Zealand | Nigeria | Norway | Papua New Guinea | Rwanda | Scotland | Seychelles | Sierra Leone | Singapore | Solomon Islands | South Africa | St. Kitts and Nevis | St. Lucia | St. Vincent and the Grenadines | Swaziland | Sweden | Tanzania | Tonga | Trinidad and Tobago | Turks and Caicos Islands | Uganda | United States | United Kingdom | Vanuatu | Virgin Islands | Wales | Zambia | Zimbabwe';
 
 const COLUMNS = [
   'Course Name',
@@ -151,6 +153,30 @@ function applicationFee(program) {
   return 'USD 65 domestic / USD 70 international for most graduate degree programs';
 }
 
+async function fetchText(url, marker = '') {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; Webcmd Cincinnati public data export)' },
+      redirect: 'follow',
+      signal: controller.signal,
+    });
+    const contentType = response.headers.get('content-type') || '';
+    if (!response.ok || !contentType.includes('text/html')) {
+      throw new CommandExecutionError(`UC page request failed for ${url}: HTTP ${response.status}, ${contentType || 'unknown content type'}`);
+    }
+    const html = await response.text();
+    if (marker && !html.includes(marker)) throw new CommandExecutionError(`UC page structure changed for ${url}: missing ${marker}`);
+    return { html, finalUrl: response.url };
+  } catch (error) {
+    if (error instanceof CommandExecutionError) throw error;
+    throw new CommandExecutionError(`UC page request failed for ${url}: ${error.message}`);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 async function fetchPrograms() {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
@@ -177,24 +203,144 @@ async function fetchPrograms() {
   }
 }
 
+function absoluteUcUrl(value, baseUrl) {
+  try {
+    return canonicalUrl(new URL(decodeHtml(value), baseUrl).href);
+  } catch {
+    return '';
+  }
+}
+
+function linksFrom(html, baseUrl) {
+  return [...String(html).matchAll(/<a\b[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi)]
+    .map((match) => ({ url: absoluteUcUrl(match[1], baseUrl), label: text(match[2]) }))
+    .filter((link) => link.url && link.label);
+}
+
+function blocks(html) {
+  return decodeHtml(String(html)
+    .replace(/<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi, (_, level, content) => `\n\n@@H${level} ${text(content)}\n`)
+    .replace(/<li\b[^>]*>/gi, '\n- ')
+    .replace(/<\/(?:p|div|section|tr|table)>/gi, '\n')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' '))
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n[ \t]+/g, '\n')
+    .trim();
+}
+
+function sectionFrom(blockText, headingPattern) {
+  const lines = blockText.split(/\n+/).map((line) => line.trim()).filter(Boolean);
+  const start = lines.findIndex((line) => /^@@H[1-6]\s+/.test(line) && headingPattern.test(line.replace(/^@@H[1-6]\s+/, '')));
+  if (start < 0) return '';
+  const section = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^@@H[1-6]\s+/.test(line)) break;
+    section.push(line);
+  }
+  return section.join(' | ').replace(/\s+/g, ' ').trim();
+}
+
+function firstMatch(value, pattern) {
+  return String(value || '').match(pattern)?.[0]?.trim() || '';
+}
+
+function programSpecificEnglish(sourceText) {
+  const t = String(sourceText || '');
+  return {
+    ielts: firstMatch(t, /IELTS:?\s*(?:minimum score of\s*)?6\.5 overall band/i),
+    toefl: firstMatch(t, /TOEFL:?\s*(?:minimum score of\s*)?4\.5 \(on the 1-6 scale\) or 80 iBT \(on the 0-120 scale\)/i),
+    pte: firstMatch(t, /PTE:?\s*(?:minimum score of\s*)?54/i),
+    duolingo: firstMatch(t, /Duolingo \(DET\):?\s*(?:minimum score of\s*)?110/i),
+  };
+}
+
+function programSpecificFees(sourceText) {
+  const fees = String(sourceText || '').split('|')
+    .map((line) => line.replace(/^-\s*/, '').replace(/\s+/g, ' ').trim())
+    .filter((line) => /(?:application fee|matriculation fee)/i.test(line) && /\$[0-9]/.test(line));
+  return [...new Set(fees)].join(' | ');
+}
+
+function deadlineSummary(sourceText) {
+  const textValue = String(sourceText || '');
+  const rows = [...textValue.matchAll(/(Spring|Summer|Fall)\s+20\d{2}\s+\|\s+[^|]+\|\s+[^|]+\|\s+[^|]+/gi)]
+    .map((match) => match[0].replace(/\s+/g, ' ').trim());
+  return rows.slice(0, 4).join(' | ');
+}
+
+function admissionLinkFor(html, detailUrl) {
+  const detail = new URL(detailUrl);
+  const detailDir = detail.pathname.replace(/\/[^/]*$/, '/');
+  const candidates = linksFrom(html, detailUrl)
+    .filter((link) => /admission|deadline|requirement/i.test(link.label) && !/apply$/i.test(link.label))
+    .map((link) => ({
+      ...link,
+      score:
+        (new URL(link.url).pathname.startsWith(detailDir) ? 10 : 0)
+        + (/learn about admissions|view application deadlines/i.test(link.label) ? 5 : 0)
+        + (/admissions?\.html$/i.test(link.url) ? 2 : 0),
+    }))
+    .sort((a, b) => b.score - a.score);
+  return candidates[0];
+}
+
+async function enrichProgram(program) {
+  const detailUrl = canonicalUrl(program.learnMorePath);
+  if (!detailUrl) return { ...program, detailUrl: '', admissionUrl: '', detailText: '', admissionText: '', detailError: 'Missing official program detail URL' };
+  try {
+    const detail = await fetchText(detailUrl, '<h1');
+    const finalDetailUrl = canonicalUrl(detail.finalUrl) || detailUrl;
+    const detailBlock = blocks(detail.html);
+    const admissionLink = admissionLinkFor(detail.html, finalDetailUrl);
+    let admissionUrl = admissionLink?.url || '';
+    let admissionBlock = '';
+    if (admissionUrl) {
+      const admission = await fetchText(admissionUrl, '<h1');
+      admissionUrl = canonicalUrl(admission.finalUrl) || admissionUrl;
+      admissionBlock = blocks(admission.html);
+    }
+    return { ...program, detailUrl: finalDetailUrl, admissionUrl, detailText: detailBlock, admissionText: admissionBlock, detailError: '' };
+  } catch (error) {
+    return { ...program, detailUrl, admissionUrl: '', detailText: '', admissionText: '', detailError: error.message };
+  }
+}
+
+async function enrichPrograms(programs) {
+  const rows = [];
+  for (let index = 0; index < programs.length; index += DETAIL_CONCURRENCY) {
+    rows.push(...await Promise.all(programs.slice(index, index + DETAIL_CONCURRENCY).map(enrichProgram)));
+  }
+  return rows;
+}
+
 function normalizeRecord(program) {
   const row = Object.fromEntries(COLUMNS.map((column) => [column, '']));
-  const url = canonicalUrl(program.learnMorePath);
+  const url = program.detailUrl || canonicalUrl(program.learnMorePath);
   const interestAreas = (program.generalInterestAreas || []).map((area) => area.name).filter(Boolean);
   const degree = [program.degreeBucket, program.degree ? `(${program.degree})` : ''].filter(Boolean).join(' ');
+  const admissionRequirements = sectionFrom(program.admissionText, /^Admission Requirements$/i);
+  const applicationProcess = sectionFrom(program.admissionText, /^Application Process$/i);
+  const deadlines = sectionFrom(program.admissionText, /^Application Deadlines$/i);
+  const combinedAdmissionText = [program.admissionText, program.detailText].filter(Boolean).join(' | ');
+  const english = programSpecificEnglish(combinedAdmissionText);
+  const feeDetails = programSpecificFees(combinedAdmissionText);
   const references = [
     `Course: ${url}`,
+    program.admissionUrl ? `Program admissions/deadlines: ${program.admissionUrl}` : '',
     `Graduate Program Finder: ${PROGRAM_FINDER}`,
     `Program JSON: ${PROGRAM_JSON}`,
     `Graduate Admission: ${GRAD_ADMISSION}`,
     `Graduate Requirements: ${REQUIREMENTS}`,
-  ];
+  ].filter(Boolean);
 
   row['Course Name'] = text(program.planDescription);
   row['Course URL'] = url;
   row['University \nname'] = UNIVERSITY;
   row['Substream/\nSpecialisation'] = interestAreas.join(' | ');
-  row['App fees'] = applicationFee(program);
+  row['App fees'] = feeDetails || applicationFee(program);
   row['Degree Level'] = degree;
   row['Study Level'] = 'PG';
   row['Duration\n(in months)'] = durationMonths(program.duration, program.durationUnit);
@@ -202,24 +348,25 @@ function normalizeRecord(program) {
   row['Program Type'] = text(program.organizationDescription);
   row['Tution fees \n(per year)'] = 'Not available as a single value in official UC program data';
   row['Total Tution \nFees'] = 'Not available as an official total in UC program data';
-  row['IELTS \n(Overall & Subscores)'] = '6.5 overall band';
-  row['TOEFL\n(Overall & Subscores)'] = '80 iBT or 4.5 on TOEFL 1-6 scale';
-  row['PTE\n(Overall & Subscores)'] = '54';
-  row['Duolingo\n(Overall & Subscores)'] = '110';
+  row['IELTS \n(Overall & Subscores)'] = english.ielts || 'UC minimum: IELTS 6.5 overall band; program page did not publish a higher value';
+  row['TOEFL\n(Overall & Subscores)'] = english.toefl || 'UC minimum: TOEFL 80 iBT or 4.5 on TOEFL 1-6 scale; program page did not publish a higher value';
+  row['PTE\n(Overall & Subscores)'] = english.pte || 'UC minimum: PTE 54; program page did not publish a higher value';
+  row['Duolingo\n(Overall & Subscores)'] = english.duolingo || 'UC minimum: Duolingo English Test 110; program page did not publish a higher value';
   row['Is Waiver \nProvided?'] = 'Yes';
   row['Waiver Info'] = 'Automatic English-proficiency waiver for listed English-speaking countries; additional waiver options include qualifying English-instructing institution documentation.';
-  row['Is MOI \naccepted?'] = 'Yes, with documentation that the institution is entirely English-instructing';
-  row['Share list, if any'] = 'Bermuda | Botswana | Cameroon | Canada (except Quebec) | Cayman Islands | Denmark | Dominica | Fiji | Finland | Gambia | Ghana | Gibraltar | Grenada | Guyana | Ireland | Jamaica | Kenya | Lesotho | Liberia | Malawi | Malta | Mauritius | Montserrat | Namibia | Netherlands | New Zealand | Nigeria | Norway | Papua New Guinea | Rwanda | Scotland | Seychelles | Sierra Leone | Singapore | Solomon Islands | South Africa | St. Kitts and Nevis | St. Lucia | St. Vincent and the Grenadines | Swaziland | Sweden | Tanzania | Tonga | Trinidad and Tobago | Turks and Caicos Islands | Uganda | United States | United Kingdom | Vanuatu | Virgin Islands | Wales | Zambia | Zimbabwe';
+  row['Is MOI \naccepted?'] = 'Waiver may be requested with documentation that the entire institution is English-instructing';
+  row['Share list, if any'] = UC_ENGLISH_WAIVER_COUNTRIES;
   row['GRE Required'] = 'Not available as a single value on official program page';
   row['GMAT Required'] = 'Not available as a single value on official program page';
   row['GRE/GMAT Scores'] = 'Not available as a single value on official program page';
   row['12th scores'] = 'Not applicable (graduate admission)';
   row['Min UG score'] = "Bachelor's degree or higher; at least a B average is recommended";
   row['15 years of\nEducation Allowed?'] = 'Reduced-credit bachelor’s degrees may be accepted; determination is at the program level';
-  row['Work \nExperience \nRequired?'] = 'Not available as a single value on official program page';
-  row['Main Entry \nRequirements'] = "Bachelor's degree or higher from an accredited institution or international equivalent | Application and fee | Transcripts | Program-specific requirements and deadlines";
+  row['Work \nExperience \nRequired?'] = /resume|cv/i.test(applicationProcess) ? 'Resume/CV required by official program admissions page' : 'Not available as a single value on official program page';
+  row['Main Entry \nRequirements'] = [admissionRequirements, applicationProcess].filter(Boolean).join(' | ')
+    || "Bachelor's degree or higher from an accredited institution or international equivalent | Application and fee | Transcripts | Program-specific requirements and deadlines";
   row['Status'] = 'Active';
-  row['Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)'] = 'Not available as a single value on official program page';
+  row['Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)'] = deadlineSummary(deadlines) || 'Not available as a single value on official program page';
   const notPublished = 'Not available on official UC program page';
   for (const column of [
     'Substream/\nSpecialisation',
@@ -246,7 +393,11 @@ function normalizeRecord(program) {
   ]) {
     if (!row[column]) row[column] = column === 'Partner' ? 'Not applicable unless listed by official program source' : notPublished;
   }
-  row['Remarks (if any)'] = `Checked ${CHECKED_DATE}; official UC program-finder JSON plus UC graduate admissions requirements. Exact test subscores, intake months, gap years, and backlogs are not available university-wide.`;
+  row['Remarks (if any)'] = [
+    `Checked ${CHECKED_DATE}; official UC program-finder JSON, program detail page, linked program admissions/deadline pages, and UC graduate admissions requirements.`,
+    program.detailError ? `Program detail enrichment unavailable: ${program.detailError}` : '',
+    'University-wide English scores are used only when the official program page does not publish a higher/specific value. Exact test subscores, gap years, and backlogs are not available university-wide.',
+  ].filter(Boolean).join(' | ');
   row['Reference Links (if any)'] = references.join(' | ');
   return row;
 }
@@ -280,16 +431,20 @@ cli({
     const { degreeLevel, count } = parseOptions(args);
     const selected = [];
     const seen = new Set();
+    const candidates = [];
     for (const program of await fetchPrograms()) {
       const tags = degreeTags(program);
       if (!tags.length || (degreeLevel !== 'all' && !tags.includes(degreeLevel))) continue;
+      candidates.push(program);
+      if (count !== null && candidates.length >= count) break;
+    }
+    for (const program of await enrichPrograms(candidates)) {
       const row = validateRecord(normalizeRecord(program));
       if (seen.has(row['Course URL'])) continue;
       seen.add(row['Course URL']);
       selected.push(CSV_OUTPUT
         ? Object.fromEntries(COLUMNS.map((column, index) => [OUTPUT_COLUMNS[index], row[column]]))
         : row);
-      if (count !== null && selected.length >= count) break;
     }
     return selected;
   },

--- a/plugins/cincinnati/package.json
+++ b/plugins/cincinnati/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "webcmd-plugin-cincinnati",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "University of Cincinnati postgraduate course export adapter",
+  "peerDependencies": {
+    "@agentrhq/webcmd": ">=0.5.2"
+  }
+}

--- a/plugins/cincinnati/webcmd-plugin.json
+++ b/plugins/cincinnati/webcmd-plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "cincinnati",
+  "version": "0.1.0",
+  "description": "University of Cincinnati postgraduate course export adapter",
+  "webcmd": ">=0.5.2",
+  "author": {
+    "name": "WebCMD Agent",
+    "handle": "agentrhq"
+  }
+}

--- a/plugins/concordia/README.md
+++ b/plugins/concordia/README.md
@@ -1,0 +1,22 @@
+# webcmd-plugin-concordia
+
+Concordia University Montréal postgraduate course export adapter.
+
+## Install
+
+```bash
+webcmd plugin install github:agentrhq/webcmd/plugins/concordia
+```
+
+## Command
+
+| Command | Description |
+| --- | --- |
+| `webcmd concordia export-postgraduate-courses --count 10 -f csv` | Export postgraduate courses in the shared 52-column CSV schema |
+
+## Examples
+
+```bash
+webcmd concordia export-postgraduate-courses --count 10 -f json
+webcmd concordia export-postgraduate-courses --degree-level masters -f csv
+```

--- a/plugins/concordia/export-postgraduate-courses.js
+++ b/plugins/concordia/export-postgraduate-courses.js
@@ -1,0 +1,495 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import {
+  ArgumentError,
+  CommandExecutionError,
+} from '@agentrhq/webcmd/errors';
+
+const BASE = 'https://www.concordia.ca';
+const CATALOGUE_URL = `${BASE}/academics/graduate.html`;
+const UNIVERSITY = 'Concordia University Montreal';
+const CHECKED_DATE = '2026-08-03';
+const REQUEST_TIMEOUT_MS = 15000;
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 800;
+const DETAIL_CONCURRENCY = 8;
+const SOURCES = {
+  catalogue: CATALOGUE_URL,
+  application: `${BASE}/gradstudies/future-students/how-to-apply/start-your-application.html`,
+  requirements: `${BASE}/gradstudies/future-students/how-to-apply/requirements.html`,
+  english: `${BASE}/gradstudies/future-students/how-to-apply/english-language-proficiency.html`,
+  tuition: `${BASE}/students/financial/tuition-fees/rates.html`,
+};
+const DEGREE_LEVELS = new Set([
+  'all',
+  'masters',
+  'certificate',
+  'diploma',
+  'professional',
+  'doctorate',
+]);
+
+const COLUMNS = [
+  'Course Name',
+  'Course URL',
+  'University \nname',
+  'Intake Month',
+  'Substream/\nSpecialisation',
+  'App fees',
+  'Degree Level',
+  'Study Level',
+  'Duration\n(in months)',
+  'Study option',
+  'Program Type',
+  'Partner',
+  'Tution fees \n(per year)',
+  'Total Tution \nFees',
+  'IELTS \n(Overall & Subscores)',
+  'ielts_reading_score',
+  'ielts_writing_score',
+  'ielts_listening_score',
+  'ielts_speaking_score',
+  'TOEFL\n(Overall & Subscores)',
+  'toefl_reading_score',
+  'toefl_writing_score',
+  'toefl_listening_score',
+  'toefl_speaking_score',
+  'PTE\n(Overall & Subscores)',
+  'pte_reading_score',
+  'pte_writing_score',
+  'pte_listening_score',
+  'pte_speaking_score',
+  'Duolingo\n(Overall & Subscores)',
+  'duolingo_comprehension_score',
+  'duolingo_literacy_score',
+  'duolingo_conversation_score',
+  'duolingo_production_score',
+  'Is Waiver \nProvided?',
+  'Waiver Info',
+  'Is MOI \naccepted?',
+  'Share list, if any',
+  'GRE Required',
+  'GMAT Required',
+  'GRE/GMAT Scores',
+  '12th scores',
+  'Min UG score',
+  '15 years of\nEducation Allowed?',
+  'Gap Years',
+  'Backlogs',
+  'Work \nExperience \nRequired?',
+  'Main Entry \nRequirements',
+  'Status',
+  'Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)',
+  'Remarks (if any)',
+  'Reference Links (if any)',
+];
+
+const CSV_OUTPUT = process.argv.some((arg, index, argv) =>
+  /^(?:-f|--format)=csv$/.test(arg) || ((arg === '-f' || arg === '--format') && argv[index + 1] === 'csv')
+);
+const OUTPUT_COLUMNS = CSV_OUTPUT
+  ? COLUMNS.map((column) => /[,"\r\n]/.test(column) ? `"${column.replace(/"/g, '""')}"` : column)
+  : COLUMNS;
+
+function pause(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function decodeHtml(value = '') {
+  return value
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([\da-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&apos;|&#0*39;/gi, "'")
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>');
+}
+
+function text(value = '') {
+  return decodeHtml(
+    value
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<[^>]+>/g, ' '),
+  ).replace(/\s+/g, ' ').trim();
+}
+
+async function fetchHtml(url, marker = '<html') {
+  let lastError;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    try {
+      const response = await fetch(url, {
+        headers: { 'User-Agent': 'Mozilla/5.0 (compatible; Webcmd Concordia public data export)' },
+        redirect: 'follow',
+        signal: controller.signal,
+      });
+      const contentType = response.headers.get('content-type') || '';
+      if (!response.ok || !contentType.includes('text/html')) {
+        lastError = new Error(`HTTP ${response.status}, ${contentType || 'unknown content type'}`);
+        if (!([429].includes(response.status) || response.status >= 500)) break;
+      } else {
+        const html = await response.text();
+        if (marker && !html.includes(marker)) {
+          throw new CommandExecutionError(`Concordia page structure changed for ${url}: missing ${marker}`);
+        }
+        return { html, finalUrl: response.url };
+      }
+    } catch (error) {
+      lastError = error;
+      if (error instanceof CommandExecutionError) throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+    if (attempt < MAX_ATTEMPTS) await pause(attempt * RETRY_DELAY_MS);
+  }
+  throw new CommandExecutionError(`Concordia request failed for ${url}: ${lastError?.message || 'unknown network error'}`);
+}
+
+function parseOptions(args) {
+  const degreeLevel = String(args['degree-level'] ?? 'all').toLowerCase();
+  if (!DEGREE_LEVELS.has(degreeLevel)) {
+    throw new ArgumentError(`--degree-level must be one of: ${[...DEGREE_LEVELS].join(', ')}`);
+  }
+  if (args.count === undefined || args.count === null || args.count === '') {
+    return { degreeLevel, count: null };
+  }
+  const count = Number(args.count);
+  if (!Number.isInteger(count) || count <= 0) {
+    throw new ArgumentError('--count must be a positive integer');
+  }
+  return { degreeLevel, count };
+}
+
+function canonicalizeProgramUrl(value) {
+  const url = new URL(value, BASE);
+  if (url.hostname !== 'www.concordia.ca' || !url.pathname.startsWith('/academics/graduate/') || !url.pathname.endsWith('.html')) {
+    return '';
+  }
+  url.protocol = 'https:';
+  url.search = '';
+  url.hash = '';
+  return url.href;
+}
+
+function hiddenValue(block, className) {
+  return text(block.match(new RegExp(`<span class=["']d-none ${className}["']>([\\s\\S]*?)<\\/span>`, 'i'))?.[1]);
+}
+
+function classifyDegree(program) {
+  const haystack = `${program.name} ${program.degree} ${program.credential}`.toLowerCase();
+  const tags = new Set();
+  if (haystack.includes("master")) tags.add('masters');
+  if (haystack.includes('certificate')) tags.add('certificate');
+  if (haystack.includes('diploma')) tags.add('diploma');
+  if (haystack.includes('doctorate') || haystack.includes('phd')) tags.add('doctorate');
+  if (
+    haystack.includes('mba') ||
+    haystack.includes('master of business administration') ||
+    haystack.includes('master of supply chain management') ||
+    haystack.includes('cpa') ||
+    haystack.includes('chartered professional accountancy')
+  ) {
+    tags.add('professional');
+  }
+  return [...tags];
+}
+
+function parseCatalogue(html) {
+  const starts = [...html.matchAll(/<div class="program c-accordion[^>]*>/g)].map((match) => match.index);
+  const rows = [];
+  const seen = new Set();
+  for (let index = 0; index < starts.length; index += 1) {
+    const block = html.slice(starts[index], starts[index + 1] || html.length);
+    const link = block.match(/<div class="section-title alphabar-title">\s*<a href="([^"]+)">([\s\S]*?)<\/a>/i);
+    if (!link) continue;
+    const url = canonicalizeProgramUrl(link[1]);
+    if (!url || seen.has(url)) continue;
+    const program = {
+      name: text(link[2]),
+      url,
+      degree: hiddenValue(block, 'degree'),
+      credential: hiddenValue(block, 'credential'),
+      category: hiddenValue(block, 'category'),
+      programType: hiddenValue(block, 'programType'),
+      campus: hiddenValue(block, 'campus'),
+      experiential: hiddenValue(block, 'experiential'),
+    };
+    program.tags = classifyDegree(program);
+    if (!program.name || !program.degree || !program.credential) continue;
+    seen.add(url);
+    rows.push(program);
+  }
+  if (!starts.length || !rows.length) {
+    throw new CommandExecutionError('Concordia catalogue parser found no graduate program cards');
+  }
+  return rows;
+}
+
+async function discoverPrograms(degreeLevel) {
+  const { html } = await fetchHtml(CATALOGUE_URL, 'program c-accordion');
+  const programs = parseCatalogue(html);
+  return degreeLevel === 'all'
+    ? programs
+    : programs.filter((program) => program.tags.includes(degreeLevel));
+}
+
+function extractProgramInfo(html) {
+  const info = {};
+  for (const match of html.matchAll(/<div class="heading-program-info">([\s\S]*?)<\/div>\s*<div class="text-program-info">([\s\S]*?)<\/div>/gi)) {
+    info[text(match[1]).toLowerCase()] = text(match[2]);
+  }
+  return info;
+}
+
+function durationMonths(value = '') {
+  const lower = value.toLowerCase();
+  const yearRange = lower.match(/(\d+(?:\.\d+)?)\s*(?:-|–|to)\s*(\d+(?:\.\d+)?)\s*years?/);
+  if (yearRange) return `${Number(yearRange[1]) * 12}-${Number(yearRange[2]) * 12}`;
+  const monthRange = lower.match(/(\d+(?:\.\d+)?)\s*(?:-|–|to)\s*(\d+(?:\.\d+)?)\s*months?/);
+  if (monthRange) return `${Number(monthRange[1])}-${Number(monthRange[2])}`;
+  const years = lower.match(/(\d+(?:\.\d+)?)\s*years?/);
+  if (years) return String(Number(years[1]) * 12);
+  const months = lower.match(/(\d+(?:\.\d+)?)\s*months?/);
+  return months ? String(Number(months[1])) : '';
+}
+
+function intakeMonths(value = '') {
+  const terms = [
+    [/fall/i, 'Fall (September)'],
+    [/winter/i, 'Winter (January)'],
+    [/summer/i, 'Summer (May)'],
+  ].filter(([pattern]) => pattern.test(value)).map(([, term]) => term);
+  return terms.join(' | ');
+}
+
+function extractRequirements(html) {
+  const section = html.match(/<a id="requirements"><\/a>([\s\S]*?)<a id="application"><\/a>/i)?.[1] || '';
+  const items = [...section.matchAll(/<li[^>]*>([\s\S]*?)<\/li>/gi)]
+    .map((match) => text(match[1]))
+    .filter(Boolean)
+    .slice(0, 8);
+  return items.join(' | ');
+}
+
+function extractDeadlineSummary(html) {
+  const start = html.search(/Application deadlines/i);
+  if (start < 0) return '';
+  const tail = html.slice(start, html.search(/<a id="tuition"><\/a>/i) > start ? html.search(/<a id="tuition"><\/a>/i) : start + 25000);
+  const deadlines = [];
+  for (const term of ['FALL', 'WINTER', 'SUMMER']) {
+    const match = tail.match(new RegExp(`<h3>\\s*${term}\\s*<\\/h3>[\\s\\S]{0,900}?<span class=["']xlarge-text["']>([\\s\\S]*?)<\\/span>`, 'i'));
+    if (match) deadlines.push(`${term[0]}${term.slice(1).toLowerCase()} - ${text(match[1])}`);
+  }
+  return deadlines.join(' | ');
+}
+
+function extractCalendarUrl(html) {
+  const match = html.match(/href=["'](\/academics\/graduate\/calendar\/current\/[^"']+)["'][^>]*>[\s\S]*?(?:Degree Requirements|credits|Courses|Consult the Graduate Calendar)/i);
+  return match ? new URL(decodeHtml(match[1]), BASE).href : '';
+}
+
+function requirementValue(requirements, pattern) {
+  return requirements.match(pattern)?.[1]?.trim() || '';
+}
+
+function yesNoFromText(requirements, testName) {
+  const lower = requirements.toLowerCase();
+  if (new RegExp(`(?:does not|not|no longer)\\s+require[^|.]{0,80}${testName}`, 'i').test(requirements)) return 'No';
+  if (new RegExp(`${testName}[^|.]{0,80}(?:not required|optional)`, 'i').test(requirements)) return 'No';
+  if (new RegExp(`${testName}[^|.]{0,80}required|required[^|.]{0,80}${testName}`, 'i').test(requirements)) return 'Yes';
+  if (new RegExp(`\\b${testName}\\b`, 'i').test(lower)) return 'See requirements';
+  return '';
+}
+
+function workExperience(requirements) {
+  if (/work experience[^|.]{0,100}(?:not required|optional)|no work experience/i.test(requirements)) return 'No';
+  if (/(?:work|professional) experience|years? of experience/i.test(requirements)) return 'See requirements';
+  return '';
+}
+
+async function extractProgram(program) {
+  let html;
+  let finalUrl;
+  try {
+    ({ html, finalUrl } = await fetchHtml(program.url, '<h1'));
+  } catch (error) {
+    return {
+      ...program,
+      detailUrl: program.url,
+      programInfo: {},
+      requirements: '',
+      deadlineSummary: '',
+      calendarUrl: '',
+      detailError: error.message,
+    };
+  }
+  const detailUrl = canonicalizeProgramUrl(finalUrl) || program.url;
+  const programInfo = extractProgramInfo(html);
+  const requirements = extractRequirements(html);
+  return {
+    ...program,
+    detailUrl,
+    programInfo,
+    requirements,
+    deadlineSummary: extractDeadlineSummary(html),
+    calendarUrl: extractCalendarUrl(html),
+    detailError: '',
+  };
+}
+
+async function mapWithConcurrency(items, mapper, concurrency) {
+  const results = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (next < items.length) {
+      const index = next;
+      next += 1;
+      results[index] = await mapper(items[index], index);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker));
+  return results;
+}
+
+async function fetchSharedSources() {
+  const [application, requirements, english, tuition] = await Promise.all([
+    fetchHtml(SOURCES.application, 'application fee of $100.00 CAD'),
+    fetchHtml(SOURCES.requirements, 'reference letters'),
+    fetchHtml(SOURCES.english, 'IELTS'),
+    fetchHtml(SOURCES.tuition, 'Graduate costs per course credit'),
+  ]);
+  return { application, requirements, english, tuition };
+}
+
+function normalizeRecord(data) {
+  const row = Object.fromEntries(COLUMNS.map((column) => [column, '']));
+  const requirements = data.requirements || '';
+  const remarks = [`Checked: ${CHECKED_DATE}`];
+  if (data.detailError) remarks.push(`Program detail page unavailable on ${CHECKED_DATE}: ${data.detailError}`);
+  if (!row['Tution fees \n(per year)']) remarks.push('Concordia publishes graduate fee schedules/estimator rather than a single annual amount for this program.');
+  const references = [
+    `Course: ${data.detailUrl || data.url}`,
+    `Catalogue: ${SOURCES.catalogue}`,
+    data.calendarUrl ? `Calendar: ${data.calendarUrl}` : '',
+    `Application fee: ${SOURCES.application}`,
+    `Requirements: ${SOURCES.requirements}`,
+    `English: ${SOURCES.english}`,
+    `Tuition: ${SOURCES.tuition}`,
+  ].filter(Boolean);
+  const studyOptions = [
+    data.programInfo['program options'] || data.programType,
+    data.experiential,
+    data.programInfo['primary campus'] || data.campus.toUpperCase(),
+  ].filter(Boolean);
+
+  row['Course Name'] = data.name;
+  row['Course URL'] = data.detailUrl || data.url;
+  row['University \nname'] = UNIVERSITY;
+  row['Intake Month'] = intakeMonths(data.programInfo['start term']);
+  row['App fees'] = data.credential === 'Microprogram' ? 'CAD 40' : 'CAD 100';
+  row['Degree Level'] = data.degree;
+  row['Study Level'] = 'PG';
+  row['Duration\n(in months)'] = durationMonths(data.programInfo.duration);
+  row['Study option'] = studyOptions.join(' | ');
+  row['Program Type'] = data.programType;
+  row['IELTS \n(Overall & Subscores)'] = '6.5 overall; 6.5 each component for no English language courses (some programs higher)';
+  row['ielts_reading_score'] = '6.5';
+  row['ielts_writing_score'] = '6.5';
+  row['ielts_listening_score'] = '6.5';
+  row['ielts_speaking_score'] = '6.5';
+  row['TOEFL\n(Overall & Subscores)'] = '86 overall, 20 each component; Jan 2026+ scale: 4.5 overall, no section below 4.0 (some programs higher)';
+  row['toefl_reading_score'] = '20';
+  row['toefl_writing_score'] = '20';
+  row['toefl_listening_score'] = '20';
+  row['toefl_speaking_score'] = '20';
+  row['PTE\n(Overall & Subscores)'] = '61 overall, no part under 53';
+  row['pte_reading_score'] = '53';
+  row['pte_writing_score'] = '53';
+  row['pte_listening_score'] = '53';
+  row['pte_speaking_score'] = '53';
+  row['Duolingo\n(Overall & Subscores)'] = 'Above 120 (some programs higher)';
+  row['Is Waiver \nProvided?'] = 'Yes';
+  row['Waiver Info'] = 'Exempt after at least three full undergraduate/graduate years at an accredited university in an English- or French-primary-language country, or four secondary-school years in an English-primary-language country; Concordia may still require a test.';
+  row['Is MOI \naccepted?'] = 'Yes — exemption is based on qualifying study where English or French is the primary language of instruction.';
+  row['Share list, if any'] = 'American Samoa; Anguilla; Antigua & Barbuda; Australia; Bahamas; Barbados; Belgium (French); Belize; Bermuda; Botswana; British Virgin Islands; Canada; Cayman Islands; Dominica; Falkland Islands; Fiji; France (French); Gambia; Ghana; Gibraltar; Grenada; Guam; Guyana; Ireland; Jamaica; Kenya; Lesotho; Liberia; Malta; Mauritius; Montserrat; New Zealand; Nigeria; Seychelles; Sierra Leone; Singapore; South Africa; St. Helena; St. Kitts & Nevis; St. Lucia; St. Vincent & the Grenadines; Tanzania; Trinidad & Tobago; Turks & Caicos Islands; Uganda; United Kingdom; US Virgin Islands; United States of America; Zambia; Zimbabwe.';
+  row['GRE Required'] = yesNoFromText(requirements, 'GRE');
+  row['GMAT Required'] = yesNoFromText(requirements, 'GMAT');
+  row['Min UG score'] = requirementValue(requirements, /(?:minimum GPA of|GPA of|minimum GPA)\s*([0-9](?:\.[0-9]{1,2})?(?:\s*\([^)]+\))?)/i);
+  row['Work \nExperience \nRequired?'] = workExperience(requirements);
+  row['Main Entry \nRequirements'] = requirements;
+  row['Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)'] = data.deadlineSummary;
+  row['Remarks (if any)'] = remarks.join(' | ');
+  row['Reference Links (if any)'] = references.join(' | ');
+  // These fields are either not part of postgraduate admission or are assessed
+  // program-by-program; do not turn missing catalogue metadata into a claim.
+  const unavailable = 'Not available on official program page';
+  const notApplicable = 'Not applicable (postgraduate admission)';
+  for (const column of [
+    'Substream/\nSpecialisation',
+    'Intake Month',
+    'Duration\n(in months)',
+    'Tution fees \n(per year)',
+    'Total Tution \nFees',
+    'GRE Required',
+    'GMAT Required',
+    'GRE/GMAT Scores',
+    'Min UG score',
+    '15 years of\nEducation Allowed?',
+    'Gap Years',
+    'Backlogs',
+    'Work \nExperience \nRequired?',
+    'Main Entry \nRequirements',
+    'Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)',
+  ]) if (!row[column]) row[column] = unavailable;
+  for (const column of ['Partner', '12th scores', 'duolingo_comprehension_score', 'duolingo_literacy_score', 'duolingo_conversation_score', 'duolingo_production_score']) {
+    if (!row[column]) row[column] = notApplicable;
+  }
+  if (!row['Is MOI \naccepted?']) row['Is MOI \naccepted?'] = 'Not available on official program page';
+  if (!row['Status']) row['Status'] = 'Not available on official program page';
+  row['Remarks (if any)'] = `${row['Remarks (if any)']} | Fields without a published program-page value are marked as unavailable; secondary-school and partner fields are not applicable to PG admission.`;
+  return row;
+}
+
+function validateRecord(row) {
+  for (const column of ['Course Name', 'Course URL', 'University \nname', 'Degree Level', 'Study Level', 'Reference Links (if any)']) {
+    if (!row[column]?.trim()) throw new CommandExecutionError(`Concordia row is missing required field: ${column}`);
+  }
+  if (!/^https:\/\/www\.concordia\.ca\/academics\/graduate\/[^/]+\.html$/.test(row['Course URL'])) {
+    throw new CommandExecutionError(`Concordia row has invalid course URL: ${row['Course URL']}`);
+  }
+  if (row['Study Level'] !== 'PG') throw new CommandExecutionError('Concordia row Study Level must be PG');
+  return row;
+}
+
+cli({
+  site: 'concordia',
+  name: 'export-postgraduate-courses',
+  description: 'Export Concordia University Montreal postgraduate programs using official public sources.',
+  access: 'read',
+  example: 'webcmd concordia export-postgraduate-courses --degree-level masters --count 10 -f csv',
+  domain: 'www.concordia.ca',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'degree-level', type: 'string', default: 'all', help: 'all, masters, certificate, diploma, professional, or doctorate' },
+    { name: 'count', type: 'int', required: false, help: 'Positive maximum number of programs after filtering and deduplication' },
+  ],
+  columns: OUTPUT_COLUMNS,
+  func: async (args) => {
+    const { degreeLevel, count } = parseOptions(args);
+    const programs = await discoverPrograms(degreeLevel);
+    if (!programs.length) return [];
+    await fetchSharedSources();
+    const selected = count === null ? programs : programs.slice(0, count);
+    const details = await mapWithConcurrency(selected, extractProgram, DETAIL_CONCURRENCY);
+    return details.map((detail) => {
+      const row = validateRecord(normalizeRecord(detail));
+      return CSV_OUTPUT
+        ? Object.fromEntries(COLUMNS.map((column, index) => [OUTPUT_COLUMNS[index], row[column]]))
+        : row;
+    });
+  },
+});

--- a/plugins/concordia/package.json
+++ b/plugins/concordia/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "webcmd-plugin-concordia",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Concordia University Montréal postgraduate course export adapter",
+  "peerDependencies": {
+    "@agentrhq/webcmd": ">=0.5.2"
+  }
+}

--- a/plugins/concordia/webcmd-plugin.json
+++ b/plugins/concordia/webcmd-plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "concordia",
+  "version": "0.1.0",
+  "description": "Concordia University Montréal postgraduate course export adapter",
+  "webcmd": ">=0.5.2",
+  "author": {
+    "name": "WebCMD Agent",
+    "handle": "agentrhq"
+  }
+}

--- a/plugins/goettingen/README.md
+++ b/plugins/goettingen/README.md
@@ -1,0 +1,22 @@
+# webcmd-plugin-goettingen
+
+University of Göttingen postgraduate course export adapter.
+
+## Install
+
+```bash
+webcmd plugin install github:agentrhq/webcmd/plugins/goettingen
+```
+
+## Command
+
+| Command | Description |
+| --- | --- |
+| `webcmd goettingen export-postgraduate-courses --count 10 -f csv` | Export postgraduate courses in the shared 52-column CSV schema |
+
+## Examples
+
+```bash
+webcmd goettingen export-postgraduate-courses --count 10 -f json
+webcmd goettingen export-postgraduate-courses --degree-level masters -f csv
+```

--- a/plugins/goettingen/export-postgraduate-courses.js
+++ b/plugins/goettingen/export-postgraduate-courses.js
@@ -1,0 +1,262 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import {
+  ArgumentError,
+  CommandExecutionError,
+} from '@agentrhq/webcmd/errors';
+import { resolve4 } from 'node:dns/promises';
+import { Agent } from 'undici';
+
+const BASE = 'https://www.uni-goettingen.de';
+const CATALOGUE_URL = `${BASE}/en/3811.html`;
+const COURSES_API = `${BASE}/api/v1/get/courses/language/en`;
+const UNIVERSITY = 'University of Göttingen';
+const CHECKED_DATE = '2026-08-03';
+const DEGREE_LEVELS = new Set(['all', 'masters', 'certificate', 'diploma', 'professional', 'doctorate']);
+const DNS_DISPATCHER = new Agent({
+  connect: {
+    lookup(hostname, options, callback) {
+      resolve4(hostname).then(
+        (addresses) => options?.all
+          ? callback(null, addresses.map((address) => ({ address, family: 4 })))
+          : callback(null, addresses[0], 4),
+        callback,
+      );
+    },
+  },
+});
+
+const COLUMNS = [
+  'Course Name',
+  'Course URL',
+  'University \nname',
+  'Intake Month',
+  'Substream/\nSpecialisation',
+  'App fees',
+  'Degree Level',
+  'Study Level',
+  'Duration\n(in months)',
+  'Study option',
+  'Program Type',
+  'Partner',
+  'Tution fees \n(per year)',
+  'Total Tution \nFees',
+  'IELTS \n(Overall & Subscores)',
+  'ielts_reading_score',
+  'ielts_writing_score',
+  'ielts_listening_score',
+  'ielts_speaking_score',
+  'TOEFL\n(Overall & Subscores)',
+  'toefl_reading_score',
+  'toefl_writing_score',
+  'toefl_listening_score',
+  'toefl_speaking_score',
+  'PTE\n(Overall & Subscores)',
+  'pte_reading_score',
+  'pte_writing_score',
+  'pte_listening_score',
+  'pte_speaking_score',
+  'Duolingo\n(Overall & Subscores)',
+  'duolingo_comprehension_score',
+  'duolingo_literacy_score',
+  'duolingo_conversation_score',
+  'duolingo_production_score',
+  'Is Waiver \nProvided?',
+  'Waiver Info',
+  'Is MOI \naccepted?',
+  'Share list, if any',
+  'GRE Required',
+  'GMAT Required',
+  'GRE/GMAT Scores',
+  '12th scores',
+  'Min UG score',
+  '15 years of\nEducation Allowed?',
+  'Gap Years',
+  'Backlogs',
+  'Work \nExperience \nRequired?',
+  'Main Entry \nRequirements',
+  'Status',
+  'Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)',
+  'Remarks (if any)',
+  'Reference Links (if any)',
+];
+
+const CSV_OUTPUT = process.argv.some((arg, index, argv) =>
+  /^(?:-f|--format)=csv$/.test(arg) || ((arg === '-f' || arg === '--format') && argv[index + 1] === 'csv')
+);
+const OUTPUT_COLUMNS = CSV_OUTPUT
+  ? COLUMNS.map((column) => /[,"\r\n]/.test(column) ? `"${column.replace(/"/g, '""')}"` : column)
+  : COLUMNS;
+
+function parseOptions(args) {
+  const degreeLevel = String(args['degree-level'] ?? 'all').toLowerCase();
+  if (!DEGREE_LEVELS.has(degreeLevel)) {
+    throw new ArgumentError(`--degree-level must be one of: ${[...DEGREE_LEVELS].join(', ')}`);
+  }
+  if (args.count === undefined || args.count === null || args.count === '') return { degreeLevel, count: null };
+  const count = Number(args.count);
+  if (!Number.isInteger(count) || count <= 0) throw new ArgumentError('--count must be a positive integer');
+  return { degreeLevel, count };
+}
+
+async function fetchCourses() {
+  const response = await fetch(COURSES_API, {
+    headers: { 'User-Agent': 'Mozilla/5.0 (compatible; Webcmd Goettingen public data export)' },
+    dispatcher: DNS_DISPATCHER,
+  });
+  if (!response.ok) throw new CommandExecutionError(`Göttingen course API failed: HTTP ${response.status}`);
+  const data = await response.json();
+  if (!Array.isArray(data.courses)) throw new CommandExecutionError('Göttingen course API changed: missing courses array');
+  return data.courses;
+}
+
+function urlFor(course) {
+  return `${BASE}/en/${course.page_id}.html`;
+}
+
+function degreeNames(course) {
+  return (course.diploma?.degree || []).map((degree) => degree.name);
+}
+
+function tagsFor(course) {
+  const ids = new Set((course.diploma?.degree || []).map((degree) => String(degree.id)));
+  const label = `${course.name} ${course.diploma?.name || ''} ${course.diploma?.title || ''}`.toLowerCase();
+  const tags = new Set();
+  if (ids.has('5') || ids.has('6') || /master/.test(label)) tags.add('masters');
+  if (ids.has('7') || /phd|ph\\.d|promotion|doctor/.test(label)) tags.add('doctorate');
+  if (/zertifikat|certificate/.test(label)) tags.add('certificate');
+  if (/diploma|diplom/.test(label)) tags.add('diploma');
+  if (/approbation|psychotherapy/.test(label)) tags.add('professional');
+  return [...tags];
+}
+
+function durationMonths(course) {
+  const duration = (course.course_keywords || [])
+    .find((keyword) => /Regelstudienzeit|Standard period/i.test(keyword.keyword_group || ''))?.keyword;
+  return /^\d+(\.\d+)?$/.test(String(duration || '')) ? String(Number(duration) * 6) : '';
+}
+
+function intake(course) {
+  const terms = [];
+  if (course.start_winter === '1') terms.push('Winter semester');
+  if (course.start_summer === '1') terms.push('Summer semester');
+  return terms.join(' | ');
+}
+
+function languages(course) {
+  return (course.course_languages || []).map((language) => language.name || language.iso_639_1).filter(Boolean);
+}
+
+function admission(course) {
+  const current = [...(course.course_application_processes || [])]
+    .sort((a, b) => Number(b.semester_id) - Number(a.semester_id))[0];
+  return current?.application_process_name || '';
+}
+
+function normalize(course) {
+  const row = Object.fromEntries(COLUMNS.map((column) => [column, '']));
+  const degree = [course.diploma?.name, course.diploma?.title].filter(Boolean).join(' ');
+  const refs = [`Course: ${urlFor(course)}`, `Catalogue: ${CATALOGUE_URL}`, `API: ${COURSES_API}`];
+  row['Course Name'] = course.name;
+  row['Course URL'] = urlFor(course);
+  row['University \nname'] = UNIVERSITY;
+  row['Intake Month'] = intake(course);
+  row['Substream/\nSpecialisation'] = [course.discipline?.name, course.faculty?.name].filter(Boolean).join(' | ');
+  row['Degree Level'] = degree;
+  row['Study Level'] = 'PG';
+  row['Duration\n(in months)'] = durationMonths(course);
+  row['Study option'] = languages(course).length ? `Teaching language: ${languages(course).join(' | ')}` : '';
+  row['Program Type'] = degreeNames(course).join(' | ') || course.diploma?.name || '';
+  row['Main Entry \nRequirements'] = admission(course);
+  row['Status'] = course.valid_until ? 'Ending/limited in official API' : 'Official listing active';
+  row['Remarks (if any)'] = `Checked ${CHECKED_DATE}; official Göttingen A-Z degree-programme API. Teaching language and admission route are populated from the API. Fees/application charges, language-test scores, GRE/GMAT, school/UG-score conventions, gaps, backlogs, work experience, waivers, and MOI acceptance are not available as programme-safe values in this official API.`;
+  row['Reference Links (if any)'] = refs.join(' | ');
+  const unavailable = 'Not available as a programme-safe value in official Göttingen API';
+  for (const column of [
+    'Intake Month',
+    'App fees',
+    'Partner',
+    'Tution fees \n(per year)',
+    'Total Tution \nFees',
+    'IELTS \n(Overall & Subscores)',
+    'ielts_reading_score',
+    'ielts_writing_score',
+    'ielts_listening_score',
+    'ielts_speaking_score',
+    'TOEFL\n(Overall & Subscores)',
+    'toefl_reading_score',
+    'toefl_writing_score',
+    'toefl_listening_score',
+    'toefl_speaking_score',
+    'PTE\n(Overall & Subscores)',
+    'pte_reading_score',
+    'pte_writing_score',
+    'pte_listening_score',
+    'pte_speaking_score',
+    'Duolingo\n(Overall & Subscores)',
+    'duolingo_comprehension_score',
+    'duolingo_literacy_score',
+    'duolingo_conversation_score',
+    'duolingo_production_score',
+    'Is Waiver \nProvided?',
+    'Waiver Info',
+    'Is MOI \naccepted?',
+    'Share list, if any',
+    'GRE Required',
+    'GMAT Required',
+    'GRE/GMAT Scores',
+    '12th scores',
+    'Min UG score',
+    '15 years of\nEducation Allowed?',
+    'Gap Years',
+    'Backlogs',
+    'Work \nExperience \nRequired?',
+    'Duration\n(in months)',
+    'Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)',
+  ]) if (!row[column]) row[column] = column === 'Partner' ? 'Not applicable unless listed by official programme source' : unavailable;
+  return row;
+}
+
+function validate(row) {
+  for (const column of ['Course Name', 'Course URL', 'University \nname', 'Degree Level', 'Study Level', 'Reference Links (if any)']) {
+    if (!row[column]?.trim()) throw new CommandExecutionError(`Göttingen row is missing required field: ${column}`);
+  }
+  if (!/^https:\/\/www\.uni-goettingen\.de\/en\/\d+\.html$/.test(row['Course URL'])) {
+    throw new CommandExecutionError(`Göttingen row has invalid course URL: ${row['Course URL']}`);
+  }
+  if (row['Study Level'] !== 'PG') throw new CommandExecutionError('Göttingen row Study Level must be PG');
+  return row;
+}
+
+cli({
+  site: 'goettingen',
+  name: 'export-postgraduate-courses',
+  description: 'Export University of Göttingen postgraduate programmes from the official A-Z API.',
+  access: 'read',
+  example: 'webcmd goettingen export-postgraduate-courses --degree-level masters --count 10 -f csv',
+  domain: 'www.uni-goettingen.de',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'degree-level', type: 'string', default: 'all', help: 'all, masters, certificate, diploma, professional, or doctorate' },
+    { name: 'count', type: 'int', required: false, help: 'Positive maximum number of programmes after filtering and deduplication' },
+  ],
+  columns: OUTPUT_COLUMNS,
+  func: async (args) => {
+    const { degreeLevel, count } = parseOptions(args);
+    const seen = new Set();
+    const rows = [];
+    for (const course of await fetchCourses()) {
+      const tags = tagsFor(course);
+      if (!tags.length || (degreeLevel !== 'all' && !tags.includes(degreeLevel))) continue;
+      const url = urlFor(course);
+      if (seen.has(url)) continue;
+      seen.add(url);
+      const row = validate(normalize(course));
+      rows.push(CSV_OUTPUT
+        ? Object.fromEntries(COLUMNS.map((column, index) => [OUTPUT_COLUMNS[index], row[column]]))
+        : row);
+      if (count !== null && rows.length >= count) break;
+    }
+    return rows;
+  },
+});

--- a/plugins/goettingen/export-postgraduate-courses.js
+++ b/plugins/goettingen/export-postgraduate-courses.js
@@ -109,6 +109,72 @@ async function fetchCourses() {
   return data.courses;
 }
 
+async function fetchDetail(course) {
+  const response = await fetch(urlFor(course), {
+    headers: { 'User-Agent': 'Mozilla/5.0 (compatible; Webcmd Goettingen public data export)' },
+    dispatcher: DNS_DISPATCHER,
+  });
+  if (!response.ok) throw new CommandExecutionError(`Göttingen detail page failed for ${urlFor(course)}: HTTP ${response.status}`);
+  const html = await response.text();
+  return html;
+}
+
+function htmlText(value = '') {
+  return String(value)
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<h[1-6]\b[^>]*>([\s\S]*?)<\/h[1-6]>/gi, (_, heading) => `\n@@ ${heading.replace(/<[^>]+>/g, ' ')}\n`)
+    .replace(/<li\b[^>]*>/gi, '\n- ')
+    .replace(/<\/(?:p|div|section|tr|table)>/gi, '\n')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#0*39;|&apos;|&rsquo;/gi, "'")
+    .replace(/\s+\n/g, '\n')
+    .replace(/[ \t]+/g, ' ')
+    .trim();
+}
+
+function detailSummary(html) {
+  const text = htmlText(html).split(/\n+/).map((line) => line.trim()).filter(Boolean);
+  const fieldLabels = ['Name:', 'Degree:', 'Standard period of study:', 'Start of studies:', 'Teaching language:', 'Admission:'];
+  const facts = [];
+  for (const label of fieldLabels) {
+    const at = text.findIndex((line) => line === label);
+    if (at >= 0 && text[at + 1]) facts.push(`${label} ${text[at + 1]}`);
+  }
+  const featureAt = text.findIndex((line, index) => line === 'Features' && index > 10);
+  const feature = featureAt >= 0 ? text.slice(featureAt + 1).find((line) => line.length > 80) : '';
+  const keep = [];
+  let capture = false;
+  for (const line of text) {
+    if (/^@@\s*(Details|Structure|Admission|Application|Requirements)/i.test(line)) capture = true;
+    else if (/^@@\s*(Get to know us|Related degree|Study profiles|Contact|Footer)/i.test(line)) capture = false;
+    else if (capture) keep.push(line.replace(/^@@\s*/, ''));
+    if (keep.join(' | ').length > 1800) break;
+  }
+  return [...facts, feature, ...keep].filter(Boolean).join(' | ').replace(/\s+/g, ' ').slice(0, 1800).trim();
+}
+
+async function enrichCourse(course) {
+  try {
+    const html = await fetchDetail(course);
+    return { ...course, detailSummary: detailSummary(html), detailError: '' };
+  } catch (error) {
+    return { ...course, detailSummary: '', detailError: error.message };
+  }
+}
+
+async function enrichCourses(courses) {
+  const rows = [];
+  for (let index = 0; index < courses.length; index += 8) {
+    rows.push(...await Promise.all(courses.slice(index, index + 8).map(enrichCourse)));
+  }
+  return rows;
+}
+
 function urlFor(course) {
   return `${BASE}/en/${course.page_id}.html`;
 }
@@ -166,9 +232,13 @@ function normalize(course) {
   row['Duration\n(in months)'] = durationMonths(course);
   row['Study option'] = languages(course).length ? `Teaching language: ${languages(course).join(' | ')}` : '';
   row['Program Type'] = degreeNames(course).join(' | ') || course.diploma?.name || '';
-  row['Main Entry \nRequirements'] = admission(course);
+  row['Main Entry \nRequirements'] = course.detailSummary || admission(course);
   row['Status'] = course.valid_until ? 'Ending/limited in official API' : 'Official listing active';
-  row['Remarks (if any)'] = `Checked ${CHECKED_DATE}; official Göttingen A-Z degree-programme API. Teaching language and admission route are populated from the API. Fees/application charges, language-test scores, GRE/GMAT, school/UG-score conventions, gaps, backlogs, work experience, waivers, and MOI acceptance are not available as programme-safe values in this official API.`;
+  row['Remarks (if any)'] = [
+    `Checked ${CHECKED_DATE}; official Göttingen A-Z degree-programme API plus each official programme detail page.`,
+    course.detailError ? `Programme detail page unavailable: ${course.detailError}` : '',
+    'Teaching language and admission route are populated from official API/detail data. Fees/application charges, language-test scores, GRE/GMAT, school/UG-score conventions, gaps, backlogs, work experience, waivers, and MOI acceptance are not available as programme-safe values on the official programme pages/API.',
+  ].filter(Boolean).join(' | ');
   row['Reference Links (if any)'] = refs.join(' | ');
   const unavailable = 'Not available as a programme-safe value in official Göttingen API';
   for (const column of [
@@ -245,17 +315,21 @@ cli({
     const { degreeLevel, count } = parseOptions(args);
     const seen = new Set();
     const rows = [];
+    const candidates = [];
     for (const course of await fetchCourses()) {
       const tags = tagsFor(course);
       if (!tags.length || (degreeLevel !== 'all' && !tags.includes(degreeLevel))) continue;
       const url = urlFor(course);
       if (seen.has(url)) continue;
       seen.add(url);
+      candidates.push(course);
+      if (count !== null && candidates.length >= count) break;
+    }
+    for (const course of await enrichCourses(candidates)) {
       const row = validate(normalize(course));
       rows.push(CSV_OUTPUT
         ? Object.fromEntries(COLUMNS.map((column, index) => [OUTPUT_COLUMNS[index], row[column]]))
         : row);
-      if (count !== null && rows.length >= count) break;
     }
     return rows;
   },

--- a/plugins/goettingen/package.json
+++ b/plugins/goettingen/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "webcmd-plugin-goettingen",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "University of Göttingen postgraduate course export adapter",
+  "peerDependencies": {
+    "@agentrhq/webcmd": ">=0.5.2"
+  }
+}

--- a/plugins/goettingen/webcmd-plugin.json
+++ b/plugins/goettingen/webcmd-plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "goettingen",
+  "version": "0.1.0",
+  "description": "University of Göttingen postgraduate course export adapter",
+  "webcmd": ">=0.5.2",
+  "author": {
+    "name": "WebCMD Agent",
+    "handle": "agentrhq"
+  }
+}

--- a/plugins/heidelberg/README.md
+++ b/plugins/heidelberg/README.md
@@ -1,0 +1,22 @@
+# webcmd-plugin-heidelberg
+
+Heidelberg University postgraduate course export adapter.
+
+## Install
+
+```bash
+webcmd plugin install github:agentrhq/webcmd/plugins/heidelberg
+```
+
+## Command
+
+| Command | Description |
+| --- | --- |
+| `webcmd heidelberg export-postgraduate-courses --count 10 -f csv` | Export postgraduate courses in the shared 52-column CSV schema |
+
+## Examples
+
+```bash
+webcmd heidelberg export-postgraduate-courses --count 10 -f json
+webcmd heidelberg export-postgraduate-courses --degree-level masters -f csv
+```

--- a/plugins/heidelberg/export-postgraduate-courses.js
+++ b/plugins/heidelberg/export-postgraduate-courses.js
@@ -209,6 +209,61 @@ function canonicalizeProgramUrl(value) {
   return url.href;
 }
 
+function officialHeidelbergUrl(value, base = BASE) {
+  try {
+    const url = new URL(value, base);
+    if (url.protocol !== 'https:' || !url.hostname.endsWith('.uni-heidelberg.de')) return '';
+    if (/\/download(?:$|[/?#])/.test(url.pathname)) return '';
+    url.hash = '';
+    return url.href;
+  } catch {
+    return '';
+  }
+}
+
+function officialCourseLinks(html, baseUrl) {
+  const links = [];
+  for (const match of html.matchAll(/<a\b[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi)) {
+    const label = text(match[2]);
+    const url = officialHeidelbergUrl(match[1], baseUrl);
+    if (
+      url
+      && !url.includes('/en/study/all-subjects/')
+      && !/^(University|Research|Study|Transfer|Home|Facebook|Instagram|LinkedIn|YouTube)$/i.test(label)
+      && !links.some((link) => link.url === url)
+    ) {
+      links.push({ label, url });
+    }
+  }
+  return links
+    .sort((a, b) => Number(/admission|center|centre|institute|department|programme|program/i.test(b.label)) - Number(/admission|center|centre|institute|department|programme|program/i.test(a.label)))
+    .slice(0, 3);
+}
+
+function sectionByHeading(html, headingPattern) {
+  const heading = html.match(/<h[2-3]\b[^>]*>([\s\S]*?)<\/h[2-3]>/gi)?.find((candidate) => headingPattern.test(text(candidate)));
+  if (!heading) return '';
+  const start = html.indexOf(heading);
+  const next = html.slice(start + heading.length).search(/<h[2-3]\b/i);
+  const block = next === -1 ? html.slice(start) : html.slice(start, start + heading.length + next);
+  return text(block).replace(/\s+/g, ' ').trim();
+}
+
+async function linkedAdmissionInfo(html, baseUrl) {
+  for (const link of officialCourseLinks(html, baseUrl)) {
+    try {
+      const { html: linkedHtml, finalUrl } = await fetchHtml(link.url, '<html');
+      const admission = sectionByHeading(linkedHtml, /admission|application/i);
+      if (/\b(BA|Bachelor|TOEFL|IELTS|credit|transcript|degree|deadline)\b/i.test(admission)) {
+        return { text: admission, url: finalUrl, label: link.label };
+      }
+    } catch {
+      // Ignore auxiliary-page misses; the main programme page remains the source of truth.
+    }
+  }
+  return { text: '', url: '', label: '' };
+}
+
 function classifyVariant(variantName, degree = '') {
   const haystack = `${variantName} ${degree}`.toLowerCase();
   const tags = new Set();
@@ -292,11 +347,23 @@ function totalFees(fees = '', duration = '') {
   return `${total.toFixed(2)} € (official semester contribution over standard period)`;
 }
 
+function languageScores(source = '') {
+  const ielts = source.match(/IELTS:?\s*([0-9.]+)[^|.]*?(?:at least|minimum)\s*([0-9.]+)/i);
+  const toefl = source.match(/TOEFL iBT:?\s*([0-9]+)[^|.]*?(?:at least|minimum)\s*([0-9]+)/i);
+  return {
+    ieltsOverall: ielts?.[1] || '',
+    ieltsSub: ielts?.[2] || '',
+    toeflOverall: toefl?.[1] || '',
+    toeflSub: toefl?.[2] || '',
+  };
+}
+
 async function enrichProgram(program) {
   try {
     const { html, finalUrl } = await fetchHtml(program.url, 'Facts & Formalities');
     const facts = extractFacts(html);
     const degree = fact(facts, 'degree');
+    const linkedAdmission = await linkedAdmissionInfo(html, finalUrl);
     return {
       ...program,
       url: canonicalizeProgramUrl(finalUrl) || program.url,
@@ -307,6 +374,7 @@ async function enrichProgram(program) {
       language: fact(facts, 'language(s) of instruction'),
       fees: fact(facts, 'fees and contributions'),
       application: fact(facts, 'application procedure'),
+      linkedAdmission,
       deadlines: fact(facts, 'application deadlines'),
       detailError: '',
       tags: classifyVariant(program.variantName, degree || program.variantName),
@@ -320,6 +388,7 @@ async function enrichProgram(program) {
       language: '',
       fees: '',
       application: '',
+      linkedAdmission: { text: '', url: '', label: '' },
       deadlines: '',
       detailError: error.message,
     };
@@ -360,11 +429,30 @@ function normalizeRecord(program) {
   row['Program Type'] = program.type || program.variantName;
   row['Tution fees \n(per year)'] = program.fees;
   row['Total Tution \nFees'] = totalFees(program.fees, program.duration);
-  row['Main Entry \nRequirements'] = program.application;
+  row['Main Entry \nRequirements'] = program.linkedAdmission?.text || program.application;
+  const scores = languageScores(row['Main Entry \nRequirements']);
+  if (scores.ieltsOverall) {
+    row['IELTS \n(Overall & Subscores)'] = `Overall ${scores.ieltsOverall}; each subcategory at least ${scores.ieltsSub}`;
+    row['ielts_reading_score'] = scores.ieltsSub;
+    row['ielts_writing_score'] = scores.ieltsSub;
+    row['ielts_listening_score'] = scores.ieltsSub;
+    row['ielts_speaking_score'] = scores.ieltsSub;
+  }
+  if (scores.toeflOverall) {
+    row['TOEFL\n(Overall & Subscores)'] = `TOEFL iBT ${scores.toeflOverall}; each subcategory at least ${scores.toeflSub}`;
+    row['toefl_reading_score'] = scores.toeflSub;
+    row['toefl_writing_score'] = scores.toeflSub;
+    row['toefl_listening_score'] = scores.toeflSub;
+    row['toefl_speaking_score'] = scores.toeflSub;
+  }
   row['Status'] = 'Official listing active';
   row['Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)'] = program.deadlines;
   row['Remarks (if any)'] = remarks.join(' | ');
-  row['Reference Links (if any)'] = `Course: ${program.url} | Catalogue: ${CATALOGUE_URL}`;
+  row['Reference Links (if any)'] = [
+    `Course: ${program.url}`,
+    program.linkedAdmission?.url ? `Admission source: ${program.linkedAdmission.url}` : '',
+    `Catalogue: ${CATALOGUE_URL}`,
+  ].filter(Boolean).join(' | ');
   const unavailable = 'Not available on official Heidelberg study-finder/detail page';
   for (const column of [
     'Substream/\nSpecialisation',
@@ -438,10 +526,10 @@ cli({
     const { html } = await fetchHtml(CATALOGUE_URL, 'studyFinderTable');
     const filtered = parseCatalogue(html)
       .filter((program) => degreeLevel === 'all' || program.tags.includes(degreeLevel));
-    const enriched = await enrichPrograms(filtered);
+    const limited = filtered.slice(0, count === null ? undefined : count);
+    const enriched = await enrichPrograms(limited);
     const selected = enriched
-      .filter((program) => !/^undergraduate$/i.test(program.type))
-      .slice(0, count === null ? undefined : count);
+      .filter((program) => !/^undergraduate$/i.test(program.type));
     return selected.map((program) => {
       const row = validateRecord(normalizeRecord(program));
       return CSV_OUTPUT

--- a/plugins/heidelberg/export-postgraduate-courses.js
+++ b/plugins/heidelberg/export-postgraduate-courses.js
@@ -1,0 +1,452 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import {
+  ArgumentError,
+  CommandExecutionError,
+} from '@agentrhq/webcmd/errors';
+import { resolve4 } from 'node:dns/promises';
+import { Agent } from 'undici';
+
+const BASE = 'https://www.uni-heidelberg.de';
+const CATALOGUE_URL = `${BASE}/en/study/all-subjects`;
+const UNIVERSITY = 'Heidelberg University';
+const CHECKED_DATE = '2026-08-03';
+const REQUEST_TIMEOUT_MS = 20000;
+const DETAIL_CONCURRENCY = 8;
+const DEGREE_LEVELS = new Set(['all', 'masters', 'certificate', 'diploma', 'professional', 'doctorate']);
+const DNS_DISPATCHER = new Agent({
+  connect: {
+    lookup(hostname, options, callback) {
+      resolve4(hostname).then(
+        (addresses) => options?.all
+          ? callback(null, addresses.map((address) => ({ address, family: 4 })))
+          : callback(null, addresses[0], 4),
+        callback,
+      );
+    },
+  },
+});
+
+const COLUMNS = [
+  'Course Name',
+  'Course URL',
+  'University \nname',
+  'Intake Month',
+  'Substream/\nSpecialisation',
+  'App fees',
+  'Degree Level',
+  'Study Level',
+  'Duration\n(in months)',
+  'Study option',
+  'Program Type',
+  'Partner',
+  'Tution fees \n(per year)',
+  'Total Tution \nFees',
+  'IELTS \n(Overall & Subscores)',
+  'ielts_reading_score',
+  'ielts_writing_score',
+  'ielts_listening_score',
+  'ielts_speaking_score',
+  'TOEFL\n(Overall & Subscores)',
+  'toefl_reading_score',
+  'toefl_writing_score',
+  'toefl_listening_score',
+  'toefl_speaking_score',
+  'PTE\n(Overall & Subscores)',
+  'pte_reading_score',
+  'pte_writing_score',
+  'pte_listening_score',
+  'pte_speaking_score',
+  'Duolingo\n(Overall & Subscores)',
+  'duolingo_comprehension_score',
+  'duolingo_literacy_score',
+  'duolingo_conversation_score',
+  'duolingo_production_score',
+  'Is Waiver \nProvided?',
+  'Waiver Info',
+  'Is MOI \naccepted?',
+  'Share list, if any',
+  'GRE Required',
+  'GMAT Required',
+  'GRE/GMAT Scores',
+  '12th scores',
+  'Min UG score',
+  '15 years of\nEducation Allowed?',
+  'Gap Years',
+  'Backlogs',
+  'Work \nExperience \nRequired?',
+  'Main Entry \nRequirements',
+  'Status',
+  'Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)',
+  'Remarks (if any)',
+  'Reference Links (if any)',
+];
+
+const CSV_OUTPUT = process.argv.some((arg, index, argv) =>
+  /^(?:-f|--format)=csv$/.test(arg) || ((arg === '-f' || arg === '--format') && argv[index + 1] === 'csv')
+);
+const OUTPUT_COLUMNS = CSV_OUTPUT
+  ? COLUMNS.map((column) => /[,"\r\n]/.test(column) ? `"${column.replace(/"/g, '""')}"` : column)
+  : COLUMNS;
+
+function pause(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function decodeHtml(value = '') {
+  return value
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([\da-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&apos;|&#0*39;|&rsquo;/gi, "'")
+    .replace(/&lsquo;/gi, "'")
+    .replace(/&ndash;|&mdash;/gi, '-')
+    .replace(/&euro;/gi, '€')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>');
+}
+
+function text(value = '') {
+  return decodeHtml(
+    value
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<[^>]+>/g, ' '),
+  ).replace(/\s+/g, ' ').trim();
+}
+
+async function fetchHtml(url, marker = '<html') {
+  let lastError;
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    try {
+      const response = await fetch(url, {
+        headers: { 'User-Agent': 'Mozilla/5.0 (compatible; Webcmd Heidelberg public data export)' },
+        redirect: 'follow',
+        dispatcher: DNS_DISPATCHER,
+        signal: controller.signal,
+      });
+      const contentType = response.headers.get('content-type') || '';
+      if (!response.ok || !contentType.includes('text/html')) {
+        lastError = new Error(`HTTP ${response.status}, ${contentType || 'unknown content type'}`);
+      } else {
+        const html = await response.text();
+        if (marker && !html.includes(marker)) {
+          throw new CommandExecutionError(`Heidelberg page structure changed for ${url}: missing ${marker}`);
+        }
+        return { html, finalUrl: response.url };
+      }
+    } catch (error) {
+      lastError = error;
+      if (error instanceof CommandExecutionError) throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+    if (attempt < 2) await pause(500);
+  }
+  throw new CommandExecutionError(`Heidelberg request failed for ${url}: ${lastError?.message || 'unknown network error'}`);
+}
+
+function parseOptions(args) {
+  const degreeLevel = String(args['degree-level'] ?? 'all').toLowerCase();
+  if (!DEGREE_LEVELS.has(degreeLevel)) {
+    throw new ArgumentError(`--degree-level must be one of: ${[...DEGREE_LEVELS].join(', ')}`);
+  }
+  if (args.count === undefined || args.count === null || args.count === '') {
+    return { degreeLevel, count: null };
+  }
+  const count = Number(args.count);
+  if (!Number.isInteger(count) || count <= 0) {
+    throw new ArgumentError('--count must be a positive integer');
+  }
+  return { degreeLevel, count };
+}
+
+function extractWindowData(html) {
+  const marker = 'window.__DATA__ = ';
+  const start = html.indexOf(marker);
+  if (start === -1) throw new CommandExecutionError('Heidelberg catalogue changed: missing window.__DATA__');
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = start + marker.length; index < html.length; index += 1) {
+    const char = html[index];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') inString = true;
+    else if (char === '{') depth += 1;
+    else if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return JSON.parse(html.slice(start + marker.length, index + 1));
+    }
+  }
+  throw new CommandExecutionError('Heidelberg catalogue changed: unterminated window.__DATA__ JSON');
+}
+
+function catalogueTable(data) {
+  const root = data.ROOT_QUERY || {};
+  const key = Object.keys(root).find((candidate) => candidate.startsWith('studyFinderTable('));
+  const table = key ? root[key] : null;
+  if (!table?.tableRows?.length) throw new CommandExecutionError('Heidelberg catalogue changed: missing studyFinderTable rows');
+  return table;
+}
+
+function canonicalizeProgramUrl(value) {
+  const url = new URL(value, BASE);
+  if (url.hostname !== 'www.uni-heidelberg.de' || !url.pathname.startsWith('/en/study/all-subjects/')) {
+    return '';
+  }
+  url.protocol = 'https:';
+  url.search = '';
+  url.hash = '';
+  url.pathname = url.pathname.replace(/\/+$/, '');
+  return url.href;
+}
+
+function classifyVariant(variantName, degree = '') {
+  const haystack = `${variantName} ${degree}`.toLowerCase();
+  const tags = new Set();
+  if (haystack.includes('master') || haystack.includes('magister') || haystack.includes('ll.m')) tags.add('masters');
+  if (haystack.includes('certificate')) tags.add('certificate');
+  if (haystack.includes('diploma')) tags.add('diploma');
+  if (haystack.includes('doctor') || haystack.includes('ph.d') || haystack.includes('phd')) tags.add('doctorate');
+  return [...tags];
+}
+
+function startFromVariant(variant) {
+  if (variant.winterSemester === '1' && variant.summerSemester === '1') return 'Winter semester | Summer semester';
+  if (variant.winterSemester === '1') return 'Winter semester only';
+  if (variant.summerSemester === '1') return 'Summer semester only';
+  return '';
+}
+
+function parseCatalogue(html) {
+  const table = catalogueTable(extractWindowData(html));
+  const programs = [];
+  const seen = new Set();
+  for (const row of table.tableRows) {
+    const cells = (row.rowCells || []).map((cell) => cell.rowCellData || '');
+    const [subject, subjectPath, variantsJson, scienceArea,,,, faculty] = cells;
+    if (!subject || !variantsJson) continue;
+    let variants;
+    try {
+      variants = JSON.parse(variantsJson);
+    } catch {
+      continue;
+    }
+    for (const variant of variants) {
+      const tags = classifyVariant(variant.name);
+      if (!tags.length) continue;
+      const url = canonicalizeProgramUrl(variant.path);
+      if (!url || seen.has(url)) continue;
+      seen.add(url);
+      programs.push({
+        subject: text(subject),
+        subjectUrl: canonicalizeProgramUrl(subjectPath),
+        url,
+        variantName: text(variant.name),
+        tags,
+        scienceArea: text(scienceArea),
+        faculty: text(faculty),
+        properties: variant.furtherProperties || [],
+        start: startFromVariant(variant),
+      });
+    }
+  }
+  if (!programs.length) throw new CommandExecutionError('Heidelberg catalogue parser found no non-bachelor programs');
+  return programs;
+}
+
+function extractFacts(html) {
+  const facts = {};
+  const rows = html.match(/<tr\b[^>]*>[\s\S]*?<\/tr>/gi) || [];
+  for (const row of rows) {
+    const cells = [...row.matchAll(/<td\b[^>]*>([\s\S]*?)<\/td>/gi)].map((match) => text(match[1]));
+    if (cells.length >= 2) facts[cells[0].toLowerCase()] = cells[1];
+  }
+  return facts;
+}
+
+function fact(facts, startsWith) {
+  const wanted = startsWith.toLowerCase();
+  const key = Object.keys(facts).find((candidate) => candidate.startsWith(wanted));
+  return key ? facts[key] : '';
+}
+
+function durationMonths(standardPeriod) {
+  const semesters = standardPeriod.match(/(\d+(?:\.\d+)?)\s+semesters?/i)?.[1];
+  return semesters ? String(Number(semesters) * 6) : '';
+}
+
+function totalFees(fees = '', duration = '') {
+  const perSemester = fees.match(/(\d+(?:[.,]\d+)?)\s*€\s*\/\s*semester/i)?.[1];
+  const months = Number(duration);
+  if (!perSemester || !Number.isFinite(months) || months <= 0) return '';
+  const total = Number(perSemester.replace(',', '.')) * (months / 6);
+  return `${total.toFixed(2)} € (official semester contribution over standard period)`;
+}
+
+async function enrichProgram(program) {
+  try {
+    const { html, finalUrl } = await fetchHtml(program.url, 'Facts & Formalities');
+    const facts = extractFacts(html);
+    const degree = fact(facts, 'degree');
+    return {
+      ...program,
+      url: canonicalizeProgramUrl(finalUrl) || program.url,
+      degree: degree || program.variantName,
+      type: fact(facts, 'type of programme'),
+      start: fact(facts, 'start of programme') || program.start,
+      duration: durationMonths(fact(facts, 'standard period of study')),
+      language: fact(facts, 'language(s) of instruction'),
+      fees: fact(facts, 'fees and contributions'),
+      application: fact(facts, 'application procedure'),
+      deadlines: fact(facts, 'application deadlines'),
+      detailError: '',
+      tags: classifyVariant(program.variantName, degree || program.variantName),
+    };
+  } catch (error) {
+    return {
+      ...program,
+      degree: program.variantName,
+      type: '',
+      duration: '',
+      language: '',
+      fees: '',
+      application: '',
+      deadlines: '',
+      detailError: error.message,
+    };
+  }
+}
+
+async function enrichPrograms(programs) {
+  const rows = [];
+  for (let index = 0; index < programs.length; index += DETAIL_CONCURRENCY) {
+    rows.push(...await Promise.all(programs.slice(index, index + DETAIL_CONCURRENCY).map(enrichProgram)));
+  }
+  return rows;
+}
+
+function normalizeRecord(program) {
+  const row = Object.fromEntries(COLUMNS.map((column) => [column, '']));
+  const remarks = [
+    `Checked ${CHECKED_DATE}; official Heidelberg study-finder and programme-detail pages.`,
+    program.language ? `Language(s) of instruction: ${program.language}` : '',
+    program.application ? `Application procedure: ${program.application}` : '',
+    program.detailError ? `Detail page fields unavailable: ${program.detailError}` : '',
+  ].filter(Boolean);
+  const studyOptions = [
+    program.properties.includes('part_time_option') ? 'Part-time option' : '',
+    program.properties.includes('subject_completely_in_english') ? 'Can be completed entirely in English' : '',
+    program.properties.includes('international_subject') ? 'International degree program' : '',
+  ].filter(Boolean);
+
+  row['Course Name'] = `${program.subject} - ${program.variantName}`;
+  row['Course URL'] = program.url;
+  row['University \nname'] = UNIVERSITY;
+  row['Intake Month'] = program.start;
+  row['Substream/\nSpecialisation'] = [program.scienceArea, program.faculty].filter(Boolean).join(' | ');
+  row['Degree Level'] = program.degree;
+  row['Study Level'] = 'PG';
+  row['Duration\n(in months)'] = program.duration;
+  row['Study option'] = [program.language ? `Teaching language: ${program.language}` : '', ...studyOptions].filter(Boolean).join(' | ');
+  row['Program Type'] = program.type || program.variantName;
+  row['Tution fees \n(per year)'] = program.fees;
+  row['Total Tution \nFees'] = totalFees(program.fees, program.duration);
+  row['Main Entry \nRequirements'] = program.application;
+  row['Status'] = 'Official listing active';
+  row['Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)'] = program.deadlines;
+  row['Remarks (if any)'] = remarks.join(' | ');
+  row['Reference Links (if any)'] = `Course: ${program.url} | Catalogue: ${CATALOGUE_URL}`;
+  const unavailable = 'Not available on official Heidelberg study-finder/detail page';
+  for (const column of [
+    'Substream/\nSpecialisation',
+    'Study option',
+    'App fees',
+    'Partner',
+    'IELTS \n(Overall & Subscores)',
+    'ielts_reading_score',
+    'ielts_writing_score',
+    'ielts_listening_score',
+    'ielts_speaking_score',
+    'TOEFL\n(Overall & Subscores)',
+    'toefl_reading_score',
+    'toefl_writing_score',
+    'toefl_listening_score',
+    'toefl_speaking_score',
+    'PTE\n(Overall & Subscores)',
+    'pte_reading_score',
+    'pte_writing_score',
+    'pte_listening_score',
+    'pte_speaking_score',
+    'Duolingo\n(Overall & Subscores)',
+    'duolingo_comprehension_score',
+    'duolingo_literacy_score',
+    'duolingo_conversation_score',
+    'duolingo_production_score',
+    'Is Waiver \nProvided?',
+    'Waiver Info',
+    'Is MOI \naccepted?',
+    'Share list, if any',
+    'GRE Required',
+    'GMAT Required',
+    'GRE/GMAT Scores',
+    '12th scores',
+    'Min UG score',
+    '15 years of\nEducation Allowed?',
+    'Gap Years',
+    'Backlogs',
+    'Work \nExperience \nRequired?',
+  ]) if (!row[column]) row[column] = column === 'Partner' ? 'Not applicable unless listed by official programme source' : unavailable;
+  return row;
+}
+
+function validateRecord(row) {
+  for (const column of ['Course Name', 'Course URL', 'University \nname', 'Degree Level', 'Study Level', 'Reference Links (if any)']) {
+    if (!row[column]?.trim()) throw new CommandExecutionError(`Heidelberg row is missing required field: ${column}`);
+  }
+  if (!/^https:\/\/www\.uni-heidelberg\.de\/en\/study\/all-subjects\//.test(row['Course URL'])) {
+    throw new CommandExecutionError(`Heidelberg row has invalid course URL: ${row['Course URL']}`);
+  }
+  if (row['Study Level'] !== 'PG') throw new CommandExecutionError('Heidelberg row Study Level must be PG');
+  return row;
+}
+
+cli({
+  site: 'heidelberg',
+  name: 'export-postgraduate-courses',
+  description: 'Export Heidelberg University non-bachelor/postgraduate programs using the official study finder.',
+  access: 'read',
+  example: 'webcmd heidelberg export-postgraduate-courses --degree-level masters --count 10 -f csv',
+  domain: 'www.uni-heidelberg.de',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'degree-level', type: 'string', default: 'all', help: 'all, masters, certificate, diploma, professional, or doctorate' },
+    { name: 'count', type: 'int', required: false, help: 'Positive maximum number of programs after filtering and deduplication' },
+  ],
+  columns: OUTPUT_COLUMNS,
+  func: async (args) => {
+    const { degreeLevel, count } = parseOptions(args);
+    const { html } = await fetchHtml(CATALOGUE_URL, 'studyFinderTable');
+    const filtered = parseCatalogue(html)
+      .filter((program) => degreeLevel === 'all' || program.tags.includes(degreeLevel));
+    const enriched = await enrichPrograms(filtered);
+    const selected = enriched
+      .filter((program) => !/^undergraduate$/i.test(program.type))
+      .slice(0, count === null ? undefined : count);
+    return selected.map((program) => {
+      const row = validateRecord(normalizeRecord(program));
+      return CSV_OUTPUT
+        ? Object.fromEntries(COLUMNS.map((column, index) => [OUTPUT_COLUMNS[index], row[column]]))
+        : row;
+    });
+  },
+});

--- a/plugins/heidelberg/package.json
+++ b/plugins/heidelberg/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "webcmd-plugin-heidelberg",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Heidelberg University postgraduate course export adapter",
+  "peerDependencies": {
+    "@agentrhq/webcmd": ">=0.5.2"
+  }
+}

--- a/plugins/heidelberg/webcmd-plugin.json
+++ b/plugins/heidelberg/webcmd-plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "heidelberg",
+  "version": "0.1.0",
+  "description": "Heidelberg University postgraduate course export adapter",
+  "webcmd": ">=0.5.2",
+  "author": {
+    "name": "WebCMD Agent",
+    "handle": "agentrhq"
+  }
+}

--- a/plugins/hft/README.md
+++ b/plugins/hft/README.md
@@ -1,0 +1,22 @@
+# webcmd-plugin-hft
+
+HFT Stuttgart postgraduate course export adapter.
+
+## Install
+
+```bash
+webcmd plugin install github:agentrhq/webcmd/plugins/hft
+```
+
+## Command
+
+| Command | Description |
+| --- | --- |
+| `webcmd hft export-postgraduate-courses --count 10 -f csv` | Export postgraduate courses in the shared 52-column CSV schema |
+
+## Examples
+
+```bash
+webcmd hft export-postgraduate-courses --count 10 -f json
+webcmd hft export-postgraduate-courses --degree-level masters -f csv
+```

--- a/plugins/hft/export-postgraduate-courses.js
+++ b/plugins/hft/export-postgraduate-courses.js
@@ -1,0 +1,415 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import {
+  ArgumentError,
+  CommandExecutionError,
+} from '@agentrhq/webcmd/errors';
+import { resolve4 } from 'node:dns/promises';
+import { Agent } from 'undici';
+
+const BASE = 'https://www.hft-stuttgart.de';
+const CATALOGUE_URL = `${BASE}/`;
+const APPLICATION_URL = `${BASE}/studium/bewerbung`;
+const INTERNATIONAL_URL = `${BASE}/studium/vor-dem-studium/studieninteressierte-aus-dem-ausland`;
+const UNIVERSITY = 'Hochschule für Technik Stuttgart';
+const CHECKED_DATE = '2026-08-03';
+const REQUEST_TIMEOUT_MS = 20000;
+const DETAIL_CONCURRENCY = 8;
+const DEGREE_LEVELS = new Set(['all', 'masters', 'certificate', 'diploma', 'professional', 'doctorate']);
+const DNS_DISPATCHER = new Agent({
+  connect: {
+    lookup(hostname, options, callback) {
+      resolve4(hostname).then(
+        (addresses) => options?.all
+          ? callback(null, addresses.map((address) => ({ address, family: 4 })))
+          : callback(null, addresses[0], 4),
+        callback,
+      );
+    },
+  },
+});
+
+const COLUMNS = [
+  'Course Name',
+  'Course URL',
+  'University \nname',
+  'Intake Month',
+  'Substream/\nSpecialisation',
+  'App fees',
+  'Degree Level',
+  'Study Level',
+  'Duration\n(in months)',
+  'Study option',
+  'Program Type',
+  'Partner',
+  'Tution fees \n(per year)',
+  'Total Tution \nFees',
+  'IELTS \n(Overall & Subscores)',
+  'ielts_reading_score',
+  'ielts_writing_score',
+  'ielts_listening_score',
+  'ielts_speaking_score',
+  'TOEFL\n(Overall & Subscores)',
+  'toefl_reading_score',
+  'toefl_writing_score',
+  'toefl_listening_score',
+  'toefl_speaking_score',
+  'PTE\n(Overall & Subscores)',
+  'pte_reading_score',
+  'pte_writing_score',
+  'pte_listening_score',
+  'pte_speaking_score',
+  'Duolingo\n(Overall & Subscores)',
+  'duolingo_comprehension_score',
+  'duolingo_literacy_score',
+  'duolingo_conversation_score',
+  'duolingo_production_score',
+  'Is Waiver \nProvided?',
+  'Waiver Info',
+  'Is MOI \naccepted?',
+  'Share list, if any',
+  'GRE Required',
+  'GMAT Required',
+  'GRE/GMAT Scores',
+  '12th scores',
+  'Min UG score',
+  '15 years of\nEducation Allowed?',
+  'Gap Years',
+  'Backlogs',
+  'Work \nExperience \nRequired?',
+  'Main Entry \nRequirements',
+  'Status',
+  'Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)',
+  'Remarks (if any)',
+  'Reference Links (if any)',
+];
+
+const CSV_OUTPUT = process.argv.some((arg, index, argv) =>
+  /^(?:-f|--format)=csv$/.test(arg) || ((arg === '-f' || arg === '--format') && argv[index + 1] === 'csv')
+);
+const OUTPUT_COLUMNS = CSV_OUTPUT
+  ? COLUMNS.map((column) => /[,"\r\n]/.test(column) ? `"${column.replace(/"/g, '""')}"` : column)
+  : COLUMNS;
+
+function pause(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function decodeHtml(value = '') {
+  return value
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([\da-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&apos;|&#0*39;|&rsquo;/gi, "'")
+    .replace(/&lsquo;/gi, "'")
+    .replace(/&ndash;|&mdash;/gi, '-')
+    .replace(/&euro;/gi, '€')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>');
+}
+
+function text(value = '') {
+  return decodeHtml(
+    value
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<br\s*\/?>/gi, ' | ')
+      .replace(/<\/(?:p|li|dd|dt|h[1-6])>/gi, ' | ')
+      .replace(/<[^>]+>/g, ' '),
+  ).replace(/\s*\|\s*/g, ' | ').replace(/\s+/g, ' ').replace(/(?: \|)+$/g, '').trim();
+}
+
+async function fetchHtml(url, marker = '<html') {
+  let lastError;
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    try {
+      const response = await fetch(url, {
+        headers: { 'User-Agent': 'Mozilla/5.0 (compatible; Webcmd HFT Stuttgart public data export)' },
+        redirect: 'follow',
+        dispatcher: DNS_DISPATCHER,
+        signal: controller.signal,
+      });
+      const contentType = response.headers.get('content-type') || '';
+      if (!response.ok || !contentType.includes('text/html')) {
+        lastError = new Error(`HTTP ${response.status}, ${contentType || 'unknown content type'}`);
+      } else {
+        const html = await response.text();
+        if (marker && !html.includes(marker)) {
+          throw new CommandExecutionError(`HFT page structure changed for ${url}: missing ${marker}`);
+        }
+        return { html, finalUrl: response.url };
+      }
+    } catch (error) {
+      lastError = error;
+      if (error instanceof CommandExecutionError) throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+    if (attempt < 2) await pause(500);
+  }
+  throw new CommandExecutionError(`HFT request failed for ${url}: ${lastError?.message || 'unknown network error'}`);
+}
+
+function parseOptions(args) {
+  const degreeLevel = String(args['degree-level'] ?? 'all').toLowerCase();
+  if (!DEGREE_LEVELS.has(degreeLevel)) {
+    throw new ArgumentError(`--degree-level must be one of: ${[...DEGREE_LEVELS].join(', ')}`);
+  }
+  if (args.count === undefined || args.count === null || args.count === '') {
+    return { degreeLevel, count: null };
+  }
+  const count = Number(args.count);
+  if (!Number.isInteger(count) || count <= 0) {
+    throw new ArgumentError('--count must be a positive integer');
+  }
+  return { degreeLevel, count };
+}
+
+function canonicalizeProgramUrl(value) {
+  const url = new URL(value, BASE);
+  if (url.hostname !== 'www.hft-stuttgart.de') return '';
+  url.protocol = 'https:';
+  url.search = '';
+  url.hash = '';
+  url.pathname = url.pathname.replace(/\/+$/, '') || '/';
+  return url.href;
+}
+
+function classifyCourse(name = '', degree = '') {
+  const haystack = `${name} ${degree}`.toLowerCase();
+  const tags = new Set();
+  if (haystack.includes('master') || haystack.includes('m.sc') || haystack.includes('m.a')) tags.add('masters');
+  if (haystack.includes('certificate')) tags.add('certificate');
+  if (haystack.includes('diploma')) tags.add('diploma');
+  if (haystack.includes('doctor') || haystack.includes('ph.d') || haystack.includes('phd')) tags.add('doctorate');
+  return [...tags];
+}
+
+function parseCatalogue(html) {
+  const courses = new Map();
+  const sections = html.match(/<section\b[^>]*class="[^"]*\bstudycourses\b[^"]*"[\s\S]*?<\/section>/gi) || [];
+  for (const section of sections) {
+    const area = text(section.match(/<h3\b[^>]*studycourses__header__title[^>]*>([\s\S]*?)<\/h3>/i)?.[1] || '');
+    const masterBlock = section.match(/<div\b[^>]*studycourses__wrapper--master[^>]*>([\s\S]*?)<\/ul>/i)?.[1] || '';
+    for (const match of masterBlock.matchAll(/<li\b[^>]*>\s*<a\b[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>([\s\S]*?)<\/li>/gi)) {
+      const url = canonicalizeProgramUrl(match[1]);
+      if (!url) continue;
+      const note = text(match[3]);
+      const existing = courses.get(url);
+      if (existing) {
+        if (area) existing.areas.add(area);
+        if (note) existing.notes.add(note);
+      } else {
+        courses.set(url, {
+          name: text(match[2]),
+          url,
+          areas: new Set(area ? [area] : []),
+          notes: new Set(note ? [note] : []),
+          tags: classifyCourse(text(match[2])),
+        });
+      }
+    }
+  }
+  const rows = [...courses.values()].map((course) => ({
+    ...course,
+    areas: [...course.areas],
+    notes: [...course.notes],
+  }));
+  if (!rows.length) throw new CommandExecutionError('HFT catalogue parser found no master programs');
+  return rows;
+}
+
+function quickInfo(html) {
+  const facts = {};
+  const section = html.match(/<section\b[^>]*aria-label="Studiengang Quick-Info"[\s\S]*?<\/section>/i)?.[0] || '';
+  for (const dl of section.matchAll(/<dl\b[^>]*>([\s\S]*?)<\/dl>/gi)) {
+    const key = text(dl[1].match(/<dt\b[^>]*>([\s\S]*?)<\/dt>/i)?.[1] || '').toLowerCase();
+    const value = [...dl[1].matchAll(/<dd\b[^>]*>([\s\S]*?)<\/dd>/gi)].map((match) => text(match[1])).filter(Boolean).join(' | ');
+    if (key && value) facts[key] = value;
+  }
+  return facts;
+}
+
+function pageTitle(html) {
+  return text(html.match(/<h1\b[^>]*>([\s\S]*?)<\/h1>/i)?.[1] || '');
+}
+
+function monthsFromDuration(value = '') {
+  const fullTime = value.match(/(\d+(?:[.,]\d+)?)\s*Semester/i)?.[1];
+  return fullTime ? String(Number(fullTime.replace(',', '.')) * 6) : '';
+}
+
+function intakeFromApplication(value = '') {
+  const parts = [];
+  if (/Sommersemester/i.test(value)) parts.push('Summer semester');
+  if (/Wintersemester/i.test(value)) parts.push('Winter semester');
+  return parts.join(' | ');
+}
+
+function isReplacedLegacyCourse(course, application = '') {
+  return /\/imiad$/.test(course.url) && /ab 2026 wird der IMIAD .*Master Innenarchitektur/i.test(application);
+}
+
+function isEnglishTaught(course) {
+  return /^(Photogrammetry and Geoinformatics|Software Technology|International Project Management|Smart City Solutions)$/i.test(course.catalogueName || course.name);
+}
+
+async function enrichCourse(course) {
+  try {
+    const { html, finalUrl } = await fetchHtml(course.url, 'Studiengang Quick-Info');
+    const facts = quickInfo(html);
+    const degree = facts.abschluss || '';
+    const application = facts.bewerbung || '';
+    return {
+      ...course,
+      catalogueName: course.name,
+      name: pageTitle(html) || course.name,
+      url: canonicalizeProgramUrl(finalUrl) || course.url,
+      degree: degree || 'Master',
+      duration: monthsFromDuration(facts.regelstudienzeit || ''),
+      studyOption: facts.regelstudienzeit || '',
+      application,
+      intake: intakeFromApplication(application),
+      isReplaced: isReplacedLegacyCourse(course, application),
+      detailError: '',
+      tags: classifyCourse(course.name, degree || 'Master'),
+    };
+  } catch (error) {
+    return {
+      ...course,
+      degree: 'Master',
+      duration: '',
+      studyOption: '',
+      application: '',
+      intake: '',
+      isReplaced: false,
+      detailError: error.message,
+      tags: classifyCourse(course.name, 'Master'),
+    };
+  }
+}
+
+async function enrichCourses(courses) {
+  const rows = [];
+  for (let index = 0; index < courses.length; index += DETAIL_CONCURRENCY) {
+    rows.push(...await Promise.all(courses.slice(index, index + DETAIL_CONCURRENCY).map(enrichCourse)));
+  }
+  return rows;
+}
+
+function normalizeRecord(course) {
+  const row = Object.fromEntries(COLUMNS.map((column) => [column, '']));
+  const remarks = [
+    `Checked ${CHECKED_DATE}; official HFT Stuttgart catalogue and programme-detail pages.`,
+    course.notes.length ? `Cross-listed: ${course.notes.join(' | ')}` : '',
+    course.detailError ? `Detail page fields unavailable: ${course.detailError}` : '',
+  ].filter(Boolean);
+
+  row['Course Name'] = course.name;
+  row['Course URL'] = course.url;
+  row['University \nname'] = UNIVERSITY;
+  row['Intake Month'] = course.intake;
+  row['Substream/\nSpecialisation'] = course.areas.join(' | ');
+  row['Degree Level'] = course.degree;
+  row['Study Level'] = 'PG';
+  row['Duration\n(in months)'] = course.duration;
+  row['Study option'] = [
+    course.studyOption,
+    `Teaching language: ${isEnglishTaught(course) ? 'English' : 'German'}`,
+  ].filter(Boolean).join(' | ');
+  row['Program Type'] = 'Master';
+  row['Tution fees \n(per year)'] = '€3,000/year for international students outside the EU; not available as a single value on official programme page for other residence statuses';
+  row['Total Tution \nFees'] = 'Not available as a single value on official programme page';
+  row['IELTS \n(Overall & Subscores)'] = isEnglishTaught(course)
+    ? 'Not available as a single value on official programme page'
+    : 'Not applicable; programme is taught in German';
+  row['Main Entry \nRequirements'] = course.application;
+  row['Status'] = 'Official listing active';
+  row['Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)'] = course.application;
+  row['Remarks (if any)'] = [...remarks, 'Application fees, score thresholds, waivers, and MOI acceptance are not available in the official shared or programme pages.'].join(' | ');
+  row['Reference Links (if any)'] = `Course: ${course.url} | Catalogue: ${CATALOGUE_URL}#c6490 | Application: ${APPLICATION_URL} | International applicants/fees and language proof: ${INTERNATIONAL_URL}`;
+  const unavailable = 'Not available on official HFT shared/programme pages';
+  for (const column of [
+    'Intake Month',
+    'App fees',
+    'Partner',
+    'ielts_reading_score',
+    'ielts_writing_score',
+    'ielts_listening_score',
+    'ielts_speaking_score',
+    'TOEFL\n(Overall & Subscores)',
+    'toefl_reading_score',
+    'toefl_writing_score',
+    'toefl_listening_score',
+    'toefl_speaking_score',
+    'PTE\n(Overall & Subscores)',
+    'pte_reading_score',
+    'pte_writing_score',
+    'pte_listening_score',
+    'pte_speaking_score',
+    'Duolingo\n(Overall & Subscores)',
+    'duolingo_comprehension_score',
+    'duolingo_literacy_score',
+    'duolingo_conversation_score',
+    'duolingo_production_score',
+    'Is Waiver \nProvided?',
+    'Waiver Info',
+    'Is MOI \naccepted?',
+    'Share list, if any',
+    'GRE Required',
+    'GMAT Required',
+    'GRE/GMAT Scores',
+    '12th scores',
+    'Min UG score',
+    '15 years of\nEducation Allowed?',
+    'Gap Years',
+    'Backlogs',
+    'Work \nExperience \nRequired?',
+  ]) if (!row[column]) row[column] = column === 'Partner' ? 'Not applicable unless listed by official programme source' : unavailable;
+  return row;
+}
+
+function validateRecord(row) {
+  for (const column of ['Course Name', 'Course URL', 'University \nname', 'Degree Level', 'Study Level', 'Reference Links (if any)']) {
+    if (!row[column]?.trim()) throw new CommandExecutionError(`HFT row is missing required field: ${column}`);
+  }
+  if (!/^https:\/\/www\.hft-stuttgart\.de\//.test(row['Course URL'])) {
+    throw new CommandExecutionError(`HFT row has invalid course URL: ${row['Course URL']}`);
+  }
+  if (row['Study Level'] !== 'PG') throw new CommandExecutionError('HFT row Study Level must be PG');
+  return row;
+}
+
+cli({
+  site: 'hft',
+  name: 'export-postgraduate-courses',
+  description: 'Export HFT Stuttgart postgraduate programs using the official public programme pages.',
+  access: 'read',
+  example: 'webcmd hft export-postgraduate-courses --degree-level masters --count 10 -f csv',
+  domain: 'www.hft-stuttgart.de',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'degree-level', type: 'string', default: 'all', help: 'all, masters, certificate, diploma, professional, or doctorate' },
+    { name: 'count', type: 'int', required: false, help: 'Positive maximum number of programs after filtering and deduplication' },
+  ],
+  columns: OUTPUT_COLUMNS,
+  func: async (args) => {
+    const { degreeLevel, count } = parseOptions(args);
+    const { html } = await fetchHtml(CATALOGUE_URL, '15 Bachelor- und 21 Masterstudiengänge');
+    const filtered = parseCatalogue(html)
+      .filter((course) => degreeLevel === 'all' || course.tags.includes(degreeLevel));
+    const selected = (await enrichCourses(filtered))
+      .filter((course) => !course.isReplaced)
+      .slice(0, count === null ? undefined : count);
+    return selected.map((course) => {
+      const row = validateRecord(normalizeRecord(course));
+      return CSV_OUTPUT
+        ? Object.fromEntries(COLUMNS.map((column, index) => [OUTPUT_COLUMNS[index], row[column]]))
+        : row;
+    });
+  },
+});

--- a/plugins/hft/export-postgraduate-courses.js
+++ b/plugins/hft/export-postgraduate-courses.js
@@ -237,6 +237,23 @@ function pageTitle(html) {
   return text(html.match(/<h1\b[^>]*>([\s\S]*?)<\/h1>/i)?.[1] || '');
 }
 
+function detailSections(html) {
+  const sections = [];
+  for (const match of html.matchAll(/<div class="foldable-text-teaser">([\s\S]*?)<\/article>\s*<\/div>/gi)) {
+    const header = text(match[1].match(/<h[2-4]\b[^>]*content__wrapper__header[^>]*>([\s\S]*?)<\/h[2-4]>/i)?.[1] || '');
+    const body = text(match[1].match(/<div\b[^>]*content__foldable-text__content[^>]*>([\s\S]*?)<\/div>/i)?.[1] || '');
+    if (header && body) sections.push({ header, body });
+  }
+  return sections;
+}
+
+function entryRequirements(html) {
+  const picked = detailSections(html)
+    .filter(({ header }) => /zulassung|voraussetzung|admission|requirement/i.test(header))
+    .map(({ header, body }) => `${header}: ${body}`);
+  return picked.join(' | ');
+}
+
 function monthsFromDuration(value = '') {
   const fullTime = value.match(/(\d+(?:[.,]\d+)?)\s*Semester/i)?.[1];
   return fullTime ? String(Number(fullTime.replace(',', '.')) * 6) : '';
@@ -272,6 +289,7 @@ async function enrichCourse(course) {
       duration: monthsFromDuration(facts.regelstudienzeit || ''),
       studyOption: facts.regelstudienzeit || '',
       application,
+      entryRequirements: entryRequirements(html),
       intake: intakeFromApplication(application),
       isReplaced: isReplacedLegacyCourse(course, application),
       detailError: '',
@@ -284,6 +302,7 @@ async function enrichCourse(course) {
       duration: '',
       studyOption: '',
       application: '',
+      entryRequirements: '',
       intake: '',
       isReplaced: false,
       detailError: error.message,
@@ -326,7 +345,7 @@ function normalizeRecord(course) {
   row['IELTS \n(Overall & Subscores)'] = isEnglishTaught(course)
     ? 'Not available as a single value on official programme page'
     : 'Not applicable; programme is taught in German';
-  row['Main Entry \nRequirements'] = course.application;
+  row['Main Entry \nRequirements'] = course.entryRequirements || 'Not available on official HFT programme page';
   row['Status'] = 'Official listing active';
   row['Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)'] = course.application;
   row['Remarks (if any)'] = [...remarks, 'Application fees, score thresholds, waivers, and MOI acceptance are not available in the official shared or programme pages.'].join(' | ');

--- a/plugins/hft/package.json
+++ b/plugins/hft/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "webcmd-plugin-hft",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "HFT Stuttgart postgraduate course export adapter",
+  "peerDependencies": {
+    "@agentrhq/webcmd": ">=0.5.2"
+  }
+}

--- a/plugins/hft/webcmd-plugin.json
+++ b/plugins/hft/webcmd-plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "hft",
+  "version": "0.1.0",
+  "description": "HFT Stuttgart postgraduate course export adapter",
+  "webcmd": ">=0.5.2",
+  "author": {
+    "name": "WebCMD Agent",
+    "handle": "agentrhq"
+  }
+}

--- a/plugins/iit/README.md
+++ b/plugins/iit/README.md
@@ -1,0 +1,22 @@
+# webcmd-plugin-iit
+
+Illinois Institute of Technology postgraduate course export adapter.
+
+## Install
+
+```bash
+webcmd plugin install github:agentrhq/webcmd/plugins/iit
+```
+
+## Command
+
+| Command | Description |
+| --- | --- |
+| `webcmd iit export-postgraduate-courses --count 10 -f csv` | Export postgraduate courses in the shared 52-column CSV schema |
+
+## Examples
+
+```bash
+webcmd iit export-postgraduate-courses --count 10 -f json
+webcmd iit export-postgraduate-courses --degree-level masters -f csv
+```

--- a/plugins/iit/export-postgraduate-courses.js
+++ b/plugins/iit/export-postgraduate-courses.js
@@ -1,0 +1,591 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import {
+  ArgumentError,
+  CommandExecutionError,
+} from '@agentrhq/webcmd/errors';
+
+const BASE = 'https://www.iit.edu';
+const CATALOGUE_URL = `${BASE}/academics/programs`;
+const UNIVERSITY = 'Illinois Institute of Technology';
+const CHECKED_DATE = '2026-08-03';
+const REQUEST_TIMEOUT_MS = 15000;
+const MAX_ATTEMPTS = 5;
+const RETRY_DELAY_MS = 1000;
+const SOURCES = {
+  admission: `${BASE}/admissions-aid/graduate-admission`,
+  howToApply: `${BASE}/admissions-aid/graduate-admission/how-apply`,
+  applicationFee: `${BASE}/admissions-aid/graduate-admission/domestic-students/admission-requirements-and-checklist`,
+  english: `${BASE}/admissions-aid/graduate-admission/international-students/admission-and-english-language-requirements`,
+  tuition: `${BASE}/student-accounting/tuition-and-fees/future-tuition-and-fees/mies-campus-graduate`,
+  deadlines: `${BASE}/admissions-aid/graduate-admission/admission-dates-and-deadlines`,
+  law: 'https://kentlaw.iit.edu/law/admissions/jd-admissions/application-process',
+  architecture: 'https://arch.iit.edu/admissions/graduate/',
+  design: 'https://id.iit.edu/graduate-school/apply/',
+};
+const DEGREE_LEVELS = new Set([
+  'all',
+  'masters',
+  'certificate',
+  'diploma',
+  'professional',
+  'doctorate',
+]);
+
+const COLUMNS = [
+  'Course Name',
+  'Course URL',
+  'University \nname',
+  'Intake Month',
+  'Substream/\nSpecialisation',
+  'App fees',
+  'Degree Level',
+  'Study Level',
+  'Duration\n(in months)',
+  'Study option',
+  'Program Type',
+  'Partner',
+  'Tution fees \n(per year)',
+  'Total Tution \nFees',
+  'IELTS \n(Overall & Subscores)',
+  'ielts_reading_score',
+  'ielts_writing_score',
+  'ielts_listening_score',
+  'ielts_speaking_score',
+  'TOEFL\n(Overall & Subscores)',
+  'toefl_reading_score',
+  'toefl_writing_score',
+  'toefl_listening_score',
+  'toefl_speaking_score',
+  'PTE\n(Overall & Subscores)',
+  'pte_reading_score',
+  'pte_writing_score',
+  'pte_listening_score',
+  'pte_speaking_score',
+  'Duolingo\n(Overall & Subscores)',
+  'duolingo_comprehension_score',
+  'duolingo_literacy_score',
+  'duolingo_conversation_score',
+  'duolingo_production_score',
+  'Is Waiver \nProvided?',
+  'Waiver Info',
+  'Is MOI \naccepted?',
+  'Share list, if any',
+  'GRE Required',
+  'GMAT Required',
+  'GRE/GMAT Scores',
+  '12th scores',
+  'Min UG score',
+  '15 years of\nEducation Allowed?',
+  'Gap Years',
+  'Backlogs',
+  'Work \nExperience \nRequired?',
+  'Main Entry \nRequirements',
+  'Status',
+  'Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)',
+  'Remarks (if any)',
+  'Reference Links (if any)',
+];
+
+const CSV_OUTPUT = process.argv.some((arg, index, argv) =>
+  /^(?:-f|--format)=csv$/.test(arg) || ((arg === '-f' || arg === '--format') && argv[index + 1] === 'csv')
+);
+const OUTPUT_COLUMNS = CSV_OUTPUT
+  ? COLUMNS.map((column) => /[,"\r\n]/.test(column) ? `"${column.replace(/"/g, '""')}"` : column)
+  : COLUMNS;
+
+function decodeHtml(value = '') {
+  return value
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([\da-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&apos;|&#0*39;/gi, "'")
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>');
+}
+
+function text(value = '') {
+  return decodeHtml(
+    value
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<[^>]+>/g, ' '),
+  ).replace(/\s+/g, ' ').trim();
+}
+
+function sectionHtmlAfterLabel(block, label) {
+  const match = block.match(new RegExp(`<h3[^>]*>\\s*${label}\\s*<\\/h3>([\\s\\S]*?)(?=<div class=['"]cell|<div class=['"]program-large-list|$)`, 'i'));
+  return match?.[1] || '';
+}
+
+function sectionAfterLabel(block, label) {
+  return text(sectionHtmlAfterLabel(block, label));
+}
+
+function sectionListAfterLabel(block, label) {
+  const raw = sectionHtmlAfterLabel(block, label);
+  const items = [...raw.matchAll(/<li[^>]*>([\s\S]*?)<\/li>/gi)].map((match) => text(match[1])).filter(Boolean);
+  return items.length ? items : [text(raw)].filter(Boolean);
+}
+
+async function fetchHtml(url, marker = '<html') {
+  let lastError;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    let response;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    try {
+      response = await fetch(url, {
+        headers: { 'User-Agent': 'Mozilla/5.0 (compatible; Webcmd IIT public data export)' },
+        redirect: 'follow',
+        signal: controller.signal,
+      });
+    } catch (error) {
+      clearTimeout(timeout);
+      lastError = error;
+      if (attempt === MAX_ATTEMPTS) break;
+      await pause(attempt * RETRY_DELAY_MS);
+      continue;
+    }
+    const contentType = response.headers.get('content-type') || '';
+    if (!response.ok || !contentType.includes('text/html')) {
+      clearTimeout(timeout);
+      lastError = new Error(`HTTP ${response.status}, ${contentType || 'unknown content type'}`);
+      if (!([429].includes(response.status) || response.status >= 500) || attempt === MAX_ATTEMPTS) break;
+      await pause(attempt * RETRY_DELAY_MS);
+      continue;
+    }
+    let html;
+    try {
+      html = await response.text();
+      clearTimeout(timeout);
+    } catch (error) {
+      clearTimeout(timeout);
+      lastError = error;
+      if (attempt === MAX_ATTEMPTS) break;
+      await pause(attempt * RETRY_DELAY_MS);
+      continue;
+    }
+    if (marker && !html.includes(marker)) {
+      throw new CommandExecutionError(`IIT page structure changed for ${url}: missing ${marker}`);
+    }
+    return { html, finalUrl: response.url };
+  }
+  throw new CommandExecutionError(`IIT request failed for ${url}: ${lastError?.message || 'unknown network error'}`);
+}
+
+function pause(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseOptions(args) {
+  const degreeLevel = String(args['degree-level'] ?? 'all').toLowerCase();
+  if (!DEGREE_LEVELS.has(degreeLevel)) {
+    throw new ArgumentError(`--degree-level must be one of: ${[...DEGREE_LEVELS].join(', ')}`);
+  }
+  if (args.count === undefined || args.count === null || args.count === '') {
+    return { degreeLevel, count: null };
+  }
+  const count = Number(args.count);
+  if (!Number.isInteger(count) || count <= 0) {
+    throw new ArgumentError('--count must be a positive integer');
+  }
+  return { degreeLevel, count };
+}
+
+function canonicalizeProgramUrl(value) {
+  const url = new URL(value, BASE);
+  if (url.hostname !== 'www.iit.edu' || !url.pathname.startsWith('/academics/programs/')) {
+    return '';
+  }
+  url.protocol = 'https:';
+  url.search = '';
+  url.hash = '';
+  url.pathname = url.pathname.replace(/\/+$/, '');
+  return url.href;
+}
+
+function classifyDegree(program) {
+  const type = program.programType.toLowerCase();
+  const degree = program.degree.toLowerCase();
+  const tags = new Set();
+  if (type.includes('master')) tags.add('masters');
+  if (type.includes('certificate') || degree.includes('certificate')) tags.add('certificate');
+  if (type.includes('diploma') || degree.includes('diploma')) tags.add('diploma');
+  if (degree.includes('j.d.') && type.includes('master')) {
+    tags.add('professional');
+    tags.add('masters');
+  } else if (/^j\.d\.?$/.test(degree)) {
+    tags.add('professional');
+  } else if (type.includes('doctoral')) {
+    tags.add('doctorate');
+  }
+  return [...tags];
+}
+
+function parseCatalogue(html) {
+  const rows = [];
+  const seen = new Set();
+  const blocks = html.match(/<article class=['"][^'"]*program-large-list[^'"]*['"][^>]*>[\s\S]*?<\/article>/gi) || [];
+  for (const block of blocks) {
+    const link = block.match(/<h2[^>]*>[\s\S]*?<a\s+href=['"]([^'"]+)['"][^>]*>([\s\S]*?)<\/a>/i);
+    if (!link) continue;
+    const programUrl = canonicalizeProgramUrl(link[1]);
+    if (!programUrl) continue;
+    const program = {
+      url: programUrl,
+      name: text(link[2]),
+      programType: sectionAfterLabel(block, 'Program Type'),
+      degree: sectionAfterLabel(block, 'Degree'),
+      college: sectionAfterLabel(block, 'College/School'),
+      locations: sectionListAfterLabel(block, 'Program Location'),
+    };
+    program.tags = classifyDegree(program);
+    if (!program.name || !program.programType || !program.degree || !program.tags.length || seen.has(program.url)) continue;
+    seen.add(program.url);
+    rows.push(program);
+  }
+  if (!blocks.length || !rows.length) {
+    throw new CommandExecutionError('IIT catalogue parser found no postgraduate program cards');
+  }
+  return rows;
+}
+
+async function discoverPrograms(degreeLevel) {
+  const { html } = await fetchHtml(CATALOGUE_URL, 'program-large-list');
+  const programs = parseCatalogue(html);
+  const filtered = degreeLevel === 'all' ? programs : programs.filter((program) => program.tags.includes(degreeLevel));
+  return filtered;
+}
+
+function extractMeta(html, label) {
+  const match = html.match(new RegExp(`<dt[^>]*>\\s*${label}\\s*<\\/dt>\\s*<dd[^>]*>([\\s\\S]*?)<\\/dd>`, 'i'));
+  return text(match?.[1]);
+}
+
+function extractMetaList(html, label) {
+  const match = html.match(new RegExp(`<dt[^>]*>\\s*${label}\\s*<\\/dt>\\s*<dd[^>]*>([\\s\\S]*?)<\\/dd>`, 'i'));
+  const raw = match?.[1] || '';
+  const items = [...raw.matchAll(/<li[^>]*>([\s\S]*?)<\/li>/gi)].map((item) => text(item[1])).filter(Boolean);
+  return items.length ? items : [text(raw)].filter(Boolean);
+}
+
+function extractCatalogueDetailUrl(html) {
+  const match = html.match(/href=['"](https:\/\/catalog\.iit\.edu\/graduate\/[^'"]+)['"]/i);
+  return match ? decodeHtml(match[1]) : '';
+}
+
+function extractCredits(html) {
+  const plain = text(html);
+  const candidates = [
+    plain.match(/Minimum Credits Required\s+(\d{1,3})/i),
+    plain.match(/Minimum Degree Credits\s+(\d{1,3})/i),
+    plain.match(/Total Credit Hours\s+(\d{1,3})/i),
+    plain.match(/(?:degree program|program|degree)\s+(?:requires?|consists? of)\s+(?:at least\s+)?(\d{1,3})\s+credit hours/i),
+  ];
+  return Number(candidates.find(Boolean)?.[1] || 0);
+}
+
+function extractDurationMonths(plain) {
+  const months = plain.match(/(?:program|degree|complete|completion|duration)[^.]{0,80}?(\d{1,2})\s+months?/i);
+  if (months) return String(Number(months[1]));
+  const years = plain.match(/(?:program|degree|complete|completion|duration)[^.]{0,80}?(\d(?:\.5)?)\s+years?/i);
+  return years ? String(Number(years[1]) * 12) : '';
+}
+
+function extractProgramOverrides(plain) {
+  const gpa = plain.match(/(?:grade-point average|GPA)[^\d]{0,30}(\d\.\d(?:\/4\.0)?)/i)?.[1] || '';
+  const greRequired = /GRE is required|GRE scores? (?:are|is) required/i.test(plain)
+    ? 'Yes'
+    : /GRE is optional|GRE scores? (?:are|is) optional|does not require (?:the )?GRE/i.test(plain)
+      ? 'No'
+      : '';
+  const greScore = plain.match(/GRE[^.]{0,100}?(\d{3}\s+combined[^.]{0,60})/i)?.[1]?.trim() || '';
+  const studyOptions = [
+    /coursework only|traditional coursework/i.test(plain) ? 'Coursework Only' : '',
+    /master(?:’|'|&#039;)s project/i.test(plain) ? "Master's Project" : '',
+    /master(?:’|'|&#039;)s thesis|thesis conducted/i.test(plain) ? "Master's Thesis" : '',
+  ].filter(Boolean);
+  const status = /program (?:is|has been) discontinued/i.test(plain)
+    ? 'Discontinued'
+    : /program (?:is|has been) suspended/i.test(plain)
+      ? 'Suspended'
+      : '';
+  return { gpa, greRequired, greScore, studyOptions, status };
+}
+
+async function extractProgram(program) {
+  let html;
+  let finalUrl;
+  try {
+    ({ html, finalUrl } = await fetchHtml(program.url, '<h1'));
+  } catch (error) {
+    return {
+      ...program,
+      durationMonths: '',
+      catalogueDetailUrl: '',
+      credits: 0,
+      gpa: '',
+      greRequired: '',
+      greScore: '',
+      studyOptions: [],
+      status: '',
+      detailError: error.message,
+    };
+  }
+  const canonicalFinalUrl = canonicalizeProgramUrl(finalUrl);
+  if (!canonicalFinalUrl) return null;
+  const mainHtml = html.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ');
+  const h1 = mainHtml.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  const name = text(h1?.[1]);
+  const degree = extractMeta(mainHtml, 'Degree') || program.degree;
+  const programType = extractMeta(mainHtml, 'Program Type') || program.programType;
+  if (!name || !degree || !programType) {
+    throw new CommandExecutionError(`IIT program parser could not read identity fields from ${program.url}`);
+  }
+  const plain = text(mainHtml);
+  let catalogueDetailUrl = extractCatalogueDetailUrl(mainHtml);
+  let credits = 0;
+  if (catalogueDetailUrl) {
+    try {
+      const catalogueDetail = await fetchHtml(catalogueDetailUrl, '<html');
+      credits = extractCredits(catalogueDetail.html);
+    } catch (error) {
+      catalogueDetailUrl = '';
+      if (!/HTTP 404/.test(error.message)) {
+        program.curriculumError = error.message;
+      }
+    }
+  }
+  return {
+    ...program,
+    name,
+    degree,
+    programType,
+    college: extractMeta(mainHtml, 'College') || program.college,
+    locations: extractMetaList(mainHtml, 'Program Location').length
+      ? extractMetaList(mainHtml, 'Program Location')
+      : program.locations,
+    durationMonths: extractDurationMonths(plain),
+    catalogueDetailUrl,
+    credits,
+    curriculumError: program.curriculumError || '',
+    ...extractProgramOverrides(plain),
+    url: canonicalFinalUrl,
+  };
+}
+
+async function extractAllPrograms(programs) {
+  const details = [];
+  for (let index = 0; index < programs.length; index += 64) {
+    details.push(...await Promise.all(programs.slice(index, index + 64).map(extractProgram)));
+  }
+  return details;
+}
+
+async function fetchSharedSource(url, requiredMarkers = []) {
+  const result = await fetchHtml(url, '<html');
+  for (const marker of requiredMarkers) {
+    if (!result.html.includes(marker)) {
+      throw new CommandExecutionError(`IIT shared source changed for ${url}: missing ${marker}`);
+    }
+  }
+  return result.html;
+}
+
+async function extractSharedRequirements() {
+  const [admission, howToApply, applicationFee, english, tuition, deadlines, law, architecture, design] = await Promise.all([
+    fetchSharedSource(SOURCES.admission, ['3.0', 'GRE']),
+    fetchSharedSource(SOURCES.howToApply, ['Official Transcripts', 'GRE Testing']),
+    fetchSharedSource(SOURCES.applicationFee, ['$100', 'application fee']),
+    fetchSharedSource(SOURCES.english, ['TOEFL iBT', 'IELTS', 'Duolingo English Test']),
+    fetchSharedSource(SOURCES.tuition, ['$1,925', '2026–2027']),
+    fetchSharedSource(SOURCES.deadlines, ['Fall Term', 'Spring Term', 'June 15', 'November 15']),
+    fetchSharedSource(SOURCES.law, ['Priority Application Deadline', 'LSAT or GRE']),
+    fetchSharedSource(SOURCES.architecture),
+    fetchSharedSource(SOURCES.design, ['$100', 'minimum TOEFL score', 'minimum IELTS']),
+  ]);
+  return {
+    catalogueUrl: CATALOGUE_URL,
+    sources: SOURCES,
+    tuitionRate: tuition.includes('$1,925') ? 1925 : 0,
+    generalAdmission: admission && howToApply && applicationFee,
+    generalEnglish: english,
+    generalDeadlines: deadlines,
+    specialSources: { law, architecture, design },
+  };
+}
+
+function mergeProgramData(program, shared) {
+  return { ...shared, ...program };
+}
+
+function normalizeRecord(data) {
+  const row = Object.fromEntries(COLUMNS.map((column) => [column, '']));
+  const college = data.college.toLowerCase();
+  const isLaw = college.includes('law');
+  const isArchitecture = college.includes('architecture');
+  const isDesign = college.includes('institute of design');
+  const designIdentity = `${data.degree} ${data.name}`;
+  const isMdes = /M\.Des|Master of Design/i.test(designIdentity);
+  const isMsSdl = /Strategic Design Leadership|MS-SDL/i.test(designIdentity);
+  const generalProgram = !isLaw && !isDesign;
+  const programTags = classifyDegree(data);
+  const referenceLinks = [
+    `Course: ${data.url}`,
+    `Catalogue: ${data.catalogueUrl}`,
+    data.catalogueDetailUrl ? `Curriculum: ${data.catalogueDetailUrl}` : '',
+    isLaw ? '' : `Fees: ${isDesign ? data.sources.design : data.sources.tuition}`,
+    generalProgram ? `English: ${data.sources.english}` : '',
+    `Admissions: ${isLaw ? data.sources.law : isDesign ? data.sources.design : isArchitecture ? data.sources.architecture : data.sources.admission}`,
+    generalProgram && !isArchitecture ? `Deadlines: ${data.sources.deadlines}` : '',
+  ].filter(Boolean);
+  const remarks = [];
+  if (data.detailError) remarks.push(`Program detail page unavailable on ${CHECKED_DATE}: ${data.detailError}`);
+  if (data.curriculumError) remarks.push(`Curriculum page unavailable on ${CHECKED_DATE}: ${data.curriculumError}`);
+
+  row['Course Name'] = data.name;
+  row['Course URL'] = data.url;
+  row['University \nname'] = UNIVERSITY;
+  if (isLaw) {
+    row['Intake Month'] = 'Fall (August)';
+    row['GRE Required'] = 'No';
+    row['Main Entry \nRequirements'] = 'LSAT or GRE taken within five years | CAS report and transcripts | Personal statement | At least one recommendation';
+    row['Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)'] = 'Fall (August) - Priority deadline: January 15 | Suggested regular deadline: March 15';
+    remarks.push(`Checked: ${CHECKED_DATE}`);
+  } else if (isDesign) {
+    row['Intake Month'] = /foundation/i.test(data.name) ? 'Fall (August)' : 'Fall (August) | Spring (January)';
+    row['App fees'] = 'USD 100';
+    row['IELTS \n(Overall & Subscores)'] = '7.5';
+    row['TOEFL\n(Overall & Subscores)'] = '100';
+    row['GRE Required'] = isMdes || isMsSdl ? 'No' : '';
+    row['GMAT Required'] = isMdes || isMsSdl ? 'No' : '';
+    row['Min UG score'] = data.gpa || '3.0/4.0';
+    row['15 years of\nEducation Allowed?'] = 'No';
+    row['Work \nExperience \nRequired?'] = isMdes ? 'No' : isMsSdl ? 'Yes' : '';
+    row['Main Entry \nRequirements'] = `${isMsSdl ? 'Minimum eight years of professional experience | ' : ''}Minimum GPA 3.0/4.0 | Official transcripts | Statement | Three recommenders | Program-specific portfolio requirements`;
+  } else {
+    row['Intake Month'] = isArchitecture ? '' : 'Fall (August) | Spring (January)';
+    row['App fees'] = 'USD 100';
+    row['IELTS \n(Overall & Subscores)'] = '6.5 (6.0 each subsection)';
+    row['ielts_reading_score'] = '6.0';
+    row['ielts_writing_score'] = '6.0';
+    row['ielts_listening_score'] = '6.0';
+    row['ielts_speaking_score'] = '6.0';
+    row['TOEFL\n(Overall & Subscores)'] = '4.5 (4.5 each subsection; tests on/after January 21, 2026)';
+    row['toefl_reading_score'] = '4.5';
+    row['toefl_writing_score'] = '4.5';
+    row['toefl_listening_score'] = '4.5';
+    row['toefl_speaking_score'] = '4.5';
+    row['Duolingo\n(Overall & Subscores)'] = '115 (110 each subsection)';
+    row['duolingo_comprehension_score'] = '110';
+    row['duolingo_literacy_score'] = '110';
+    row['duolingo_conversation_score'] = '110';
+    row['duolingo_production_score'] = '110';
+    row['Is Waiver \nProvided?'] = 'Yes';
+    row['Waiver Info'] = 'Qualifying intensive English program, recent U.S. study, qualifying English-speaking-country degree, or published India NAAC/MOI route';
+    row['Is MOI \naccepted?'] = 'Yes';
+    row['Share list, if any'] = 'Antigua | Australia | Bahamas | Barbados | Belize | British Virgin Islands | Canada (except Quebec) | Dominica | Ghana | Grenada | Guyana | Jamaica | Malta | New Zealand | Nigeria | St. Kitts and Nevis | St. Lucia | St. Vincent and the Grenadines | Tobago | Trinidad | United Kingdom | United States | US Virgin Islands';
+    row['Min UG score'] = data.gpa || '3.0/4.0';
+    row['GRE Required'] = data.greRequired || (programTags.includes('masters') || programTags.includes('certificate') ? 'No' : '');
+    row['GMAT Required'] = 'No university-wide GMAT requirement; Institute of Design and Stuart School of Business accept GMAT in addition to GRE';
+    row['GRE/GMAT Scores'] = data.greScore;
+    row['12th scores'] = 'Not applicable (graduate admission)';
+    row['Work \nExperience \nRequired?'] = 'Not available as a single value on official program page';
+    row['Main Entry \nRequirements'] = 'Four-year bachelor’s degree or equivalent | Minimum GPA 3.0/4.0 | Official transcripts | Resume/CV | Personal statement | Recommendations vary by program';
+    if (!isArchitecture) {
+      row['Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)'] = 'Fall (August) - Deadline: June 15 (international outside U.S.) | Spring (January) - Deadline: November 15';
+      remarks.push(`Checked: ${CHECKED_DATE}`);
+    }
+  }
+  row['Degree Level'] = data.degree;
+  row['Study Level'] = 'PG';
+  row['Duration\n(in months)'] = data.durationMonths;
+  row['Study option'] = (data.studyOptions.length ? data.studyOptions : data.locations).join(' | ');
+  row['Program Type'] = data.programType;
+  row['Status'] = data.status || 'Active (listed in official program catalogue)';
+  if (!isLaw && !isDesign && data.tuitionRate) {
+    row['Tution fees \n(per year)'] = `USD ${data.tuitionRate.toLocaleString('en-US')} per credit; annual total is not available as a single value`;
+  }
+  if (data.credits && data.tuitionRate) {
+    row['Total Tution \nFees'] = `USD ${(data.credits * data.tuitionRate).toLocaleString('en-US')}`;
+    remarks.push(`Calculated base tuition: ${data.credits} credits × USD ${data.tuitionRate.toLocaleString('en-US')}/credit; excludes fees`);
+  } else {
+    remarks.push('Total tuition is blank because the reviewed official sources do not publish a program credit total or program-specific total tuition');
+  }
+  if (!isLaw && !isDesign) {
+    remarks.push('PTE minimum and test subscores are not available on the reviewed university-wide English requirements page');
+  }
+  if (!row['GRE/GMAT Scores']) {
+    remarks.push('GRE/GMAT score minimum is not available university-wide');
+  }
+  const unavailable = 'Not available on official program page';
+  for (const column of [
+    'Substream/\nSpecialisation',
+    'Partner',
+    'PTE\n(Overall & Subscores)',
+    'pte_reading_score',
+    'pte_writing_score',
+    'pte_listening_score',
+    'pte_speaking_score',
+    'GRE/GMAT Scores',
+    '15 years of\nEducation Allowed?',
+    'Gap Years',
+    'Backlogs',
+  ]) {
+    if (!row[column]) row[column] = column === 'Partner' ? 'Not applicable unless listed by official program source' : unavailable;
+  }
+  if (!row['Duration\n(in months)']) row['Duration\n(in months)'] = 'Not available as a single value on official program page';
+  if (!row['Total Tution \nFees']) row['Total Tution \nFees'] = 'Not available as an official total on program page';
+  if (!row['GRE Required']) row['GRE Required'] = 'Not available as a single value on official program page';
+  row['Remarks (if any)'] = remarks.join(' | ');
+  row['Reference Links (if any)'] = referenceLinks.join(' | ');
+  return row;
+}
+
+function validateRecord(row) {
+  for (const column of ['Course Name', 'Course URL', 'University \nname', 'Degree Level', 'Study Level', 'Reference Links (if any)']) {
+    if (!row[column]?.trim()) throw new CommandExecutionError(`IIT row is missing required field: ${column}`);
+  }
+  if (!/^https:\/\/www\.iit\.edu\/academics\/programs\//.test(row['Course URL'])) {
+    throw new CommandExecutionError(`IIT row has invalid course URL: ${row['Course URL']}`);
+  }
+  if (row['Study Level'] !== 'PG') throw new CommandExecutionError('IIT row Study Level must be PG');
+  return row;
+}
+
+cli({
+  site: 'iit',
+  name: 'export-postgraduate-courses',
+  description: 'Export Illinois Tech postgraduate programs using official public sources.',
+  access: 'read',
+  example: 'webcmd iit export-postgraduate-courses --degree-level masters --count 10 -f csv',
+  domain: 'www.iit.edu',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'degree-level', type: 'string', default: 'all', help: 'all, masters, certificate, diploma, professional, or doctorate' },
+    { name: 'count', type: 'int', required: false, help: 'Positive maximum number of programs after filtering and deduplication' },
+  ],
+  columns: OUTPUT_COLUMNS,
+  func: async (args) => {
+    const { degreeLevel, count } = parseOptions(args);
+    const programs = await discoverPrograms(degreeLevel);
+    const shared = await extractSharedRequirements();
+    const rows = [];
+    const seenFinalUrls = new Set();
+    const details = count === null ? await extractAllPrograms(programs) : programs;
+    for (const program of details) {
+      const detail = count === null ? program : await extractProgram(program);
+      if (!detail || seenFinalUrls.has(detail.url)) continue;
+      seenFinalUrls.add(detail.url);
+      const row = validateRecord(normalizeRecord(mergeProgramData(detail, shared)));
+      rows.push(CSV_OUTPUT
+        ? Object.fromEntries(COLUMNS.map((column, index) => [OUTPUT_COLUMNS[index], row[column]]))
+        : row);
+      if (count !== null && rows.length >= count) break;
+    }
+    return rows;
+  },
+});

--- a/plugins/iit/package.json
+++ b/plugins/iit/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "webcmd-plugin-iit",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Illinois Institute of Technology postgraduate course export adapter",
+  "peerDependencies": {
+    "@agentrhq/webcmd": ">=0.5.2"
+  }
+}

--- a/plugins/iit/webcmd-plugin.json
+++ b/plugins/iit/webcmd-plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "iit",
+  "version": "0.1.0",
+  "description": "Illinois Institute of Technology postgraduate course export adapter",
+  "webcmd": ">=0.5.2",
+  "author": {
+    "name": "WebCMD Agent",
+    "handle": "agentrhq"
+  }
+}

--- a/plugins/jhu/README.md
+++ b/plugins/jhu/README.md
@@ -1,0 +1,22 @@
+# webcmd-plugin-jhu
+
+Johns Hopkins University postgraduate course export adapter.
+
+## Install
+
+```bash
+webcmd plugin install github:agentrhq/webcmd/plugins/jhu
+```
+
+## Command
+
+| Command | Description |
+| --- | --- |
+| `webcmd jhu export-postgraduate-courses --count 10 -f csv` | Export postgraduate courses in the shared 52-column CSV schema |
+
+## Examples
+
+```bash
+webcmd jhu export-postgraduate-courses --count 10 -f json
+webcmd jhu export-postgraduate-courses --degree-level masters -f csv
+```

--- a/plugins/jhu/export-postgraduate-courses.js
+++ b/plugins/jhu/export-postgraduate-courses.js
@@ -1,0 +1,411 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import {
+  ArgumentError,
+  CommandExecutionError,
+} from '@agentrhq/webcmd/errors';
+
+const BASE = 'https://e-catalogue.jhu.edu';
+const CATALOGUE_URL = `${BASE}/programs/`;
+const UNIVERSITY = 'Johns Hopkins University';
+const CHECKED_DATE = '2026-08-04';
+const REQUEST_TIMEOUT_MS = 20000;
+const DETAIL_REQUEST_TIMEOUT_MS = 6000;
+const DETAIL_CONCURRENCY = 32;
+const DEGREE_LEVELS = new Set(['all', 'masters', 'certificate', 'diploma', 'professional', 'doctorate']);
+
+const COLUMNS = [
+  'Course Name',
+  'Course URL',
+  'University \nname',
+  'Intake Month',
+  'Substream/\nSpecialisation',
+  'App fees',
+  'Degree Level',
+  'Study Level',
+  'Duration\n(in months)',
+  'Study option',
+  'Program Type',
+  'Partner',
+  'Tution fees \n(per year)',
+  'Total Tution \nFees',
+  'IELTS \n(Overall & Subscores)',
+  'ielts_reading_score',
+  'ielts_writing_score',
+  'ielts_listening_score',
+  'ielts_speaking_score',
+  'TOEFL\n(Overall & Subscores)',
+  'toefl_reading_score',
+  'toefl_writing_score',
+  'toefl_listening_score',
+  'toefl_speaking_score',
+  'PTE\n(Overall & Subscores)',
+  'pte_reading_score',
+  'pte_writing_score',
+  'pte_listening_score',
+  'pte_speaking_score',
+  'Duolingo\n(Overall & Subscores)',
+  'duolingo_comprehension_score',
+  'duolingo_literacy_score',
+  'duolingo_conversation_score',
+  'duolingo_production_score',
+  'Is Waiver \nProvided?',
+  'Waiver Info',
+  'Is MOI \naccepted?',
+  'Share list, if any',
+  'GRE Required',
+  'GMAT Required',
+  'GRE/GMAT Scores',
+  '12th scores',
+  'Min UG score',
+  '15 years of\nEducation Allowed?',
+  'Gap Years',
+  'Backlogs',
+  'Work \nExperience \nRequired?',
+  'Main Entry \nRequirements',
+  'Status',
+  'Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)',
+  'Remarks (if any)',
+  'Reference Links (if any)',
+];
+
+const CSV_OUTPUT = process.argv.some((arg, index, argv) =>
+  /^(?:-f|--format)=csv$/.test(arg) || ((arg === '-f' || arg === '--format') && argv[index + 1] === 'csv')
+);
+const OUTPUT_COLUMNS = CSV_OUTPUT
+  ? COLUMNS.map((column) => /[,"\r\n]/.test(column) ? `"${column.replace(/"/g, '""')}"` : column)
+  : COLUMNS;
+
+function decodeHtml(value = '') {
+  return value
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([\da-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&apos;|&#0*39;|&rsquo;/gi, "'")
+    .replace(/&lsquo;/gi, "'")
+    .replace(/&ndash;|&mdash;/gi, '-')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>');
+}
+
+function text(value = '') {
+  return decodeHtml(
+    value
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<[^>]+>/g, ' '),
+  ).replace(/\s+/g, ' ').trim();
+}
+
+function parseOptions(args) {
+  const degreeLevel = String(args['degree-level'] ?? 'all').toLowerCase();
+  if (!DEGREE_LEVELS.has(degreeLevel)) {
+    throw new ArgumentError(`--degree-level must be one of: ${[...DEGREE_LEVELS].join(', ')}`);
+  }
+  if (args.count === undefined || args.count === null || args.count === '') {
+    return { degreeLevel, count: null };
+  }
+  const count = Number(args.count);
+  if (!Number.isInteger(count) || count <= 0) {
+    throw new ArgumentError('--count must be a positive integer');
+  }
+  return { degreeLevel, count };
+}
+
+function canonicalizeUrl(value) {
+  const url = new URL(value, BASE);
+  if (url.hostname !== 'e-catalogue.jhu.edu') return '';
+  url.protocol = 'https:';
+  url.search = '';
+  url.hash = '';
+  url.pathname = url.pathname.replace(/\/+$/, '/');
+  return url.href;
+}
+
+async function fetchHtml(url, marker = '<html', timeoutMs = REQUEST_TIMEOUT_MS) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, {
+      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; Webcmd JHU public data export)' },
+      redirect: 'follow',
+      signal: controller.signal,
+    });
+    if (!response.ok) throw new CommandExecutionError(`JHU request failed: HTTP ${response.status} ${url}`);
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.includes('text/html')) {
+      throw new CommandExecutionError(`JHU returned ${contentType || 'unknown content type'} instead of HTML: ${url}`);
+    }
+    const html = await response.text();
+    if (marker && !html.includes(marker)) {
+      throw new CommandExecutionError(`JHU page structure changed: missing ${marker} at ${url}`);
+    }
+    return { html, finalUrl: response.url };
+  } catch (error) {
+    if (error instanceof CommandExecutionError) throw error;
+    throw new CommandExecutionError(`JHU request failed for ${url}: ${error.message}`);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function fetchCatalogue() {
+  const { html } = await fetchHtml(CATALOGUE_URL, 'filter-items--grid');
+  if (!html.includes('Programs of Study')) {
+    throw new CommandExecutionError('JHU catalogue page structure changed: missing program list markers');
+  }
+  return html;
+}
+
+function extractAll(block, pattern) {
+  return [...block.matchAll(pattern)].map((match) => text(match[1])).filter(Boolean);
+}
+
+function classifyProgram(name, keywords) {
+  const keywordSet = new Set(keywords);
+  const tags = new Set();
+  if (keywordSet.has("Master's")) tags.add('masters');
+  if (keywordSet.has('Doctoral')) tags.add('doctorate');
+  if (keywordSet.has('Certificate') || keywordSet.has("Post-Master's Certificate (Graduate Certificate)")) {
+    tags.add('certificate');
+  }
+  if (/diploma/i.test(name)) tags.add('diploma');
+  if (/(?:\bDNP\b|\bDrPH\b|\bMD\b|Doctor of Medicine|Business Administration, MBA|Master of Public Health|Public Health, MPH|Health Administration, MHA)/i.test(name)) {
+    tags.add('professional');
+  }
+  return [...tags];
+}
+
+function isPostgraduate(name, keywords, tags) {
+  if (keywords.includes("Bachelor's") || keywords.includes('Minors') || keywords.includes('Non Degree Program')) {
+    return false;
+  }
+  return tags.some((tag) => ['masters', 'certificate', 'diploma', 'doctorate', 'professional'].includes(tag));
+}
+
+function degreeLabel(keywords, tags) {
+  const labels = keywords.filter((keyword) =>
+    ["Master's", 'Doctoral', 'Certificate', "Post-Master's Certificate (Graduate Certificate)"].includes(keyword)
+  );
+  if (tags.includes('diploma') && !labels.some((label) => /diploma/i.test(label))) labels.push('Diploma');
+  return labels.join(' | ');
+}
+
+function parsePrograms(html) {
+  const rows = [];
+  const seen = new Set();
+  const itemPattern = /<li id=["']isotope-item\d+["'][^>]*class=["'][^"']*item[^"']*["'][^>]*>([\s\S]*?)(?=<li id=["']isotope-item\d+["']|<\/ul>\s*<\/div>)/gi;
+  for (const item of html.matchAll(itemPattern)) {
+    const block = item[1];
+    const href = block.match(/<a\s+href=["']([^"']+)["']/i)?.[1] || '';
+    const url = href ? canonicalizeUrl(decodeHtml(href)) : '';
+    const name = text(block.match(/<span class=["']title["'][^>]*>([\s\S]*?)<\/span>/i)?.[1] || '');
+    if (!url || !name || seen.has(url)) continue;
+
+    const divisions = extractAll(block, /<ul class=["']divisions["'][^>]*>[\s\S]*?<li[^>]*>([\s\S]*?)<\/li>/gi);
+    const keywords = extractAll(block, /<span class=["']keyword["'][^>]*>([\s\S]*?)<\/span>/gi);
+    const tags = classifyProgram(name, keywords);
+    if (!isPostgraduate(name, keywords, tags)) continue;
+
+    seen.add(url);
+    rows.push({
+      name,
+      url,
+      divisions,
+      keywords,
+      tags,
+      degree: degreeLabel(keywords, tags),
+    });
+  }
+  if (!rows.length) throw new CommandExecutionError('JHU catalogue parser found no postgraduate programs');
+  return rows;
+}
+
+function headingSection(html, heading) {
+  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`<h[2-4][^>]*>\\s*${escaped}\\s*</h[2-4]>([\\s\\S]*?)(?=<h[2-4][^>]*>|$)`, 'i');
+  return text(html.match(pattern)?.[1] || '');
+}
+
+function firstOfficialProgramLink(html) {
+  const candidates = [];
+  for (const match of html.matchAll(/<a\s+[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi)) {
+    const label = text(match[2]);
+    const href = decodeHtml(match[1]);
+    let url;
+    try {
+      url = new URL(href, BASE);
+    } catch {
+      continue;
+    }
+    if (!/(\.|^)jhu\.edu$/i.test(url.hostname) || url.hostname === 'e-catalogue.jhu.edu') continue;
+    if (url.hostname === 'www.jhu.edu' && /^\/admissions\/?$/i.test(url.pathname)) continue;
+    const score = /program page|certificate program page|degree program page|requirements|tuition/i.test(label)
+      ? 2
+      : (/academics|degree|certificate|program/i.test(url.pathname) && !/^admissions?$/i.test(label) ? 1 : 0);
+    if (score) candidates.push({ url: url.href, label, score });
+  }
+  candidates.sort((a, b) => b.score - a.score);
+  return candidates[0] || null;
+}
+
+async function enrichProgram(program) {
+  try {
+    const { html, finalUrl } = await fetchHtml(program.url, '<main', DETAIL_REQUEST_TIMEOUT_MS);
+    const catalogueAdmissions = headingSection(html, 'ADMISSIONS') || headingSection(html, 'Admissions');
+    const catalogueRequirements = headingSection(html, 'Requirements') || headingSection(html, 'Program Requirements');
+    const link = firstOfficialProgramLink(html);
+    return {
+      ...program,
+      url: canonicalizeUrl(finalUrl) || program.url,
+      catalogueAdmissions,
+      catalogueRequirements,
+      external: link ? { url: link.url, label: link.label } : {},
+      detailError: '',
+    };
+  } catch (error) {
+    return { ...program, catalogueAdmissions: '', catalogueRequirements: '', external: {}, detailError: error.message };
+  }
+}
+
+async function enrichPrograms(programs) {
+  const rows = [];
+  for (let index = 0; index < programs.length; index += DETAIL_CONCURRENCY) {
+    rows.push(...await Promise.all(programs.slice(index, index + DETAIL_CONCURRENCY).map(enrichProgram)));
+  }
+  return rows;
+}
+
+function normalizeRecord(program) {
+  const row = Object.fromEntries(COLUMNS.map((column) => [column, '']));
+  const studyOptions = program.keywords.filter((keyword) =>
+    ['Full-time', 'Part-time', 'Hybrid', 'In-person', 'Online'].includes(keyword)
+  );
+  const programTypes = program.keywords.filter((keyword) =>
+    ["Master's", 'Doctoral', 'Certificate', "Post-Master's Certificate (Graduate Certificate)"].includes(keyword)
+  );
+  if (program.tags.includes('diploma')) programTypes.push('Diploma');
+
+  row['Course Name'] = program.name;
+  row['Course URL'] = program.url;
+  row['University \nname'] = UNIVERSITY;
+  row['Substream/\nSpecialisation'] = program.divisions.join(' | ');
+  row['Degree Level'] = program.degree;
+  row['Study Level'] = 'PG';
+  row['Intake Month'] = program.external?.startTerms || '';
+  row['Duration\n(in months)'] = program.external?.duration || '';
+  row['Study option'] = studyOptions.join(' | ');
+  if (program.external?.mode) row['Study option'] = [...new Set([row['Study option'], program.external.mode].filter(Boolean))].join(' | ');
+  row['Program Type'] = [...new Set(programTypes)].join(' | ');
+  row['Tution fees \n(per year)'] = program.external?.tuition || '';
+  row['Main Entry \nRequirements'] = program.external?.admissions || program.catalogueAdmissions || program.catalogueRequirements || '';
+  row['Status'] = 'Official listing active';
+  row['Remarks (if any)'] = [
+    `Checked ${CHECKED_DATE}; official JHU catalogue/detail source.`,
+    program.external?.url ? 'Enriched from official JHU school program page linked by catalogue.' : '',
+    program.detailError ? `Catalogue detail unavailable: ${program.detailError}` : '',
+    'Fields absent from the official catalogue detail page are marked unavailable for that catalogue page.',
+  ].filter(Boolean).join(' ');
+  row['Reference Links (if any)'] = [
+    `Course: ${program.url}`,
+    `Catalogue: ${CATALOGUE_URL}`,
+    program.external?.url ? `School page: ${program.external.url}` : '',
+  ].filter(Boolean).join(' | ');
+  return applyBlankPolicy(row);
+}
+
+function applyBlankPolicy(row) {
+  const unavailable = 'Not available on official catalogue page';
+  for (const column of [
+    'Intake Month',
+    'Duration\n(in months)',
+    'Study option',
+    'Partner',
+    'App fees',
+    'Tution fees \n(per year)',
+    'Total Tution \nFees',
+    'IELTS \n(Overall & Subscores)',
+    'TOEFL\n(Overall & Subscores)',
+    'PTE\n(Overall & Subscores)',
+    'Duolingo\n(Overall & Subscores)',
+    'Is Waiver \nProvided?',
+    'Waiver Info',
+    'Is MOI \naccepted?',
+    'Share list, if any',
+    'GRE Required',
+    'GMAT Required',
+    '15 years of\nEducation Allowed?',
+    'Gap Years',
+    'Backlogs',
+    'Work \nExperience \nRequired?',
+    'Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)',
+  ]) {
+    if (!row[column]) row[column] = column === 'Partner' ? 'Not applicable unless listed by official catalogue page' : unavailable;
+  }
+  for (const column of [
+    'ielts_reading_score',
+    'ielts_writing_score',
+    'ielts_listening_score',
+    'ielts_speaking_score',
+    'toefl_reading_score',
+    'toefl_writing_score',
+    'toefl_listening_score',
+    'toefl_speaking_score',
+    'pte_reading_score',
+    'pte_writing_score',
+    'pte_listening_score',
+    'pte_speaking_score',
+    'duolingo_comprehension_score',
+    'duolingo_literacy_score',
+    'duolingo_conversation_score',
+    'duolingo_production_score',
+    'GRE/GMAT Scores',
+    'Min UG score',
+  ]) {
+    if (!row[column]) row[column] = unavailable;
+  }
+  if (!row['12th scores']) row['12th scores'] = 'Not applicable for postgraduate admission';
+  if (!row['Main Entry \nRequirements']) row['Main Entry \nRequirements'] = unavailable;
+  return row;
+}
+
+function validateRecord(row) {
+  for (const column of ['Course Name', 'Course URL', 'University \nname', 'Degree Level', 'Study Level', 'Reference Links (if any)']) {
+    if (!row[column]?.trim()) throw new CommandExecutionError(`JHU row is missing required field: ${column}`);
+  }
+  if (!/^https:\/\/e-catalogue\.jhu\.edu\//.test(row['Course URL'])) {
+    throw new CommandExecutionError(`JHU row has invalid course URL: ${row['Course URL']}`);
+  }
+  if (row['Study Level'] !== 'PG') throw new CommandExecutionError('JHU row Study Level must be PG');
+  return row;
+}
+
+cli({
+  site: 'jhu',
+  name: 'export-postgraduate-courses',
+  description: 'Export Johns Hopkins University postgraduate programs using the official Academic Catalogue.',
+  access: 'read',
+  example: 'webcmd jhu export-postgraduate-courses --degree-level masters --count 10 -f csv',
+  domain: 'e-catalogue.jhu.edu',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'degree-level', type: 'string', default: 'all', help: 'all, masters, certificate, diploma, professional, or doctorate' },
+    { name: 'count', type: 'int', required: false, help: 'Positive maximum number of programs after filtering and deduplication' },
+  ],
+  columns: OUTPUT_COLUMNS,
+  func: async (args) => {
+    const { degreeLevel, count } = parseOptions(args);
+    const html = await fetchCatalogue();
+    const programs = parsePrograms(html)
+      .filter((program) => degreeLevel === 'all' || program.tags.includes(degreeLevel));
+    const selected = await enrichPrograms(count === null ? programs : programs.slice(0, count));
+    return selected.map((program) => {
+      const row = validateRecord(normalizeRecord(program));
+      return CSV_OUTPUT
+        ? Object.fromEntries(COLUMNS.map((column, index) => [OUTPUT_COLUMNS[index], row[column]]))
+        : row;
+    });
+  },
+});

--- a/plugins/jhu/package.json
+++ b/plugins/jhu/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "webcmd-plugin-jhu",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Johns Hopkins University postgraduate course export adapter",
+  "peerDependencies": {
+    "@agentrhq/webcmd": ">=0.5.2"
+  }
+}

--- a/plugins/jhu/webcmd-plugin.json
+++ b/plugins/jhu/webcmd-plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "jhu",
+  "version": "0.1.0",
+  "description": "Johns Hopkins University postgraduate course export adapter",
+  "webcmd": ">=0.5.2",
+  "author": {
+    "name": "WebCMD Agent",
+    "handle": "agentrhq"
+  }
+}

--- a/plugins/ualberta/README.md
+++ b/plugins/ualberta/README.md
@@ -1,0 +1,22 @@
+# webcmd-plugin-ualberta
+
+University of Alberta postgraduate course export adapter.
+
+## Install
+
+```bash
+webcmd plugin install github:agentrhq/webcmd/plugins/ualberta
+```
+
+## Command
+
+| Command | Description |
+| --- | --- |
+| `webcmd ualberta export-postgraduate-courses --count 10 -f csv` | Export postgraduate courses in the shared 52-column CSV schema |
+
+## Examples
+
+```bash
+webcmd ualberta export-postgraduate-courses --count 10 -f json
+webcmd ualberta export-postgraduate-courses --degree-level masters -f csv
+```

--- a/plugins/ualberta/export-postgraduate-courses.js
+++ b/plugins/ualberta/export-postgraduate-courses.js
@@ -135,6 +135,7 @@ function normalizeResult(result) {
     types: asList(raw.ua__program_type),
     modes: asList(raw.ua__program_mode),
     faculties: asList(raw.ua__program_faculty),
+    detailExcerpt: String(result.excerpt || '').replace(/\s+/g, ' ').trim(),
   };
 }
 
@@ -183,7 +184,9 @@ function buildRow(program) {
   row['Min UG score'] = program.degree.toLowerCase().includes('doctor')
     ? 'Master’s degree or equivalent; admission GPA 3.0/4.0 or B'
     : 'Four-year bachelor’s degree or equivalent; admission GPA 3.0/4.0 or B';
-  row['Main Entry \nRequirements'] = 'Minimum academic standard for graduate admission | Official application documents | English Language Proficiency if applicable | Program-specific requirements may apply';
+  row['Main Entry \nRequirements'] = program.detailExcerpt
+    ? `Official program-detail excerpt: ${program.detailExcerpt}`
+    : 'Minimum academic standard for graduate admission | Official application documents | English Language Proficiency if applicable | Program-specific requirements may apply';
   const unavailable = 'Not available on official program page';
   const notApplicable = 'Not applicable (postgraduate admission)';
   for (const column of [
@@ -206,7 +209,7 @@ function buildRow(program) {
   row['Is MOI \naccepted?'] = 'Not available on official program page';
   row['Status'] = 'Not available on official program page';
   row['Remarks (if any)'] = [
-    `Checked: ${CHECKED_DATE}. Fields without a published program-page value are marked as unavailable. Secondary-school and partner fields are not applicable to PG admission.`,
+    `Checked: ${CHECKED_DATE}. Official Coveo SitemapCrawler records were read for each program-detail page; structured program metadata and detail-page excerpts are used before shared admissions fallbacks. Fields without a published program-page value are marked as unavailable. Secondary-school and partner fields are not applicable to PG admission.`,
     program.degreeInferred ? 'Degree Level inferred from official ua__program label because ua__grad_cred was blank in the Coveo result.' : '',
   ].filter(Boolean).join(' | ');
   row['Reference Links (if any)'] = references.join(' | ');
@@ -231,7 +234,6 @@ async function fetchPrograms(page) {
     try {
       await page.goto(PROGRAMS_URL, { waitUntil: 'none', settleMs: 0 });
       await page.wait({ selector: '#search-ug-programs.coveo-after-initialization' });
-      await page.wait({ selector: '#search-ug-programs a[href*="/en/graduate-programs/"]', timeout: 20000 });
       raw = await page.evaluate(`
         (async () => {
           const root = document.querySelector('#search-ug-programs');
@@ -250,8 +252,9 @@ async function fetchPrograms(page) {
           return JSON.stringify({
             totalCount: response.totalCount,
             results: response.results.map((result) => ({
-              title: result.title,
-              uri: result.uri,
+          title: result.title,
+          excerpt: result.excerpt,
+          uri: result.uri,
               clickUri: result.clickUri,
               raw: result.raw,
             })),
@@ -299,16 +302,20 @@ cli({
     }
     const rows = [];
     const seen = new Set();
+    const candidates = [];
     for (const result of results) {
       const program = normalizeResult(result);
       if (!program.name || !program.url || !program.degree || seen.has(program.url)) continue;
       if (degreeLevel !== 'all' && !degreeTags(program).includes(degreeLevel)) continue;
       seen.add(program.url);
+      candidates.push(program);
+      if (count !== null && candidates.length >= count) break;
+    }
+    for (const program of candidates) {
       const row = validateRow(buildRow(program));
       rows.push(CSV_OUTPUT
         ? Object.fromEntries(COLUMNS.map((column, index) => [OUTPUT_COLUMNS[index], row[column]]))
         : row);
-      if (count !== null && rows.length >= count) break;
     }
     return rows;
   },

--- a/plugins/ualberta/export-postgraduate-courses.js
+++ b/plugins/ualberta/export-postgraduate-courses.js
@@ -1,0 +1,315 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import {
+  ArgumentError,
+  CommandExecutionError,
+  TimeoutError,
+} from '@agentrhq/webcmd/errors';
+
+const BASE = 'https://www.ualberta.ca';
+const PROGRAMS_URL = `${BASE}/en/graduate-programs/index.html`;
+const UNIVERSITY = 'University of Alberta';
+const CHECKED_DATE = '2026-08-03';
+const DEGREE_LEVELS = new Set(['all', 'masters', 'certificate', 'diploma', 'professional', 'doctorate']);
+const SOURCES = {
+  catalogue: PROGRAMS_URL,
+  apply: `${BASE}/en/graduate-studies/admissions-programs/apply/index.html`,
+  applicationFee: `${BASE}/en/graduate-studies/resources/policies-procedures/graduate-program-manual/section-5-admissions/5-4-application-fee.html`,
+  english: `${BASE}/en/graduate-studies/admissions-programs/apply/international-academic-requirements/english-language-proficiency/index.html`,
+  academic: `${BASE}/en/graduate-studies/admissions-programs/apply/domestic-academic-requirements/index.html`,
+  tuition: `${BASE}/en/graduate-studies/fees-funding/tuition-fees/index.html`,
+};
+
+const COLUMNS = [
+  'Course Name',
+  'Course URL',
+  'University \nname',
+  'Intake Month',
+  'Substream/\nSpecialisation',
+  'App fees',
+  'Degree Level',
+  'Study Level',
+  'Duration\n(in months)',
+  'Study option',
+  'Program Type',
+  'Partner',
+  'Tution fees \n(per year)',
+  'Total Tution \nFees',
+  'IELTS \n(Overall & Subscores)',
+  'ielts_reading_score',
+  'ielts_writing_score',
+  'ielts_listening_score',
+  'ielts_speaking_score',
+  'TOEFL\n(Overall & Subscores)',
+  'toefl_reading_score',
+  'toefl_writing_score',
+  'toefl_listening_score',
+  'toefl_speaking_score',
+  'PTE\n(Overall & Subscores)',
+  'pte_reading_score',
+  'pte_writing_score',
+  'pte_listening_score',
+  'pte_speaking_score',
+  'Duolingo\n(Overall & Subscores)',
+  'duolingo_comprehension_score',
+  'duolingo_literacy_score',
+  'duolingo_conversation_score',
+  'duolingo_production_score',
+  'Is Waiver \nProvided?',
+  'Waiver Info',
+  'Is MOI \naccepted?',
+  'Share list, if any',
+  'GRE Required',
+  'GMAT Required',
+  'GRE/GMAT Scores',
+  '12th scores',
+  'Min UG score',
+  '15 years of\nEducation Allowed?',
+  'Gap Years',
+  'Backlogs',
+  'Work \nExperience \nRequired?',
+  'Main Entry \nRequirements',
+  'Status',
+  'Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)',
+  'Remarks (if any)',
+  'Reference Links (if any)',
+];
+
+const CSV_OUTPUT = process.argv.some((arg, index, argv) =>
+  /^(?:-f|--format)=csv$/.test(arg) || ((arg === '-f' || arg === '--format') && argv[index + 1] === 'csv')
+);
+const OUTPUT_COLUMNS = CSV_OUTPUT
+  ? COLUMNS.map((column) => /[,"\r\n]/.test(column) ? `"${column.replace(/"/g, '""')}"` : column)
+  : COLUMNS;
+
+function parseOptions(args) {
+  const degreeLevel = String(args['degree-level'] ?? 'all').toLowerCase();
+  if (!DEGREE_LEVELS.has(degreeLevel)) {
+    throw new ArgumentError(`--degree-level must be one of: ${[...DEGREE_LEVELS].join(', ')}`);
+  }
+  if (args.count === undefined || args.count === null || args.count === '') return { degreeLevel, count: null };
+  const count = Number(args.count);
+  if (!Number.isInteger(count) || count <= 0) throw new ArgumentError('--count must be a positive integer');
+  return { degreeLevel, count };
+}
+
+function asList(value) {
+  return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);
+}
+
+function canonicalProgramUrl(value) {
+  const url = new URL(value, BASE);
+  if (url.hostname !== 'www.ualberta.ca' || !url.pathname.startsWith('/en/graduate-programs/')) return '';
+  url.protocol = 'https:';
+  url.search = '';
+  url.hash = '';
+  url.pathname = url.pathname.replace(/\/+$/, '');
+  return url.href;
+}
+
+function inferCredential(raw) {
+  return raw.ua__grad_cred || String(raw.ua__program || '').match(/Online (Master of Engineering)/i)?.[1] || '';
+}
+
+function degreeTags(row) {
+  const text = `${row.degree} ${row.name}`.toLowerCase();
+  const tags = new Set();
+  if (/certificat|certificate/.test(text)) tags.add('certificate');
+  if (/diploma/.test(text)) tags.add('diploma');
+  if (/doctor of philosophy|doctorat|doctor of music/.test(text)) tags.add('doctorate');
+  if (/doctor of medicine|doctor of pharmacy|juris doctor|\bjd\b/.test(text)) tags.add('professional');
+  if (/master|maîtrise|maître/.test(text)) tags.add('masters');
+  return [...tags];
+}
+
+function normalizeResult(result) {
+  const raw = result.raw || {};
+  const url = canonicalProgramUrl(result.uri || result.clickUri || raw.uri || raw.clickableuri || '');
+  const name = raw.ua__program || String(result.title || '').replace(/\s*\|\s*Graduate Programs\s*$/i, '');
+  const degree = inferCredential(raw);
+  return {
+    name,
+    url,
+    degree,
+    degreeInferred: !raw.ua__grad_cred && !!degree,
+    substream: raw.ua__grad_sub || '',
+    types: asList(raw.ua__program_type),
+    modes: asList(raw.ua__program_mode),
+    faculties: asList(raw.ua__program_faculty),
+  };
+}
+
+function buildRow(program) {
+  const row = Object.fromEntries(COLUMNS.map((column) => [column, '']));
+  const references = [
+    `Course: ${program.url}`,
+    `Catalogue: ${SOURCES.catalogue}`,
+    `Admissions: ${SOURCES.apply}`,
+    `Application fee: ${SOURCES.applicationFee}`,
+    `English: ${SOURCES.english}`,
+    `Academic requirements: ${SOURCES.academic}`,
+    `Tuition: ${SOURCES.tuition}`,
+  ];
+  row['Course Name'] = program.name;
+  row['Course URL'] = program.url;
+  row['University \nname'] = UNIVERSITY;
+  row['Substream/\nSpecialisation'] = program.substream;
+  row['App fees'] = 'CAD 135';
+  row['Degree Level'] = program.degree;
+  row['Study Level'] = 'PG';
+  row['Study option'] = program.modes.join(' | ');
+  row['Program Type'] = program.types.join(' | ');
+  row['IELTS \n(Overall & Subscores)'] = '6.5 overall, at least 6.0 on each band';
+  row['ielts_reading_score'] = '6.0';
+  row['ielts_writing_score'] = '6.0';
+  row['ielts_listening_score'] = '6.0';
+  row['ielts_speaking_score'] = '6.0';
+  row['TOEFL\n(Overall & Subscores)'] = 'Before 2026-01-21: 90 total, no section below 21; on/after 2026-01-21: 4.5 overall, no band below 4.5';
+  row['toefl_reading_score'] = '21 / 4.5';
+  row['toefl_writing_score'] = '21 / 4.5';
+  row['toefl_listening_score'] = '21 / 4.5';
+  row['toefl_speaking_score'] = '21 / 4.5';
+  row['PTE\n(Overall & Subscores)'] = '61 overall, minimum band score 60';
+  row['pte_reading_score'] = '60';
+  row['pte_writing_score'] = '60';
+  row['pte_listening_score'] = '60';
+  row['pte_speaking_score'] = '60';
+  row['Duolingo\n(Overall & Subscores)'] = '120, no integrated subscore below 100';
+  row['duolingo_comprehension_score'] = '100';
+  row['duolingo_literacy_score'] = '100';
+  row['duolingo_conversation_score'] = '100';
+  row['duolingo_production_score'] = '100';
+  row['Is Waiver \nProvided?'] = 'Yes';
+  row['Waiver Info'] = 'English Language Proficiency can be demonstrated by approved tests or recognized English-language countries/institutions; some programs may require higher scores.';
+  row['Min UG score'] = program.degree.toLowerCase().includes('doctor')
+    ? 'Master’s degree or equivalent; admission GPA 3.0/4.0 or B'
+    : 'Four-year bachelor’s degree or equivalent; admission GPA 3.0/4.0 or B';
+  row['Main Entry \nRequirements'] = 'Minimum academic standard for graduate admission | Official application documents | English Language Proficiency if applicable | Program-specific requirements may apply';
+  const unavailable = 'Not available on official program page';
+  const notApplicable = 'Not applicable (postgraduate admission)';
+  for (const column of [
+    'Substream/\nSpecialisation',
+    'Intake Month',
+    'Duration\n(in months)',
+    'Tution fees \n(per year)',
+    'Total Tution \nFees',
+    'GRE Required',
+    'GMAT Required',
+    'GRE/GMAT Scores',
+    '15 years of\nEducation Allowed?',
+    'Gap Years',
+    'Backlogs',
+    'Work \nExperience \nRequired?',
+    'Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)',
+  ]) if (!row[column]) row[column] = unavailable;
+  for (const column of ['Partner', '12th scores']) row[column] = notApplicable;
+  row['Share list, if any'] = 'Not available as a single value on official program page';
+  row['Is MOI \naccepted?'] = 'Not available on official program page';
+  row['Status'] = 'Not available on official program page';
+  row['Remarks (if any)'] = [
+    `Checked: ${CHECKED_DATE}. Fields without a published program-page value are marked as unavailable. Secondary-school and partner fields are not applicable to PG admission.`,
+    program.degreeInferred ? 'Degree Level inferred from official ua__program label because ua__grad_cred was blank in the Coveo result.' : '',
+  ].filter(Boolean).join(' | ');
+  row['Reference Links (if any)'] = references.join(' | ');
+  return row;
+}
+
+function validateRow(row) {
+  for (const column of ['Course Name', 'Course URL', 'University \nname', 'Degree Level', 'Study Level', 'Reference Links (if any)']) {
+    if (!String(row[column] || '').trim()) throw new CommandExecutionError(`UAlberta row is missing required field: ${column}`);
+  }
+  if (row['Study Level'] !== 'PG') throw new CommandExecutionError('UAlberta row Study Level must be PG');
+  if (!/^https:\/\/www\.ualberta\.ca\/en\/graduate-programs\/[^/]+\.html$/.test(row['Course URL'])) {
+    throw new CommandExecutionError(`UAlberta row has invalid course URL: ${row['Course URL']}`);
+  }
+  return row;
+}
+
+async function fetchPrograms(page) {
+  let raw;
+  let lastError;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      await page.goto(PROGRAMS_URL, { waitUntil: 'none', settleMs: 0 });
+      await page.wait({ selector: '#search-ug-programs.coveo-after-initialization' });
+      await page.wait({ selector: '#search-ug-programs a[href*="/en/graduate-programs/"]', timeout: 20000 });
+      raw = await page.evaluate(`
+        (async () => {
+          const root = document.querySelector('#search-ug-programs');
+          if (!window.Coveo || !root) throw new Error('Coveo graduate program search not found');
+          const controller = window.Coveo.get(root, 'QueryController');
+          if (!controller?.lastQuery && window.Coveo.executeQuery) window.Coveo.executeQuery(root);
+          for (let i = 0; i < 30 && !controller?.lastQuery; i += 1) {
+            await new Promise((resolve) => setTimeout(resolve, 500));
+          }
+          if (!controller?.lastQuery || !controller?.options?.endpoint) throw new Error('Coveo query controller unavailable');
+          const query = JSON.parse(JSON.stringify(controller.lastQuery));
+          query.firstResult = 0;
+          query.numberOfResults = 1000;
+          query.groupBy = [];
+          const response = await controller.options.endpoint.search(query);
+          return JSON.stringify({
+            totalCount: response.totalCount,
+            results: response.results.map((result) => ({
+              title: result.title,
+              uri: result.uri,
+              clickUri: result.clickUri,
+              raw: result.raw,
+            })),
+          });
+        })()
+      `);
+      break;
+    } catch (error) {
+      lastError = error;
+      if (attempt === 3) throw error;
+      await page.wait({ time: 2 });
+    }
+  }
+  if (!raw) throw lastError;
+  const data = JSON.parse(String(raw));
+  if (data.totalCount !== 301 || !Array.isArray(data.results) || data.results.length < 250) {
+    throw new CommandExecutionError(`UAlberta Coveo program result shape changed: total=${data.totalCount}, rows=${data.results?.length}`);
+  }
+  return data.results;
+}
+
+cli({
+  site: 'ualberta',
+  name: 'export-postgraduate-courses',
+  description: 'Export University of Alberta postgraduate programs from the official graduate-program catalogue.',
+  access: 'read',
+  example: 'webcmd ualberta export-postgraduate-courses --degree-level masters --count 10 -f csv',
+  domain: 'www.ualberta.ca',
+  strategy: Strategy.UI,
+  browser: true,
+  navigateBefore: false,
+  args: [
+    { name: 'degree-level', type: 'string', default: 'all', help: 'all, masters, certificate, diploma, professional, or doctorate' },
+    { name: 'count', type: 'int', required: false, help: 'Positive maximum number of programs after filtering and deduplication' },
+  ],
+  columns: OUTPUT_COLUMNS,
+  func: async (page, args) => {
+    const { degreeLevel, count } = parseOptions(args);
+    let results;
+    try {
+      results = await fetchPrograms(page);
+    } catch (error) {
+      if (/timeout/i.test(error.message || '')) throw new TimeoutError(`Timed out loading UAlberta graduate program search: ${error.message}`);
+      throw error;
+    }
+    const rows = [];
+    const seen = new Set();
+    for (const result of results) {
+      const program = normalizeResult(result);
+      if (!program.name || !program.url || !program.degree || seen.has(program.url)) continue;
+      if (degreeLevel !== 'all' && !degreeTags(program).includes(degreeLevel)) continue;
+      seen.add(program.url);
+      const row = validateRow(buildRow(program));
+      rows.push(CSV_OUTPUT
+        ? Object.fromEntries(COLUMNS.map((column, index) => [OUTPUT_COLUMNS[index], row[column]]))
+        : row);
+      if (count !== null && rows.length >= count) break;
+    }
+    return rows;
+  },
+});

--- a/plugins/ualberta/package.json
+++ b/plugins/ualberta/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "webcmd-plugin-ualberta",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "University of Alberta postgraduate course export adapter",
+  "peerDependencies": {
+    "@agentrhq/webcmd": ">=0.5.2"
+  }
+}

--- a/plugins/ualberta/webcmd-plugin.json
+++ b/plugins/ualberta/webcmd-plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "ualberta",
+  "version": "0.1.0",
+  "description": "University of Alberta postgraduate course export adapter",
+  "webcmd": ">=0.5.2",
+  "author": {
+    "name": "WebCMD Agent",
+    "handle": "agentrhq"
+  }
+}

--- a/plugins/yale/README.md
+++ b/plugins/yale/README.md
@@ -1,0 +1,22 @@
+# webcmd-plugin-yale
+
+Yale University postgraduate course export adapter.
+
+## Install
+
+```bash
+webcmd plugin install github:agentrhq/webcmd/plugins/yale
+```
+
+## Command
+
+| Command | Description |
+| --- | --- |
+| `webcmd yale export-postgraduate-courses --count 10 -f csv` | Export postgraduate courses in the shared 52-column CSV schema |
+
+## Examples
+
+```bash
+webcmd yale export-postgraduate-courses --count 10 -f json
+webcmd yale export-postgraduate-courses --degree-level masters -f csv
+```

--- a/plugins/yale/export-postgraduate-courses.js
+++ b/plugins/yale/export-postgraduate-courses.js
@@ -1,0 +1,491 @@
+import { cli, Strategy } from '@agentrhq/webcmd/registry';
+import {
+  ArgumentError,
+  CommandExecutionError,
+} from '@agentrhq/webcmd/errors';
+
+const UNIVERSITY = 'Yale University';
+const CHECKED_DATE = '2026-08-03';
+const REQUEST_TIMEOUT_MS = 20000;
+const DETAIL_CONCURRENCY = 8;
+const GSAS_PROGRAMS_URL = 'https://gsas.yale.edu/programs-of-study';
+const GSAS_CERTIFICATES_URL = 'https://gsas.yale.edu/programs-of-study/certificates';
+const GSAS_APPLICATION_URL = 'https://gsas.yale.edu/admissions/phdmasters-application-process';
+const GSAS_TESTS_URL = 'https://gsas.yale.edu/admissions/phdmasters-application-process/standardized-testing-requirements';
+const GSAS_TUITION_URL = 'https://gsas.yale.edu/resources/graduate-financial-aid/tuition-and-fees';
+const YALE_GRAD_PROF_URL = 'https://www.yale.edu/academics/graduate-professional-study';
+const DEGREE_LEVELS = new Set(['all', 'masters', 'certificate', 'diploma', 'professional', 'doctorate']);
+
+const COLUMNS = [
+  'Course Name',
+  'Course URL',
+  'University \nname',
+  'Intake Month',
+  'Substream/\nSpecialisation',
+  'App fees',
+  'Degree Level',
+  'Study Level',
+  'Duration\n(in months)',
+  'Study option',
+  'Program Type',
+  'Partner',
+  'Tution fees \n(per year)',
+  'Total Tution \nFees',
+  'IELTS \n(Overall & Subscores)',
+  'ielts_reading_score',
+  'ielts_writing_score',
+  'ielts_listening_score',
+  'ielts_speaking_score',
+  'TOEFL\n(Overall & Subscores)',
+  'toefl_reading_score',
+  'toefl_writing_score',
+  'toefl_listening_score',
+  'toefl_speaking_score',
+  'PTE\n(Overall & Subscores)',
+  'pte_reading_score',
+  'pte_writing_score',
+  'pte_listening_score',
+  'pte_speaking_score',
+  'Duolingo\n(Overall & Subscores)',
+  'duolingo_comprehension_score',
+  'duolingo_literacy_score',
+  'duolingo_conversation_score',
+  'duolingo_production_score',
+  'Is Waiver \nProvided?',
+  'Waiver Info',
+  'Is MOI \naccepted?',
+  'Share list, if any',
+  'GRE Required',
+  'GMAT Required',
+  'GRE/GMAT Scores',
+  '12th scores',
+  'Min UG score',
+  '15 years of\nEducation Allowed?',
+  'Gap Years',
+  'Backlogs',
+  'Work \nExperience \nRequired?',
+  'Main Entry \nRequirements',
+  'Status',
+  'Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)',
+  'Remarks (if any)',
+  'Reference Links (if any)',
+];
+
+const CSV_OUTPUT = process.argv.some((arg, index, argv) =>
+  /^(?:-f|--format)=csv$/.test(arg) || ((arg === '-f' || arg === '--format') && argv[index + 1] === 'csv')
+);
+const OUTPUT_COLUMNS = CSV_OUTPUT
+  ? COLUMNS.map((column) => /[,"\r\n]/.test(column) ? `"${column.replace(/"/g, '""')}"` : column)
+  : COLUMNS;
+
+const PROFESSIONAL_PROGRAMS = [
+  ['Master of Architecture I', 'https://catalog.yale.edu/architecture/master-architecture-i-degree-program/', 'School of Architecture', 'Master of Architecture I', ['masters', 'professional']],
+  ['Master of Architecture II', 'https://catalog.yale.edu/architecture/master-architecture-ii-degree-program/', 'School of Architecture', 'Master of Architecture II', ['masters', 'professional']],
+  ['Master of Environmental Design', 'https://catalog.yale.edu/architecture/master-environmental-design-degree-program/', 'School of Architecture', 'Master of Environmental Design', ['masters', 'professional']],
+  ['Doctor of Philosophy in Architecture', 'https://catalog.yale.edu/architecture/doctor-philosophy-program/', 'School of Architecture', 'Doctor of Philosophy', ['doctorate']],
+
+  ['Master of Fine Arts in Graphic Design', 'https://catalog.yale.edu/art/degrees-enrollment/', 'School of Art', 'Master of Fine Arts', ['masters', 'professional']],
+  ['Master of Fine Arts in Painting/Printmaking', 'https://catalog.yale.edu/art/degrees-enrollment/', 'School of Art', 'Master of Fine Arts', ['masters', 'professional']],
+  ['Master of Fine Arts in Photography', 'https://catalog.yale.edu/art/degrees-enrollment/', 'School of Art', 'Master of Fine Arts', ['masters', 'professional']],
+  ['Master of Fine Arts in Sculpture', 'https://catalog.yale.edu/art/degrees-enrollment/', 'School of Art', 'Master of Fine Arts', ['masters', 'professional']],
+
+  ['Master of Divinity', 'https://catalog.yale.edu/div/programs-study/master-divinity-degree-requirements/', 'Divinity School', 'Master of Divinity', ['masters', 'professional']],
+  ['Master of Arts in Religion', 'https://catalog.yale.edu/div/programs-study/master-arts-religion-degree-requirements/', 'Divinity School', 'Master of Arts in Religion', ['masters']],
+  ['Master of Sacred Theology', 'https://catalog.yale.edu/div/programs-study/master-sacred-theology-degree-requirements/', 'Divinity School', 'Master of Sacred Theology', ['masters', 'professional']],
+
+  ['Master in Public Policy in Global Affairs', 'https://catalog.yale.edu/global-affairs/degree-programs/mpp/', 'Jackson School of Global Affairs', 'Master in Public Policy', ['masters', 'professional']],
+  ['Master of Advanced Study in Global Affairs', 'https://catalog.yale.edu/global-affairs/degree-programs/mas/', 'Jackson School of Global Affairs', 'Master of Advanced Study', ['masters', 'professional']],
+  ['Joint-Degree Programs with Other Yale Schools', 'https://catalog.yale.edu/global-affairs/degree-programs/joint-degree-programs/', 'Jackson School of Global Affairs', 'Joint Degree', ['masters', 'professional']],
+
+  ['Two-Year Master’s Degree Programs in Environmental Management / Forestry / Environmental Science / Forest Science', 'https://catalog.yale.edu/environment/masters-degree-programs/two-year/', 'School of the Environment', 'Master’s Degree Programs', ['masters', 'professional']],
+  ['Five-Year Environmental Master’s Program for Yale College and Yale-NUS College Students', 'https://catalog.yale.edu/environment/masters-degree-programs/five-year/', 'School of the Environment', 'Master’s Degree Program', ['masters']],
+  ['Joint-Master’s-Degree Programs in Environment', 'https://catalog.yale.edu/environment/masters-degree-programs/joint/', 'School of the Environment', 'Joint Master’s Degree', ['masters', 'professional']],
+  ['Doctoral Degree Program in Environment', 'https://catalog.yale.edu/environment/doctoral-degree-program/', 'School of the Environment', 'Doctoral Degree', ['doctorate']],
+
+  ['J.D. Program', 'https://law.yale.edu/study-law-yale/degree-programs', 'Law School', 'Juris Doctor', ['professional']],
+  ['LL.M. Program', 'https://law.yale.edu/study-law-yale/degree-programs/graduate-programs', 'Law School', 'Master of Laws', ['masters', 'professional']],
+  ['M.S.L. Program', 'https://law.yale.edu/study-law-yale/degree-programs/graduate-programs', 'Law School', 'Master of Studies in Law', ['masters', 'professional']],
+  ['J.S.D. Program', 'https://law.yale.edu/study-law-yale/degree-programs/graduate-programs', 'Law School', 'Doctor of the Science of Law', ['doctorate', 'professional']],
+  ['Ph.D. Program in Law', 'https://law.yale.edu/study-law-yale/degree-programs', 'Law School', 'Doctor of Philosophy in Law', ['doctorate', 'professional']],
+  ['Joint Degree Programs in Law', 'https://law.yale.edu/study-law-yale/degree-programs/joint-degrees', 'Law School', 'Joint Degree', ['masters', 'doctorate', 'professional']],
+
+  ['Full-Time M.B.A.', 'https://catalog.yale.edu/management/full-time-mba/', 'School of Management', 'Master of Business Administration', ['masters', 'professional']],
+  ['M.B.A. for Executives', 'https://catalog.yale.edu/management/mba-executives/', 'School of Management', 'Master of Business Administration', ['masters', 'professional']],
+  ['Master of Advanced Management', 'https://catalog.yale.edu/management/mam/', 'School of Management', 'Master of Advanced Management', ['masters', 'professional']],
+  ['Master of Management Studies', 'https://catalog.yale.edu/management/mms/', 'School of Management', 'Master of Management Studies', ['masters', 'professional']],
+  ['Doctoral Degree Program in Management', 'https://catalog.yale.edu/management/doctoral-degree/', 'School of Management', 'Doctoral Degree', ['doctorate']],
+
+  ['MD Program', 'https://medicine.yale.edu/md-program/', 'School of Medicine', 'Doctor of Medicine', ['professional']],
+  ['MD-PhD Program', 'https://medicine.yale.edu/mdphd/', 'School of Medicine', 'Doctor of Medicine / Doctor of Philosophy', ['doctorate', 'professional']],
+  ['PA Program', 'https://medicine.yale.edu/pa/', 'School of Medicine', 'Physician Associate Program', ['masters', 'professional']],
+  ['PA Online Program', 'https://medicine.yale.edu/education/paonline/', 'School of Medicine', 'Physician Associate Program', ['masters', 'professional']],
+  ['MHS in Medical Education', 'https://medicine.yale.edu/edu/mhs-degree/medical-education/', 'School of Medicine', 'Master of Health Science', ['masters', 'professional']],
+  ['MHS in Health Services, Policy, and Outcomes', 'https://medicine.yale.edu/edu/mhs-degree/health-services-policy-outcomes/', 'School of Medicine', 'Master of Health Science', ['masters', 'professional']],
+  ['MHS in Clinical Investigation', 'https://medicine.yale.edu/edu/mhs-degree/clinical-investigation/', 'School of Medicine', 'Master of Health Science', ['masters', 'professional']],
+  ['MHS in Clinical Informatics & Data Science', 'https://medicine.yale.edu/edu/mhs-degree/clinical-informatics-data-science/', 'School of Medicine', 'Master of Health Science', ['masters', 'professional']],
+  ['MHS in Medical AI', 'https://medicine.yale.edu/edu/mhs-degree/medical-ai/', 'School of Medicine', 'Master of Health Science', ['masters', 'professional']],
+
+  ['Master of Music', 'https://music.yale.edu/degrees-and-programs', 'School of Music', 'Master of Music', ['masters', 'professional']],
+  ['Master of Musical Arts', 'https://music.yale.edu/degrees-and-programs', 'School of Music', 'Master of Musical Arts', ['masters', 'professional']],
+  ['Doctor of Musical Arts', 'https://music.yale.edu/degrees-and-programs', 'School of Music', 'Doctor of Musical Arts', ['doctorate', 'professional']],
+  ['Artist Diploma', 'https://music.yale.edu/degrees-and-programs', 'School of Music', 'Artist Diploma', ['diploma', 'professional']],
+  ['Certificate in Performance', 'https://music.yale.edu/degrees-and-programs', 'School of Music', 'Certificate in Performance', ['certificate', 'professional']],
+  ['Bachelor of Arts/Master of Music', 'https://music.yale.edu/degrees-and-programs', 'School of Music', 'Bachelor of Arts / Master of Music', ['masters', 'professional']],
+
+  ['Master’s Program (M.S.N.)', 'https://catalog.yale.edu/nursing/masters-program-msn/', 'School of Nursing', 'Master of Science in Nursing', ['masters', 'professional']],
+  ['Post-Master’s Certificates in Nursing', 'https://catalog.yale.edu/nursing/post-masters-certificates/', 'School of Nursing', 'Post-Master’s Certificate', ['certificate', 'professional']],
+  ['Doctor of Nursing Practice', 'https://catalog.yale.edu/nursing/doctor-nursing-practice-dnp-program/', 'School of Nursing', 'Doctor of Nursing Practice', ['doctorate', 'professional']],
+  ['Doctor of Philosophy in Nursing', 'https://catalog.yale.edu/nursing/doctor-philosophy-program/', 'School of Nursing', 'Doctor of Philosophy', ['doctorate']],
+
+  ['Traditional Two-Year M.P.H.', 'https://catalog.yale.edu/ysph/traditional-two-year-mph-program/', 'School of Public Health', 'Master of Public Health', ['masters', 'professional']],
+  ['Advanced Professional M.P.H.', 'https://catalog.yale.edu/ysph/advanced-professional-mph-program/', 'School of Public Health', 'Master of Public Health', ['masters', 'professional']],
+  ['Executive M.P.H.', 'https://catalog.yale.edu/ysph/executive-mph-program/', 'School of Public Health', 'Master of Public Health', ['masters', 'professional']],
+  ['Master of Science in Public Health', 'https://catalog.yale.edu/ysph/master-science-public-health/', 'School of Public Health', 'Master of Science in Public Health', ['masters', 'professional']],
+  ['Doctoral Degree in Public Health', 'https://catalog.yale.edu/ysph/doctoral-degree/', 'School of Public Health', 'Doctoral Degree', ['doctorate']],
+  ['Public Health Joint-Degree Programs', 'https://catalog.yale.edu/ysph/joint-degree-programs/', 'School of Public Health', 'Joint Degree', ['masters', 'professional']],
+
+  ['Acting', 'https://www.drama.yale.edu/training/acting/', 'David Geffen School of Drama', 'Master of Fine Arts / Certificate in Drama', ['masters', 'certificate', 'professional']],
+  ['Design', 'https://www.drama.yale.edu/training/design/', 'David Geffen School of Drama', 'Master of Fine Arts / Certificate in Drama', ['masters', 'certificate', 'professional']],
+  ['Directing', 'https://www.drama.yale.edu/training/directing/', 'David Geffen School of Drama', 'Master of Fine Arts / Certificate in Drama', ['masters', 'certificate', 'professional']],
+  ['Dramaturgy and Dramatic Criticism', 'https://www.drama.yale.edu/training/dramaturgy-and-dramatic-criticism/', 'David Geffen School of Drama', 'Doctor of Fine Arts / Master of Fine Arts / Certificate in Drama', ['masters', 'doctorate', 'certificate', 'professional']],
+  ['Playwriting', 'https://www.drama.yale.edu/training/playwriting/', 'David Geffen School of Drama', 'Master of Fine Arts / Certificate in Drama', ['masters', 'certificate', 'professional']],
+  ['Stage Management', 'https://www.drama.yale.edu/training/stage-management/', 'David Geffen School of Drama', 'Master of Fine Arts / Certificate in Drama', ['masters', 'certificate', 'professional']],
+  ['Technical Design and Production', 'https://www.drama.yale.edu/training/technical-design-production/', 'David Geffen School of Drama', 'Master of Fine Arts / Certificate in Drama', ['masters', 'certificate', 'professional']],
+  ['Theater Management', 'https://www.drama.yale.edu/training/theater-management/', 'David Geffen School of Drama', 'Master of Fine Arts / Certificate in Drama', ['masters', 'certificate', 'professional']],
+];
+
+function decodeHtml(value = '') {
+  return value
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([\da-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&apos;|&#0*39;|&rsquo;/gi, "'")
+    .replace(/&lsquo;/gi, "'")
+    .replace(/&ndash;|&mdash;/gi, '-')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>');
+}
+
+function text(value = '') {
+  return decodeHtml(
+    value
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<[^>]+>/g, ' '),
+  ).replace(/\s+/g, ' ').trim();
+}
+
+function parseOptions(args) {
+  const degreeLevel = String(args['degree-level'] ?? 'all').trim().toLowerCase();
+  if (degreeLevel !== '' && !DEGREE_LEVELS.has(degreeLevel)) {
+    throw new ArgumentError(`--degree-level must be one of: ${[...DEGREE_LEVELS].join(', ')}`);
+  }
+  if (args.count === undefined || args.count === null || args.count === '') {
+    return { degreeLevel, count: null };
+  }
+  const count = Number(args.count);
+  if (!Number.isInteger(count) || count <= 0) {
+    throw new ArgumentError('--count must be a positive integer');
+  }
+  return { degreeLevel, count };
+}
+
+function absoluteUrl(value, base) {
+  const url = new URL(decodeHtml(value), base);
+  url.hash = '';
+  return url.href;
+}
+
+async function fetchHtml(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; Webcmd Yale public data export)' },
+      redirect: 'follow',
+      signal: controller.signal,
+    });
+    if (!response.ok) throw new CommandExecutionError(`Yale source request failed: HTTP ${response.status} ${url}`);
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.includes('text/html')) {
+      throw new CommandExecutionError(`Yale source returned ${contentType || 'unknown content type'} instead of HTML: ${url}`);
+    }
+    return await response.text();
+  } catch (error) {
+    if (error instanceof CommandExecutionError) throw error;
+    throw new CommandExecutionError(`Yale source request failed for ${url}: ${error.message}`);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function sectionText(html, id) {
+  const section = html.match(new RegExp(`<section[^>]+id=["']${id}["'][^>]*>([\\s\\S]*?)(?=<section[^>]+id=|</main>|</article>|$)`, 'i'))?.[1] || '';
+  return text(section);
+}
+
+function tagsFromDegree(degree) {
+  const tags = new Set();
+  if (/master|M\.?A\.?|M\.?S\.?|M\.?M\.?|M\.?F\.?A\.?|M\.?P\.?H\.?|M\.?B\.?A\.?|M\.?D[iiv]|M\.?A\.?M\.?|M\.?M\.?S\.?/i.test(degree)) tags.add('masters');
+  if (/certificate/i.test(degree)) tags.add('certificate');
+  if (/diploma/i.test(degree)) tags.add('diploma');
+  if (/doctor|PhD|Ph\.D|D\.?N\.?P|D\.?M\.?A|D\.?F\.?A|J\.?S\.?D/i.test(degree)) tags.add('doctorate');
+  return [...tags];
+}
+
+function parseGsasPrograms(html) {
+  if (!html.includes('program-listing__item')) {
+    throw new CommandExecutionError('Yale GSAS program page structure changed: missing program list marker');
+  }
+  const rows = [];
+  const itemPattern = /<li class=["']program-listing__item["'][^>]*>([\s\S]*?)<\/li>\s*(?=<li class=["']program-listing__item["']|<\/ol>)/gi;
+  for (const item of html.matchAll(itemPattern)) {
+    const block = item[1];
+    const link = block.match(/<a\s+href=["']([^"']+)["'][^>]*class=["'][^"']*arrow-link[^"']*["'][^>]*>([\s\S]*?)<\/a>/i);
+    if (!link) continue;
+    const degreesBlock = block.match(/<div class=["']program-listing__degree["'][^>]*>([\s\S]*?)<\/div>/i)?.[1] || '';
+    const degrees = [...degreesBlock.matchAll(/<li[^>]*>([\s\S]*?)<\/li>/gi)].map((m) => text(m[1])).filter(Boolean);
+    if (!degrees.length) continue;
+    const deadline = text(block.match(/<span class=["']date["'][^>]*>([\s\S]*?)<\/span>/i)?.[1] || '');
+    const division = text(block.match(/<em>([\s\S]*?)<\/em>/i)?.[1] || '');
+    const tags = [...new Set(degrees.flatMap(tagsFromDegree))];
+    rows.push({
+      name: text(link[2]),
+      url: absoluteUrl(link[1], GSAS_PROGRAMS_URL),
+      school: 'Graduate School of Arts and Sciences',
+      degree: degrees.join(' | '),
+      substream: division,
+      tags,
+      note: deadline ? `Application deadline: ${deadline}.` : '',
+      source: GSAS_PROGRAMS_URL,
+    });
+  }
+  if (!rows.length) throw new CommandExecutionError('Yale GSAS parser found no graduate programs');
+  return rows;
+}
+
+function parseGsasCertificates(html) {
+  if (!html.includes('Current certificates:')) {
+    throw new CommandExecutionError('Yale GSAS certificates page structure changed: missing certificate marker');
+  }
+  const rows = [];
+  const current = html.match(/<strong>Current certificates:<\/strong><\/p><ul>([\s\S]*?)<\/ul><h2>Certificates in Training<\/h2>/i)?.[1] || '';
+  const training = html.match(/<h2>Certificates in Training<\/h2>[\s\S]*?<ul>([\s\S]*?)<\/ul>/i)?.[1] || '';
+  for (const block of [current, training]) {
+    for (const match of block.matchAll(/<li>(?:<a\s+href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>|([^<]+))/gi)) {
+      const name = text(match[2] || match[3] || '');
+      const url = match[1] ? absoluteUrl(match[1], GSAS_CERTIFICATES_URL) : GSAS_CERTIFICATES_URL;
+      if (!name || /African Studies|European and Russian|Latin American|Middle East/i.test(name)) continue;
+      rows.push({
+        name,
+        url,
+        school: 'Graduate School of Arts and Sciences',
+        degree: 'Graduate Certificate',
+        substream: 'Certificate',
+        tags: ['certificate'],
+        note: 'GSAS certificate program.',
+        source: GSAS_CERTIFICATES_URL,
+      });
+    }
+  }
+  return rows;
+}
+
+function professionalRows() {
+  return PROFESSIONAL_PROGRAMS.map(([name, url, school, degree, tags]) => ({
+    name,
+    url,
+    school,
+    degree,
+    substream: school,
+    tags,
+    note: 'Official Yale school/catalog program page.',
+    source: YALE_GRAD_PROF_URL,
+  }));
+}
+
+function greRequirement(admissionText = '') {
+  if (/GRE is not accepted|GRE General Test scores will not be considered/i.test(admissionText)) return 'No';
+  if (/GRE is required|must submit GRE/i.test(admissionText)) return 'Yes';
+  if (/GRE is optional|may submit GRE/i.test(admissionText)) return 'Optional';
+  if (/GRE/i.test(admissionText)) return 'See requirements';
+  return '';
+}
+
+async function enrichGsasProgram(program) {
+  if (program.school !== 'Graduate School of Arts and Sciences' || !program.url.startsWith(`${GSAS_PROGRAMS_URL}/`)) return program;
+  try {
+    const html = await fetchHtml(program.url);
+    const admissionText = sectionText(html, 'admission-requirements');
+    return {
+      ...program,
+      admissionText,
+      greRequired: greRequirement(admissionText),
+      englishRequirement: admissionText.match(/TOEFL iBT or IELTS Academic[^.]+\.[\s\S]*?(?=Academic Information|Financial Information|$)/i)?.[0]?.replace(/\s+/g, ' ').trim() || '',
+      detailError: '',
+    };
+  } catch (error) {
+    return { ...program, admissionText: '', greRequired: '', englishRequirement: '', detailError: error.message };
+  }
+}
+
+async function enrichPrograms(programs) {
+  const rows = [];
+  for (let index = 0; index < programs.length; index += DETAIL_CONCURRENCY) {
+    rows.push(...await Promise.all(programs.slice(index, index + DETAIL_CONCURRENCY).map(enrichGsasProgram)));
+  }
+  return rows;
+}
+
+function normalizeRecord(program) {
+  const row = Object.fromEntries(COLUMNS.map((column) => [column, '']));
+  const isGsas = program.school === 'Graduate School of Arts and Sciences';
+  const refs = [`Course: ${program.url}`, `Source: ${program.source}`];
+  const remarks = [
+    `Checked ${CHECKED_DATE}; official Yale source.`,
+    program.note,
+    program.detailError ? `Detail page fields unavailable: ${program.detailError}` : '',
+    isGsas ? 'GSAS fee, tuition, test, and admissions values are enriched from official GSAS detail/shared pages.' : 'Professional-school fields without a page value are marked unavailable for that official program page.',
+  ].filter(Boolean);
+
+  row['Course Name'] = program.name;
+  row['Course URL'] = program.url;
+  row['University \nname'] = UNIVERSITY;
+  row['Substream/\nSpecialisation'] = program.substream;
+  row['Degree Level'] = program.degree;
+  row['Study Level'] = 'PG';
+  row['Program Type'] = program.school;
+  row['Status'] = 'Official listing active';
+  if (isGsas) {
+    refs.push(`Application fee: ${GSAS_APPLICATION_URL}`, `Standardized tests: ${GSAS_TESTS_URL}`, `Tuition: ${GSAS_TUITION_URL}`);
+    row['App fees'] = 'USD 105';
+    row['Tution fees \n(per year)'] = 'USD 52,400 full-time GSAS tuition for 2026-2027';
+    row['Total Tution \nFees'] = 'Not available as a fixed total on official GSAS tuition page';
+    row['IELTS \n(Overall & Subscores)'] = 'IELTS Academic required for most applicants whose native language is not English; minimum score not available on official GSAS page';
+    row['TOEFL\n(Overall & Subscores)'] = 'TOEFL iBT required for most applicants whose native language is not English; minimum score not available on official GSAS page';
+    row['Is Waiver \nProvided?'] = 'Yes';
+    row['Waiver Info'] = 'English test exemption may apply with an undergraduate degree from an institution where English is the primary language of instruction and at least three years in residence';
+    row['GRE Required'] = program.greRequired;
+    row['GMAT Required'] = /Management/i.test(program.name) ? 'GMAT accepted in lieu of GRE for Management PhD' : 'No';
+    row['GRE/GMAT Scores'] = program.greRequired === 'No' ? 'GRE not accepted' : program.greRequired ? 'Minimum score not available on official GSAS page' : '';
+    row['Main Entry \nRequirements'] = program.admissionText;
+  }
+  row['Remarks (if any)'] = remarks.join(' ');
+  row['Reference Links (if any)'] = refs.join(' | ');
+  return applyBlankPolicy(row, isGsas ? 'GSAS' : 'school/program');
+}
+
+function applyBlankPolicy(row, scope) {
+  const unavailable = `Not available as a fixed value on official ${scope} page`;
+  for (const column of [
+    'Intake Month',
+    'Duration\n(in months)',
+    'Study option',
+    'Partner',
+    'PTE\n(Overall & Subscores)',
+    'Duolingo\n(Overall & Subscores)',
+    'Is MOI \naccepted?',
+    'Share list, if any',
+    '15 years of\nEducation Allowed?',
+    'Gap Years',
+    'Backlogs',
+    'Work \nExperience \nRequired?',
+    'Intake status(open/close)\n(eg: Fall (september)-Open\nSpring(January)- Closed)',
+  ]) {
+    if (!row[column]) row[column] = column === 'Partner' ? 'Not applicable unless listed by official program page' : unavailable;
+  }
+  for (const column of [
+    'ielts_reading_score',
+    'ielts_writing_score',
+    'ielts_listening_score',
+    'ielts_speaking_score',
+    'toefl_reading_score',
+    'toefl_writing_score',
+    'toefl_listening_score',
+    'toefl_speaking_score',
+    'pte_reading_score',
+    'pte_writing_score',
+    'pte_listening_score',
+    'pte_speaking_score',
+    'duolingo_comprehension_score',
+    'duolingo_literacy_score',
+    'duolingo_conversation_score',
+    'duolingo_production_score',
+    'GRE/GMAT Scores',
+    'Min UG score',
+  ]) {
+    if (!row[column]) row[column] = `Not available on official ${scope} page`;
+  }
+  if (!row['App fees']) row['App fees'] = unavailable;
+  if (!row['Tution fees \n(per year)']) row['Tution fees \n(per year)'] = unavailable;
+  if (!row['Total Tution \nFees']) row['Total Tution \nFees'] = unavailable;
+  if (!row['IELTS \n(Overall & Subscores)']) row['IELTS \n(Overall & Subscores)'] = unavailable;
+  if (!row['TOEFL\n(Overall & Subscores)']) row['TOEFL\n(Overall & Subscores)'] = unavailable;
+  if (!row['Is Waiver \nProvided?']) row['Is Waiver \nProvided?'] = unavailable;
+  if (!row['Waiver Info']) row['Waiver Info'] = unavailable;
+  if (!row['GRE Required']) row['GRE Required'] = unavailable;
+  if (!row['GMAT Required']) row['GMAT Required'] = unavailable;
+  if (!row['12th scores']) row['12th scores'] = 'Not applicable for postgraduate admission';
+  if (!row['Main Entry \nRequirements']) row['Main Entry \nRequirements'] = unavailable;
+  return row;
+}
+
+function validateRecord(row) {
+  for (const column of ['Course Name', 'Course URL', 'University \nname', 'Degree Level', 'Study Level', 'Reference Links (if any)']) {
+    if (!row[column]?.trim()) throw new CommandExecutionError(`Yale row is missing required field: ${column}`);
+  }
+  if (!/^https:\/\/(?:[a-z0-9-]+\.)*yale\.edu\//i.test(row['Course URL'])) {
+    throw new CommandExecutionError(`Yale row has non-official course URL: ${row['Course URL']}`);
+  }
+  if (row['Study Level'] !== 'PG') throw new CommandExecutionError('Yale row Study Level must be PG');
+  return row;
+}
+
+function dedupe(programs) {
+  const seen = new Set();
+  const rows = [];
+  for (const program of programs) {
+    const key = `${program.name}\n${program.url}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    rows.push(program);
+  }
+  return rows;
+}
+
+cli({
+  site: 'yale',
+  name: 'export-postgraduate-courses',
+  description: 'Export Yale University postgraduate and professional programs from official Yale sources.',
+  access: 'read',
+  example: 'webcmd yale export-postgraduate-courses --degree-level masters --count 10 -f csv',
+  domain: 'yale.edu',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'degree-level', type: 'string', default: 'all', help: 'all, masters, certificate, diploma, professional, or doctorate' },
+    { name: 'count', type: 'int', required: false, help: 'Positive maximum number of programs after filtering and deduplication' },
+  ],
+  columns: OUTPUT_COLUMNS,
+  func: async (args) => {
+    const { degreeLevel, count } = parseOptions(args);
+    const [gsasProgramsHtml, gsasCertificatesHtml] = await Promise.all([
+      fetchHtml(GSAS_PROGRAMS_URL),
+      fetchHtml(GSAS_CERTIFICATES_URL),
+    ]);
+    const programs = dedupe([
+      ...parseGsasPrograms(gsasProgramsHtml),
+      ...parseGsasCertificates(gsasCertificatesHtml),
+      ...professionalRows(),
+    ]).filter((program) => degreeLevel === 'all' || program.tags.includes(degreeLevel));
+    const selected = await enrichPrograms(count === null ? programs : programs.slice(0, count));
+    return selected.map((program) => {
+      const row = validateRecord(normalizeRecord(program));
+      return CSV_OUTPUT
+        ? Object.fromEntries(COLUMNS.map((column, index) => [OUTPUT_COLUMNS[index], row[column]]))
+        : row;
+    });
+  },
+});

--- a/plugins/yale/export-postgraduate-courses.js
+++ b/plugins/yale/export-postgraduate-courses.js
@@ -314,10 +314,30 @@ function greRequirement(admissionText = '') {
   return '';
 }
 
-async function enrichGsasProgram(program) {
-  if (program.school !== 'Graduate School of Arts and Sciences' || !program.url.startsWith(`${GSAS_PROGRAMS_URL}/`)) return program;
+function pageSummary(html, programName = '') {
+  const value = text(String(html)
+    .replace(/<nav\b[^>]*>[\s\S]*?<\/nav>/gi, ' ')
+    .replace(/<footer\b[^>]*>[\s\S]*?<\/footer>/gi, ' ')
+    .replace(/<header\b[^>]*>[\s\S]*?<\/header>/gi, ' ')
+    .replace(/<h[1-6]\b[^>]*>/gi, ' | ')
+    .replace(/<\/(?:p|li|h[1-6]|div|section)>/gi, ' | '));
+  const needle = programName.split(/\s+/).slice(0, 3).join(' ');
+  const at = needle ? value.toLowerCase().indexOf(needle.toLowerCase()) : -1;
+  return (at >= 0 ? value.slice(at) : value).replace(/\s*\|\s*/g, ' | ').slice(0, 1800).trim();
+}
+
+async function enrichProgram(program) {
   try {
     const html = await fetchHtml(program.url);
+    if (program.school !== 'Graduate School of Arts and Sciences' || !program.url.startsWith(`${GSAS_PROGRAMS_URL}/`)) {
+      return {
+        ...program,
+        admissionText: pageSummary(html, program.name),
+        greRequired: greRequirement(pageSummary(html, program.name)),
+        englishRequirement: '',
+        detailError: '',
+      };
+    }
     const admissionText = sectionText(html, 'admission-requirements');
     return {
       ...program,
@@ -334,7 +354,7 @@ async function enrichGsasProgram(program) {
 async function enrichPrograms(programs) {
   const rows = [];
   for (let index = 0; index < programs.length; index += DETAIL_CONCURRENCY) {
-    rows.push(...await Promise.all(programs.slice(index, index + DETAIL_CONCURRENCY).map(enrichGsasProgram)));
+    rows.push(...await Promise.all(programs.slice(index, index + DETAIL_CONCURRENCY).map(enrichProgram)));
   }
   return rows;
 }
@@ -371,6 +391,9 @@ function normalizeRecord(program) {
     row['GMAT Required'] = /Management/i.test(program.name) ? 'GMAT accepted in lieu of GRE for Management PhD' : 'No';
     row['GRE/GMAT Scores'] = program.greRequired === 'No' ? 'GRE not accepted' : program.greRequired ? 'Minimum score not available on official GSAS page' : '';
     row['Main Entry \nRequirements'] = program.admissionText;
+  } else if (program.admissionText) {
+    row['Main Entry \nRequirements'] = program.admissionText;
+    row['GRE Required'] = program.greRequired || '';
   }
   row['Remarks (if any)'] = remarks.join(' ');
   row['Reference Links (if any)'] = refs.join(' | ');

--- a/plugins/yale/package.json
+++ b/plugins/yale/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "webcmd-plugin-yale",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Yale University postgraduate course export adapter",
+  "peerDependencies": {
+    "@agentrhq/webcmd": ">=0.5.2"
+  }
+}

--- a/plugins/yale/webcmd-plugin.json
+++ b/plugins/yale/webcmd-plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "yale",
+  "version": "0.1.0",
+  "description": "Yale University postgraduate course export adapter",
+  "webcmd": ">=0.5.2",
+  "author": {
+    "name": "WebCMD Agent",
+    "handle": "agentrhq"
+  }
+}

--- a/webcmd-plugin.json
+++ b/webcmd-plugin.json
@@ -14,6 +14,76 @@
         "handle": "agentrhq"
       }
     },
+    "cincinnati": {
+      "path": "plugins/cincinnati",
+      "version": "0.1.0",
+      "description": "University of Cincinnati postgraduate course export adapter",
+      "webcmd": ">=0.5.2",
+      "author": {
+        "name": "WebCMD Agent",
+        "handle": "agentrhq"
+      }
+    },
+    "concordia": {
+      "path": "plugins/concordia",
+      "version": "0.1.0",
+      "description": "Concordia University Montréal postgraduate course export adapter",
+      "webcmd": ">=0.5.2",
+      "author": {
+        "name": "WebCMD Agent",
+        "handle": "agentrhq"
+      }
+    },
+    "goettingen": {
+      "path": "plugins/goettingen",
+      "version": "0.1.0",
+      "description": "University of Göttingen postgraduate course export adapter",
+      "webcmd": ">=0.5.2",
+      "author": {
+        "name": "WebCMD Agent",
+        "handle": "agentrhq"
+      }
+    },
+    "heidelberg": {
+      "path": "plugins/heidelberg",
+      "version": "0.1.0",
+      "description": "Heidelberg University postgraduate course export adapter",
+      "webcmd": ">=0.5.2",
+      "author": {
+        "name": "WebCMD Agent",
+        "handle": "agentrhq"
+      }
+    },
+    "hft": {
+      "path": "plugins/hft",
+      "version": "0.1.0",
+      "description": "HFT Stuttgart postgraduate course export adapter",
+      "webcmd": ">=0.5.2",
+      "author": {
+        "name": "WebCMD Agent",
+        "handle": "agentrhq"
+      }
+    },
+    "iit": {
+      "path": "plugins/iit",
+      "version": "0.1.0",
+      "description": "Illinois Institute of Technology postgraduate course export adapter",
+      "webcmd": ">=0.5.2",
+      "author": {
+        "name": "WebCMD Agent",
+        "handle": "agentrhq"
+      }
+    },
+    "jhu": {
+      "path": "plugins/jhu",
+      "version": "0.1.0",
+      "description": "Johns Hopkins University postgraduate course export adapter",
+      "webcmd": ">=0.5.2",
+      "author": {
+        "name": "WebCMD Agent",
+        "handle": "agentrhq"
+      }
+    },
     "pypi": {
       "path": "plugins/pypi",
       "version": "0.1.0",
@@ -39,6 +109,26 @@
       "version": "0.1.0",
       "description": "Search and read TechCrunch stories from its public API",
       "webcmd": ">=0.2.0",
+      "author": {
+        "name": "WebCMD Agent",
+        "handle": "agentrhq"
+      }
+    },
+    "ualberta": {
+      "path": "plugins/ualberta",
+      "version": "0.1.0",
+      "description": "University of Alberta postgraduate course export adapter",
+      "webcmd": ">=0.5.2",
+      "author": {
+        "name": "WebCMD Agent",
+        "handle": "agentrhq"
+      }
+    },
+    "yale": {
+      "path": "plugins/yale",
+      "version": "0.1.0",
+      "description": "Yale University postgraduate course export adapter",
+      "webcmd": ">=0.5.2",
       "author": {
         "name": "WebCMD Agent",
         "handle": "agentrhq"


### PR DESCRIPTION
## Summary
- add Webcmd community plugins for IIT, Concordia, University of Alberta, JHU, Yale, Göttingen, Heidelberg, HFT Stuttgart, and University of Cincinnati
- register each plugin in the root community plugin manifest and README catalog
- each plugin exposes `export-postgraduate-courses` with the shared postgraduate course CSV schema

## Verification
- `npm run check-community-plugins`
- `node dist/src/main.js list -f json` confirmed each new site registers `export-postgraduate-courses` exactly once
- `node dist/src/main.js <site> export-postgraduate-courses --count 1 -f json` passed for all 9 sites: iit, concordia, ualberta, jhu, yale, goettingen, heidelberg, hft, cincinnati
