### PR TITLE
docs: update Skyscanner command syntax and examples in README

### DIFF
--- a/plugins/skyscanner/README.md
+++ b/plugins/skyscanner/README.md
@@ -12,10 +12,12 @@ webcmd plugin install github:rishabhraj36/webcmd-plugin-skyscanner
 
 | Command | Description |
 |---------|-------------|
-| `skyscanner flights <origin> <destination>` | Visible round-trip flight results from a warmed browser session |
+| `skyscanner flights <origin> <destination> --depart-date <YYYY-MM-DD> --return-date <YYYY-MM-DD>` | Visible round-trip flight results from a warmed browser session. Optional `--limit` caps the rows returned (default 10). |
 
 ## Examples
 
 ```bash
-webcmd skyscanner flights nyca lond --depart-date 2026-08-01 --return-date 2026-08-08 --limit 5
+webcmd skyscanner flights nyca lond --depart-date 2027-03-14 --return-date 2027-03-21 --limit 5
 ```
+
+Both dates are required, and Skyscanner only returns results for dates in the future — substitute your own travel dates rather than copying these.


### PR DESCRIPTION
## Description

The Commands table in `plugins/skyscanner/README.md` documented the command as:

| Command | Description |
|---------|-------------|
| `skyscanner flights <origin> <destination>` | Visible round-trip flight results from a warmed browser session |

But `--depart-date` and `--return-date` are both required (`plugins/skyscanner/flights.js:169-170`):

```js
{ name: 'depart-date', required: true, help: 'Outbound date as YYYY-MM-DD' },
{ name: 'return-date', required: true, help: 'Return date as YYYY-MM-DD' },
```

Copying the table row as written fails with a missing-argument error.

This PR:

1. **Adds the required flags to the table row**, so the documented signature matches what the command actually accepts. Also notes `--limit` as optional with its default of `10` (`flights.js:171`), so the row covers the full surface.
2. **Moves the example dates forward.** The example used `--depart-date 2026-08-01`, which is now in the past, so the one runnable line in the file no longer returned results. Replaced with clearly-future dates and a line telling readers to substitute their own.

Closes #208

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

Notes on the checklist:

- Docs-only change to one plugin README. No adapter code, manifest, tests, or generated artifacts are touched.
- `plugins/skyscanner/webcmd-plugin.json` is unchanged, so the generated community table in the root `README.md` and `npm run check-community-plugins` are unaffected.
- Both documented flags were verified against the `args` array in `plugins/skyscanner/flights.js` rather than by running the command, which needs a live browser session.

### Adapter Notes

- [x] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

The last two do not apply — no adapter code changes here. The command's primary subjects (`origin`, `destination`) are already positional, and error handling is untouched.

## Screenshots / Output

One file, +4 / -2:

```diff
 | Command | Description |
 |---------|-------------|
-| `skyscanner flights <origin> <destination>` | Visible round-trip flight results from a warmed browser session |
+| `skyscanner flights <origin> <destination> --depart-date <YYYY-MM-DD> --return-date <YYYY-MM-DD>` | Visible round-trip flight results from a warmed browser session. Optional `--limit` caps the rows returned (default 10). |

 ## Examples

 ```bash
-webcmd skyscanner flights nyca lond --depart-date 2026-08-01 --return-date 2026-08-08 --limit 5
+webcmd skyscanner flights nyca lond --depart-date 2027-03-14 --return-date 2027-03-21 --limit 5
 ```
+
+Both dates are required, and Skyscanner only returns results for dates in the future — substitute your own travel dates rather than copying these.
```

### Out of scope

`plugins/skyscanner/README.md:8` still shows `webcmd plugin install github:rishabhraj36/webcmd-plugin-skyscanner`, pointing at the author's standalone repo, while `docs/cli-reference.mdx:129` documents the in-repo form as `github:agentrhq/webcmd/plugins/<name>`. That line is likely stale too, but which source is canonical for a promoted community plugin is a maintainer call, so I left it. Happy to file it separately or fold it in if you tell me which form you want.