### PR TITLE
docs: document the plain output format and yaml/md aliases

### DIFF
--- a/docs/cli-reference.mdx
+++ b/docs/cli-reference.mdx
@@ -77,11 +77,14 @@ The old `web read` command has been renamed to `web fetch-browser`.
 
 ```bash
 webcmd hackernews top -f table
+webcmd hackernews top -f plain
 webcmd hackernews top -f json
 webcmd hackernews top -f yaml
 webcmd hackernews top -f md
 webcmd hackernews top -f csv
 ```
+
+`plain` prints `key: value` lines instead of a table, and prints the bare value when a command returns a single field named `response`, `content`, `markdown`, `text`, or `value`. It suits chat-style commands. `yml` and `markdown` are accepted aliases for `yaml` and `md`.
 
 Agents should use JSON unless they are presenting output to a human.
 


### PR DESCRIPTION
## Description

Fixes #201 

The **Output Formats** section of `docs/cli-reference.mdx` listed five formats — `table`, `json`, `yaml`, `md`, `csv` — but eight are supported (`src/command-surface.ts:5`):

```ts
export const OUTPUT_FORMATS = ['table', 'plain', 'json', 'yaml', 'yml', 'md', 'markdown', 'csv'] as const;
```

This adds `-f plain` to the example block and one sentence covering what `plain` does and the two aliases.

`plain` was the notable omission. It is dispatched at `src/output.ts:50` and appears in both help strings — `src/command-surface.ts:72` builds the `-f` help from `OUTPUT_FORMATS.join(', ')`, and `src/command-presentation.ts:91` spells out "table, plain, json, yaml, md, csv" — and `skills/webcmd-usage/SKILL.md` documents it for agents. The published reference was the only place it was missing, so it was invisible to anyone reading the docs rather than running `--help`.

Behaviour documented, taken from `formatPlain` (`src/output.ts:123-146`):

| Claim | Source |
| --- | --- |
| prints `key: value` lines instead of a table | `src/output.ts:137-144` |
| prints the bare value for a single field named `response`, `content`, `markdown`, `text`, or `value` | `src/output.ts:127-134` |
| `yml` is an alias for `yaml`, `markdown` for `md` | `src/output.ts:51-55` |

Related issue: Closes #201

### One thing intentionally left undocumented

`-f` is not validated. `OUTPUT_FORMATS` is used only to build help text, never to check the supplied value, so an unrecognised format falls through the `default:` case in `formatOutput` (`src/output.ts:56`) and silently renders a table — `-f jsonn` produces table output with no error.

I left that out of the docs because it reads as a defect rather than intended behaviour, and writing it down would bless it. Happy to open a separate issue for it if that is useful. If `-f` gains validation later, the alias sentence added here stays correct and a rejection note becomes worth adding alongside it.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

Notes on the checklist:

- Docs-only change to one `.mdx` file; no code, tests, or generated artifacts are touched. Each claim was verified against `src/` rather than by running the suite.
- No automated check covers this page's contents. `src/docs-sync-review.ts` lists `docs/cli-reference.mdx` as a watched path only, which is why the drift went unnoticed.

### Adapter Notes

Not applicable — no adapter is added or modified in this PR.

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

One file, +3:

````diff
 ```bash
 webcmd hackernews top -f table
+webcmd hackernews top -f plain
 webcmd hackernews top -f json
 webcmd hackernews top -f yaml
 webcmd hackernews top -f md
 webcmd hackernews top -f csv
 ```

+`plain` prints `key: value` lines instead of a table, and prints the bare value when a command returns a single field named `response`, `content`, `markdown`, `text`, or `value`. It suits chat-style commands. `yml` and `markdown` are accepted aliases for `yaml` and `md`.
+
 Agents should use JSON unless they are presenting output to a human.
```