### PR TITLE
docs: use "Webcmd" in the README's opening paragraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@
 
 **Self-learning browser infra for AI agents.**
 
-WebCMD learns the navigational context of websites as agents use them, then compiles that knowledge into deterministic commands for faster, cheaper, more reliable browser automation. The goal is simple: stop making agents rediscover the same sites on every run and cut browser-agent token spend by up to 90%.
+Webcmd learns the navigational context of websites as agents use them, then compiles that knowledge into deterministic commands for faster, cheaper, more reliable browser automation. The goal is simple: stop making agents rediscover the same sites on every run and cut browser-agent token spend by up to 90%.
 
-On top of live browser control, WebCMD adds 3 layers of learnings. Each layer collapses cost and variance for the layer above it.
+On top of live browser control, Webcmd adds 3 layers of learnings. Each layer collapses cost and variance for the layer above it.
 
 | Layer | Scenario | What Webcmd Helps With |
 | --- | --- | --- |


### PR DESCRIPTION
## Description

Fixes #206 

`README.md:29` and `README.md:31` spelled the product name `WebCMD`:

> **WebCMD** learns the navigational context of websites as agents use them…
>
> On top of live browser control, **WebCMD** adds 3 layers of learnings.

Everywhere else uses `Webcmd` — including the H1 four lines above (`README.md:25`), `docs/docs.json`, every `docs/*.mdx` page, the bundled skills, `CONTRIBUTING.md`, and `PRIVACY.md`. These are the first two body paragraphs, so the inconsistency is above the fold on both npm and GitHub.

Closes #206

### Scope: generated content left untouched

`WebCMD` still appears further down the README, and that is deliberate:

- `README.md:127-141` — `WebCMD Agent` in the Author column and "commands for WebCMD" in the `ycombinator` description. These are inside the `<!-- webcmd-community-plugins:start -->` markers. `docs/publish-community-plugin.mdx` states the community table is generated by repository tooling and must not be hand-edited, and `npm run check-community-plugins` would flag an edit.
- `plugins/*/webcmd-plugin.json` — `"author": { "name": "WebCMD Agent" }` across a dozen manifests. That is the generated table's source, and it is attribution metadata rather than prose.
- `plugins/techcrunch/README.md:3` — "through WebCMD" in prose. A real instance, but a different file and outside this issue.

Normalizing the author name would mean editing the manifests and regenerating with `npm run sync-community-plugins`. That is a maintainer decision about an author identity, not a typo fix, so it is not bundled here. Happy to open a follow-up if you want it.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

Notes on the checklist:

- Two-word change in `README.md`. No code, tests, or generated artifacts are touched.
- The edit is confined to the hand-written section above the community-plugins markers, so the generated table and `npm run check-community-plugins` are unaffected.

### Adapter Notes

Not applicable — no adapter is added or modified in this PR.

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

One file, +2 / -2:

```diff
-WebCMD learns the navigational context of websites as agents use them, then compiles that knowledge into deterministic commands for faster, cheaper, more reliable browser automation. …
+Webcmd learns the navigational context of websites as agents use them, then compiles that knowledge into deterministic commands for faster, cheaper, more reliable browser automation. …

-On top of live browser control, WebCMD adds 3 layers of learnings. Each layer collapses cost and variance for the layer above it.
+On top of live browser control, Webcmd adds 3 layers of learnings. Each layer collapses cost and variance for the layer above it.
