### PR TITLE
feat: add webcmd update command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -917,7 +917,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     .description('Update webcmd to the latest version and refresh bundled skills')
     .option('--skip-skills', 'Skip refreshing bundled skill links after updating', false)
     .action(async (opts) => {
-      const { buildUpgradeCommand, upgradePackage } = await import('./update.js');
+      const { buildUpgradeCommand, upgradePackage, getRuntimeUpdateNotice } = await import('./update.js');
       const { cmd, args } = buildUpgradeCommand();
       console.log(`Updating ${PACKAGE_NAME}: ${cmd} ${args.join(' ')}`);
       try {
@@ -937,6 +937,9 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
           console.error('Hint: run "webcmd skills update" once the new version is active.');
         }
       }
+      // The Cloak runtime/extension ships separately from npm; surface it if stale.
+      const runtimeNotice = getRuntimeUpdateNotice();
+      if (runtimeNotice) process.stdout.write(runtimeNotice);
       console.log('Update complete.');
     });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,7 +43,7 @@ import { fetchDaemonStatus } from './browser/daemon-transport.js';
 import { aliasForContextId, loadProfileConfig, profileRouteParams, renameProfile, resolveProfileSelection, setDefaultProfile, type ProfileSelection } from './browser/profile.js';
 import { formatDaemonVersion, isDaemonStale } from './browser/daemon-version.js';
 import { DEFAULT_BROWSER_CONNECT_TIMEOUT } from './browser/config.js';
-import { CLI_COMMAND } from './brand.js';
+import { CLI_COMMAND, PACKAGE_NAME } from './brand.js';
 import type { BrowserDownloadWaitResult, IPage, ScreenshotOptions } from './types.js';
 import type { BrowserWindowMode } from './runtime.js';
 import { configureRootCommandSurface } from './root-command-surface.js';
@@ -911,6 +911,34 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     .option('--path <path>', 'Also remove links from a custom agent skills directory')
     .option('--json', 'Output a JSON envelope', false)
     .action((opts) => handleSkillRemoveCommand(opts.path, opts.json));
+
+  program
+    .command('update')
+    .description('Update webcmd to the latest version and refresh bundled skills')
+    .option('--skip-skills', 'Skip refreshing bundled skill links after updating', false)
+    .action(async (opts) => {
+      const { buildUpgradeCommand, upgradePackage } = await import('./update.js');
+      const { cmd, args } = buildUpgradeCommand();
+      console.log(`Updating ${PACKAGE_NAME}: ${cmd} ${args.join(' ')}`);
+      try {
+        upgradePackage();
+      } catch (err) {
+        console.error(`Error: package update failed: ${getErrorMessage(err)}`);
+        console.error(`Hint: check your network connection and that ${cmd} is on PATH.`);
+        process.exitCode = EXIT_CODES.GENERIC_ERROR;
+        return;
+      }
+      if (!opts.skipSkills) {
+        try {
+          const { skills } = updateWebcmdSkill();
+          console.log(`Bundled skills refreshed: ${skills.length}`);
+        } catch (err) {
+          console.error(`Warning: skill refresh failed: ${getErrorMessage(err)}`);
+          console.error('Hint: run "webcmd skills update" once the new version is active.');
+        }
+      }
+      console.log('Update complete.');
+    });
 
   const authCmd = registerAuthCommands(program);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -73,7 +73,7 @@ if (!fastPathHandled) {
   if (argv[0] === 'setup') {
     const { runHostedSetup } = await import('./hosted/setup.js');
     process.exitCode = await runHostedSetup();
-  } else if (argv[0] === 'skills') {
+  } else if (argv[0] === 'skills' || argv[0] === 'update') {
     const { createProgram } = await import('./cli.js');
     await createProgram(BUILTIN_CLIS, USER_CLIS).parseAsync(argv, { from: 'user' });
   } else if (argv[0] === 'web' && argv[1] === 'fetch') {

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -232,6 +232,11 @@ export function getCachedLatestExtensionVersion(): string | undefined {
   return _cache?.latestExtensionVersion;
 }
 
+/** Read the update-check cache fresh from disk. Used by `webcmd update`. */
+export function readUpdateCache(): UpdateCache | null {
+  return readCacheSync();
+}
+
 export {
   extractLatestExtensionVersionFromReleases as _extractLatestExtensionVersionFromReleases,
   buildUpdateNotices as _buildUpdateNotices,

--- a/src/update.test.ts
+++ b/src/update.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { buildUpgradeCommand } from './update.js';
+import { PACKAGE_NAME } from './brand.js';
+
+describe('buildUpgradeCommand', () => {
+  it('uses npm global install by default', () => {
+    // Test runtime is Node, not Bun.
+    expect(buildUpgradeCommand()).toEqual({
+      cmd: 'npm',
+      args: ['install', '-g', `${PACKAGE_NAME}@latest`],
+    });
+  });
+
+  it('honours an explicit spec', () => {
+    expect(buildUpgradeCommand(`${PACKAGE_NAME}@1.2.3`).args).toContain(`${PACKAGE_NAME}@1.2.3`);
+  });
+});

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,0 +1,33 @@
+/**
+ * `webcmd update` — self-update the globally installed package.
+ *
+ * Reuses the same install command the update notice prints (see update-check.ts),
+ * so the manual and automatic paths stay in sync. Runs under Bun when the CLI
+ * itself is running under Bun; otherwise npm.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { PACKAGE_NAME } from './brand.js';
+
+export interface UpgradeCommand {
+  cmd: string;
+  args: string[];
+}
+
+/** Build the global-install command for the running runtime. Pure; exported for tests. */
+export function buildUpgradeCommand(spec: string = `${PACKAGE_NAME}@latest`): UpgradeCommand {
+  const isBun = typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined';
+  return isBun
+    ? { cmd: 'bun', args: ['add', '-g', spec] }
+    : { cmd: 'npm', args: ['install', '-g', spec] };
+}
+
+/** Run the global install, streaming package-manager output. Throws on failure. */
+export function upgradePackage(): UpgradeCommand {
+  const command = buildUpgradeCommand();
+  execFileSync(command.cmd, command.args, {
+    stdio: 'inherit',
+    ...(process.platform === 'win32' && { shell: true }),
+  });
+  return command;
+}

--- a/src/update.ts
+++ b/src/update.ts
@@ -8,6 +8,8 @@
 
 import { execFileSync } from 'node:child_process';
 import { PACKAGE_NAME } from './brand.js';
+import { PKG_VERSION } from './version.js';
+import { _buildUpdateNotices, readUpdateCache } from './update-check.js';
 
 export interface UpgradeCommand {
   cmd: string;
@@ -20,6 +22,19 @@ export function buildUpgradeCommand(spec: string = `${PACKAGE_NAME}@latest`): Up
   return isBun
     ? { cmd: 'bun', args: ['add', '-g', spec] }
     : { cmd: 'npm', args: ['install', '-g', spec] };
+}
+
+/**
+ * Notice for the separately-shipped Cloak runtime/extension, which `npm install -g`
+ * does NOT update. Returns the notice text when a newer runtime is known, else
+ * undefined. Currently dormant until update-check URLs are enabled upstream.
+ */
+export function getRuntimeUpdateNotice(): string | undefined {
+  return _buildUpdateNotices({
+    cliVersion: PKG_VERSION,
+    cache: readUpdateCache(),
+    now: Date.now(),
+  }).extension;
 }
 
 /** Run the global install, streaming package-manager output. Throws on failure. */


### PR DESCRIPTION
## Description

Adds a top-level `webcmd update` command that upgrades the globally installed package with the active runtime package manager, then refreshes bundled skill links by default.

- Uses `npm install -g` under Node and `bun add -g` under Bun
- Supports `--skip-skills`
- Routes locally instead of dispatching to hosted mode
- Adds focused command-selection tests
- Surfaces a notice when the separately-shipped Cloak runtime/extension is stale (checked against the update-check cache)

Related issue: N/A

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Adapter Notes

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the commands primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

- `npm run build`
- `npm test` — 5,165 passed, 1 skipped