### PR TITLE
docs: document the skills subcommands in the CLI reference

### DIFF
--- a/docs/cli-reference.mdx
+++ b/docs/cli-reference.mdx
@@ -134,6 +134,19 @@ webcmd plugin install github:agentrhq/webcmd/plugins/ycombinator
 
 Hosted mode supports the same `plugin search` and `plugin install` grammar for Webcmd-verified marketplace adapters. Other plugin management commands remain local-only in hosted mode.
 
+## Skills
+
+Bundled agent skills ship with the package. `webcmd skills add` links them into an agent harness and is part of first-time setup.
+
+```bash
+webcmd skills list
+webcmd skills add
+webcmd skills update
+webcmd skills remove
+```
+
+On a TTY, `skills add` prompts for whichever of scope and harness you did not pass. Use `--scope <user|project>` and `--provider <agents|codex|claude>` to skip the prompts, or `--path <skills-dir>` to link into a custom directory. Outside a TTY, and with `--json`, it never prompts. Run `skills update` after upgrading the package to refresh the links.
+
 ## External CLIs
 
 Agents can expose local tools through Webcmd, such as `gh`, `docker`, `vercel`, or internal CLIs.

--- a/docs/cli-reference.mdx
+++ b/docs/cli-reference.mdx
@@ -62,15 +62,18 @@ The old `web read` command has been renamed to `web fetch-browser`.
 | `list` | Show registered built-in, user, plugin, and external commands. |
 | `setup` | Choose local or hosted mode interactively. |
 | `doctor` | Diagnose browser bridge and daemon connectivity. |
+| `daemon` | Manage the local Webcmd daemon: status, stop, and restart. |
 | `browser` | Agent-facing browser runtime for exploration and verification. |
 | `web` | Local URL fetch and browser-backed page fetch helpers. |
 | `profile` | List, rename, and select browser runtime profiles. |
+| `auth` | Inspect website login status, and refresh logged-in site sessions. |
 | `plugin` | Install, update, list, create, and uninstall plugins. |
 | `adapter` | Eject, reset, and inspect local adapter overrides. |
 | `external` | Register or install external local CLIs. |
 | `validate` | Validate adapter definitions. |
 | `verify` | Validate and smoke test an adapter. |
-| `skills` | List and read bundled Webcmd agent skills. |
+| `convention-audit` | Scan adapters for agent-native convention violations. |
+| `skills` | List, add, update, and remove bundled Webcmd agent skills. |
 | `completion` | Print shell completion scripts. |
 
 ## Output Formats


### PR DESCRIPTION
## Description

Fixes #199 

Adds a **Skills** section to `docs/cli-reference.mdx` documenting the four `skills` subcommands and the flags that control `skills add`.

`webcmd skills add` is the second command in the README Quick Start, `docs/index.mdx`, and `docs/quickstart.mdx` — the install step every new user runs — but the command reference never showed it, or the other three subcommands, or any of their flags.

Everything in the new section is taken from the registrations rather than paraphrased:

| Documented | Source |
| --- | --- |
| `skills list` / `add` / `update` / `remove` | `src/cli.ts:857`, `:872`, `:893`, `:908` |
| `--scope <user\|project>` | `normalizeScope`, `src/skills.ts:162-165` (`global` and `local` are accepted aliases) |
| `--provider <agents\|codex\|claude>` | `src/cli.ts:875` |
| Prompts for whichever of scope and harness was not passed | `resolveSkillAddOptions`, `src/cli.ts:96-116` |
| Never prompts outside a TTY or with `--json` | `isInteractiveSkillAdd`, `src/cli.ts:92-94` |

That last row is the practically useful one and was not written down anywhere: an agent or CI job running `skills add` non-interactively needs to know it will not block on a prompt.

Placed between **Plugins** and **External CLIs**, since plugins and skills are the two extension surfaces on the page.

### Stacking

This branch is based on `fix/cli-reference-missing-commands`, not on `main`, because that branch already corrects the `skills` row in the Top-Level Commands table ("List and read…" → "List, add, update, and remove…"). Branching from `main` would have touched the same line twice across two PRs.

- Against its base branch, this PR is **+13 / -0** — the new section only.
- Against `main`, it shows **+17 / -1**, because it carries the base branch's table changes too.

Please merge the base PR first. If you would rather have one self-contained PR, say so and I will rebuild this against `main` with both changes and close the other.

Related issue:

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

Notes on the checklist:

- Docs-only change to one `.mdx` file; no code, tests, or generated artifacts are touched. Each claim was verified against its registration in `src/` rather than by running the suite.
- No automated check covers this page's contents. `src/docs-sync-review.ts` lists `docs/cli-reference.mdx` as a watched path only.

### Adapter Notes

Not applicable — no adapter is added or modified in this PR.

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Diff against the base branch — one file, +13:

````diff
 Hosted mode supports the same `plugin search` and `plugin install` grammar for Webcmd-verified marketplace adapters. Other plugin management commands remain local-only in hosted mode.

+## Skills
+
+Bundled agent skills ship with the package. `webcmd skills add` links them into an agent harness and is part of first-time setup.
+
+```bash
+webcmd skills list
+webcmd skills add
+webcmd skills update
+webcmd skills remove
+```
+
+On a TTY, `skills add` prompts for whichever of scope and harness you did not pass. Use `--scope <user|project>` and `--provider <agents|codex|claude>` to skip the prompts, or `--path <skills-dir>` to link into a custom directory. Outside a TTY, and with `--json`, it never prompts. Run `skills update` after upgrading the package to refresh the links.
+
 ## External CLIs
````