### PR TITLE
fix: omit links for internal plugin authors

### DIFF
--- a/plugins/luma/webcmd-plugin.json
+++ b/plugins/luma/webcmd-plugin.json
@@ -4,7 +4,7 @@
   "description": "Manage hosted Luma events, registration questions, and guests",
   "webcmd": ">=0.5.2",
   "author": {
-    "name": "Webcmd",
-    "handle": "webcmd"
+    "name": "WebCMD Agent",
+    "handle": "agentrhq"
   }
 }

--- a/src/community-plugin-sync.test.ts
+++ b/src/community-plugin-sync.test.ts
@@ -51,7 +51,7 @@ describe('community plugin sync', () => {
       version: '0.1.0',
       description: 'Last plugin',
       webcmd: '>=0.2.0',
-      author: { name: 'Zed', handle: 'zed-user' },
+      author: { name: 'WebCMD Agent', handle: 'agentrhq' },
     });
     writePlugin('alpha', {
       name: 'alpha',
@@ -85,6 +85,8 @@ describe('community plugin sync', () => {
     });
     expect(result.readme).toContain('| Plugin | Description | Author |');
     expect(result.readme).toContain('| [`alpha`](./plugins/alpha/) | Forecasts \\| alerts | [Alice](https://github.com/alice) |');
+    expect(result.readme).toContain('| [`zeta`](./plugins/zeta/) | Last plugin | WebCMD Agent |');
+    expect(result.readme).not.toContain('[WebCMD Agent](https://github.com/agentrhq)');
     expect(result.readme.indexOf('`alpha`')).toBeLessThan(result.readme.indexOf('`zeta`'));
     expect(result.readme).toContain('### Plugin marketplaces');
     expect(result.readme).toContain('[other/plugins](https://github.com/other/plugins)');

--- a/src/community-plugin-sync.ts
+++ b/src/community-plugin-sync.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
   validatePluginAuthor,
+  type PluginAuthor,
   type PluginManifest,
   type SubPluginEntry,
 } from './plugin-manifest.js';
@@ -110,7 +111,7 @@ function renderCommunityPlugins(
   for (const [name, plugin] of Object.entries(plugins)) {
     const author = plugin.author!;
     lines.push(
-      `| [\`${markdownCell(name)}\`](./plugins/${name}/) | ${markdownCell(plugin.description!)} | [${markdownCell(author.name)}](https://github.com/${author.handle}) |`,
+      `| [\`${markdownCell(name)}\`](./plugins/${name}/) | ${markdownCell(plugin.description!)} | ${renderAuthor(author)} |`,
     );
   }
 
@@ -123,6 +124,13 @@ function renderCommunityPlugins(
 
   lines.push(COMMUNITY_PLUGINS_END);
   return lines.join('\n');
+}
+
+function renderAuthor(author: PluginAuthor): string {
+  const name = markdownCell(author.name);
+  return author.handle.toLowerCase() === 'agentrhq'
+    ? name
+    : `[${name}](https://github.com/${author.handle})`;
 }
 
 function replaceGeneratedSection(readme: string, section: string): string {


### PR DESCRIPTION
## Description

<!-- Briefly describe your changes and link to any related issues. -->

Related issue:

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [x] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

### Adapter Notes

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

<!-- If applicable, paste CLI output or screenshots here. -->
