### PR TITLE
 docs: add missing top-level commands to CLI reference

### DIFF
--- a/docs/cli-reference.mdx
+++ b/docs/cli-reference.mdx
@@ -62,15 +62,18 @@ The old `web read` command has been renamed to `web fetch-browser`.
 | `list` | Show registered built-in, user, plugin, and external commands. |
 | `setup` | Choose local or hosted mode interactively. |
 | `doctor` | Diagnose browser bridge and daemon connectivity. |
+| `daemon` | Manage the local Webcmd daemon: status, stop, and restart. |
 | `browser` | Agent-facing browser runtime for exploration and verification. |
 | `web` | Local URL fetch and browser-backed page fetch helpers. |
 | `profile` | List, rename, and select browser runtime profiles. |
+| `auth` | Inspect website login status, and refresh logged-in site sessions. |
 | `plugin` | Install, update, list, create, and uninstall plugins. |
 | `adapter` | Eject, reset, and inspect local adapter overrides. |
 | `external` | Register or install external local CLIs. |
 | `validate` | Validate adapter definitions. |
 | `verify` | Validate and smoke test an adapter. |
-| `skills` | List and read bundled Webcmd agent skills. |
+| `convention-audit` | Scan adapters for agent-native convention violations. |
+| `skills` | List, add, update, and remove bundled Webcmd agent skills. |
 | `completion` | Print shell completion scripts. |
 
 ## Output Formats


### PR DESCRIPTION
## Description

Fixes #197 

The **Top-Level Commands** table in `docs/cli-reference.mdx` has drifted from the registered command surface. Three commands are missing entirely, and one row describes a subcommand that does not exist.

**Missing rows**

| Command | Registered at | Description in code |
| --- | --- | --- |
| `daemon` | `src/cli.ts:3572` | "Manage the webcmd daemon" (`status`, `stop`, `restart`) |
| `auth` | `src/commands/auth.ts:457` (via `registerAuthCommands(program)`) | "Inspect website login status" (`status`, `refresh`) |
| `convention-audit` | `src/cli.ts:918` | "Scan adapters for agent-native convention violations" |

All three already appear in `src/completion-shared.ts` `localOnlyCommands`, so shell completion offers them while the published reference does not document them.

**Incorrect row**

`skills` was described as "List and **read** bundled Webcmd agent skills." There is no `skills read` subcommand. The actual set is `list` / `add` / `update` / `remove` (`src/cli.ts:857`, `:872`, `:893`, `:908`), described in code as "List, add, update, and remove bundled Webcmd skills" (`src/cli.ts:845`).

This one matters beyond accuracy: `webcmd skills add` is the second command in the README Quick Start, `docs/index.mdx`, and `docs/quickstart.mdx` — the install step every new user runs — and it appeared nowhere in the command reference, while a capability that does not exist did.

Each new row's wording is taken from the command's own `.description()` so the table and `--help` stay consistent.

Related issue:

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

Notes on the checklist:

- This is a docs-only change to a Markdown table; no code, tests, or generated artifacts are touched. Every row was verified against its registration in `src/` rather than by running the suite.
- No automated check covers this table's contents. `src/docs-sync-review.ts` lists `docs/cli-reference.mdx` as a watched path only, which is why the drift went unnoticed.

### Adapter Notes

Not applicable — no adapter is added or modified in this PR.

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Net diff against `main` — one file, +4 / -1:

```diff
 | `list` | Show registered built-in, user, plugin, and external commands. |
 | `setup` | Choose local or hosted mode interactively. |
 | `doctor` | Diagnose browser bridge and daemon connectivity. |
+| `daemon` | Manage the local Webcmd daemon: status, stop, and restart. |
 | `browser` | Agent-facing browser runtime for exploration and verification. |
 | `web` | Local URL fetch and browser-backed page fetch helpers. |
 | `profile` | List, rename, and select browser runtime profiles. |
+| `auth` | Inspect website login status, and refresh logged-in site sessions. |
 | `plugin` | Install, update, list, create, and uninstall plugins. |
 | `adapter` | Eject, reset, and inspect local adapter overrides. |
 | `external` | Register or install external local CLIs. |
 | `validate` | Validate adapter definitions. |
 | `verify` | Validate and smoke test an adapter. |
-| `skills` | List and read bundled Webcmd agent skills. |
+| `convention-audit` | Scan adapters for agent-native convention violations. |
+| `skills` | List, add, update, and remove bundled Webcmd agent skills. |
 | `completion` | Print shell completion scripts. |
```

### Scope note

`antigravity` also appears in `completion-shared.ts` `localOnlyCommands` but is deliberately **not** added here. It is a site adapter with 31 commands in `cli-manifest.json` (`send`, `read`, `history`, `model`, `watch`, …); `src/cli.ts:3670` only attaches a `serve` subcommand to that existing namespace. Listing it in a table of non-adapter commands would raise the question of why the other ~110 adapters are absent. Happy to add it if maintainers prefer otherwise.