### PR TITLE
docs: renumber the README layer table so it matches the "3 layers" claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ On top of live browser control, WebCMD adds 3 layers of learnings. Each layer co
 
 | Layer | Scenario | What Webcmd Helps With |
 | --- | --- | --- |
-| 1. Live browser control | The site is unfamiliar. | Use `webcmd browser` to inspect, click, type, extract, capture network calls, and complete the task in a real browser. |
-| 2. Sitemap memory | The site is familiar, but the action space is not fully known. | Capture an agent-facing sitemap of observed pages, states, actions, workflows, APIs, pitfalls, and fallback paths. |
-| 3. CLI authoring | The action space is known, but the path is still too variable for one fixed sequence. | Explicitly author a reusable `webcmd <site>` adapter with structured output, so future agents spend tokens on the task instead of navigation. |
-| 4. Extend existing CLIs | The workflow is deterministic enough to stop browsing. | Extend the `webcmd <site>` adapter with a tailored command so the workflow runs instantly with the least amount of tokens. |
+| 0. Live browser control | The site is unfamiliar. | Use `webcmd browser` to inspect, click, type, extract, capture network calls, and complete the task in a real browser. |
+| 1. Sitemap memory | The site is familiar, but the action space is not fully known. | Capture an agent-facing sitemap of observed pages, states, actions, workflows, APIs, pitfalls, and fallback paths. |
+| 2. CLI authoring | The action space is known, but the path is still too variable for one fixed sequence. | Explicitly author a reusable `webcmd <site>` adapter with structured output, so future agents spend tokens on the task instead of navigation. |
+| 3. Extend existing CLIs | The workflow is deterministic enough to stop browsing. | Extend the `webcmd <site>` adapter with a tailored command so the workflow runs instantly with the least amount of tokens. |
 
 ## Demo
 


### PR DESCRIPTION
## Description

`README.md:31` says:

> On top of live browser control, WebCMD adds 3 layers of learnings.

The table directly beneath it numbered four rows, `1.` through `4.`, starting with *Live browser control* — the thing the sentence says the layers sit on top of. So the README claimed three layers and then showed four.

This renumbers the table `0.`–`3.`, which makes the prose literally true: layer 0 is live browser control, and layers 1–3 are the three learnings built on it. No prose changes were needed.

Closes #204

### Note on the "collapses cost" sentence

The same paragraph ends with "Each layer collapses cost and variance for the layer above it." I checked whether that direction was also wrong and it is **correct** — reading down the table, each row makes the row above it cheaper: a sitemap makes live browsing cheaper, an authored adapter makes sitemap-guided work cheaper, and a tailored command makes adapter authoring cheaper. Left untouched.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

Notes on the checklist:

- Docs-only change to four table rows in `README.md`. No code, tests, or generated artifacts are touched.
- The change is confined to the hand-written section above `## Demo`; the generated community-plugins table between the `webcmd-community-plugins` markers is untouched, so `npm run check-community-plugins` is unaffected.

### Adapter Notes

Not applicable — no adapter is added or modified in this PR.

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

One file, +4 / -4:

```diff
 | Layer | Scenario | What Webcmd Helps With |
 | --- | --- | --- |
-| 1. Live browser control | The site is unfamiliar. | … |
-| 2. Sitemap memory | … | … |
-| 3. CLI authoring | … | … |
-| 4. Extend existing CLIs | … | … |
+| 0. Live browser control | The site is unfamiliar. | … |
+| 1. Sitemap memory | … | … |
+| 2. CLI authoring | … | … |
+| 3. Extend existing CLIs | … | … |
```

Rendered, the table now reads as one base layer plus the three learnings the sentence promises.