### PR TITLE
fix(hosted): accept expiresAt in browser run responses

### DIFF
--- a/src/hosted/client.test.ts
+++ b/src/hosted/client.test.ts
@@ -1014,6 +1014,61 @@ describe('HostedClient', () => {
     ]);
   });
 
+  it('accepts the live-view expiry returned with a hosted browser run', async () => {
+    const client = new HostedClient({
+      apiBaseUrl: 'https://api.example.com',
+      apiKey: 'wcmd_live_test',
+      fetchImpl: async () => new Response(JSON.stringify({
+        ok: true,
+        result: { url: 'https://example.com' },
+        columns: ['url'],
+        trace: null,
+        run: {
+          executionId: 'exec_1',
+          session: 'work',
+          profile: { id: 'profile_default', displayName: 'default' },
+          liveViewUrl: 'https://api.example.com/account/live/view_1',
+          expiresAt: '2026-08-03T20:54:04.384Z',
+        },
+        execution: { id: 'exec_1', status: 'succeeded' },
+      }), { status: 200 }),
+    });
+
+    await expect(client.runBrowserAction('work', {
+      command: 'browser/open',
+      action: 'navigate',
+      args: { url: 'https://example.com' },
+    })).resolves.toMatchObject({
+      run: { expiresAt: '2026-08-03T20:54:04.384Z' },
+    });
+  });
+
+  it('rejects a non-string hosted browser run expiry', async () => {
+    const client = new HostedClient({
+      apiBaseUrl: 'https://api.example.com',
+      apiKey: 'wcmd_live_test',
+      fetchImpl: async () => new Response(JSON.stringify({
+        ok: true,
+        result: { url: 'https://example.com' },
+        columns: ['url'],
+        trace: null,
+        run: {
+          executionId: 'exec_1',
+          session: 'work',
+          profile: { id: 'profile_default', displayName: 'default' },
+          expiresAt: 123,
+        },
+        execution: { id: 'exec_1', status: 'succeeded' },
+      }), { status: 200 }),
+    });
+
+    await expect(client.runBrowserAction('work', {
+      command: 'browser/open',
+      action: 'navigate',
+      args: { url: 'https://example.com' },
+    })).rejects.toMatchObject({ code: 'HOSTED_PROTOCOL' });
+  });
+
   it('attaches the workspace header when a workspace is configured', async () => {
     const requests: Array<{ workspace: string | null }> = [];
     const client = new HostedClient({

--- a/src/hosted/client.ts
+++ b/src/hosted/client.ts
@@ -569,11 +569,12 @@ function isHostedBrowserRunResponse(value: unknown, requestedSession: string): v
 
 function isHostedBrowserRunPayload(value: unknown, requestedSession: string): value is HostedBrowserRunResponse['run'] {
   const run = value;
-  if (!hasOnlyKeys(run, ['executionId', 'session', 'profile', 'liveViewUrl'])) return false;
+  if (!hasOnlyKeys(run, ['executionId', 'session', 'profile', 'liveViewUrl', 'expiresAt'])) return false;
   if (typeof run.executionId !== 'string' || run.session !== requestedSession) return false;
   if (!hasExactKeys(run.profile, ['id', 'displayName'])) return false;
   if (typeof run.profile.id !== 'string' || typeof run.profile.displayName !== 'string') return false;
-  return run.liveViewUrl === undefined || typeof run.liveViewUrl === 'string';
+  if (run.liveViewUrl !== undefined && typeof run.liveViewUrl !== 'string') return false;
+  return run.expiresAt === undefined || typeof run.expiresAt === 'string';
 }
 
 function isHostedBrowserActionResponse(value: unknown): value is HostedBrowserActionResponse {

--- a/src/hosted/types.ts
+++ b/src/hosted/types.ts
@@ -211,6 +211,7 @@ export interface HostedBrowserRunResponse {
       displayName: string;
     };
     liveViewUrl?: string;
+    expiresAt?: string;
   };
 }
 


### PR DESCRIPTION
## Description

Updates the hosted browser response contract and runtime validation to accept the optional `run.expiresAt` timestamp returned by Webcmd Cloud.

Previously, the strict response validator rejected otherwise-valid cloud responses containing this field, causing hosted browser commands and cloud-backed evals to fail with an invalid browser run response error.

Adds regression coverage to ensure:

- String-valued `expiresAt` fields are accepted.
- Responses without `expiresAt` remain supported.
- Non-string `expiresAt` values are rejected.

Related issue: Closes #193

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [ ] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

### Adapter Notes

Not applicable—this change does not modify a site adapter or command interface.

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Before:

```text
Webcmd Cloud returned an invalid browser run response.