### PR TITLE
fix(local-cloak): match profile processes on an exact --user-data-dir boundary

### DIFF
--- a/src/browser/runtime/local-cloak/darwin-background-launch.ts
+++ b/src/browser/runtime/local-cloak/darwin-background-launch.ts
@@ -7,6 +7,7 @@ import { buildLaunchOptions, humanizeBrowser } from 'cloakbrowser';
 import type { LaunchPersistentContextOptions } from 'cloakbrowser';
 import { chromium } from 'playwright-core';
 import type { Browser, BrowserContext } from 'playwright-core';
+import { findCloakProfileProcesses, signalPids } from './profile-processes.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -40,13 +41,7 @@ export async function waitForDevToolsPort(portFile: string, timeoutMs = 10_000):
 }
 
 async function terminateProfile(userDataDir: string): Promise<void> {
-  const { stdout } = await execFileAsync('/bin/ps', ['-axo', 'pid=,command=']);
-  const needle = `--user-data-dir=${userDataDir}`;
-  for (const line of stdout.split('\n')) {
-    if (!line.includes(needle)) continue;
-    const pid = Number.parseInt(line.trim().split(/\s+/, 1)[0], 10);
-    if (Number.isInteger(pid) && pid !== process.pid) process.kill(pid, 'SIGTERM');
-  }
+  signalPids(await findCloakProfileProcesses(userDataDir), 'SIGTERM');
 }
 
 const defaultDependencies: Dependencies = {
@@ -109,7 +104,9 @@ export async function launchDarwinBackgroundPersistentContext(
         await browser!.close();
       } finally {
         contextActivators.delete(context);
-        await deps.terminateProfile(options.userDataDir);
+        // Best-effort: a ps/kill failure must not replace the outcome of
+        // `browser.close()`, which is what the caller awaited.
+        await deps.terminateProfile(options.userDataDir).catch(() => {});
       }
     };
     return context;

--- a/src/browser/runtime/local-cloak/profile-processes.test.ts
+++ b/src/browser/runtime/local-cloak/profile-processes.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockExecFile } = vi.hoisted(() => ({ mockExecFile: vi.fn() }));
+
+vi.mock('node:child_process', () => ({ execFile: mockExecFile }));
+
+import { commandUsesProfileDir, findCloakProfileProcesses, isCloakBrowserCommand } from './profile-processes.js';
+
+const CLOAK_BINARY = '/home/u/.cloakbrowser/chromium-1234/chrome-linux/chrome';
+const PROFILES = '/home/u/.webcmd/cloak/profiles';
+
+// Offsets keep these apart from the running process, whose pid is filtered out.
+const OWNER_PID = process.pid + 1;
+const SIBLING_PID = process.pid + 2;
+const USER_CHROME_PID = process.pid + 3;
+
+function mockPs(stdout: string): void {
+  mockExecFile.mockImplementation((_command, _args, _options, callback) => callback(null, stdout));
+}
+
+beforeEach(() => {
+  mockExecFile.mockReset();
+});
+
+describe('commandUsesProfileDir', () => {
+  it('does not match a profile dir that is a prefix of another', () => {
+    const command = `${CLOAK_BINARY} --user-data-dir=${PROFILES}/work-2 about:blank`;
+
+    expect(commandUsesProfileDir(command, [`${PROFILES}/work`])).toBe(false);
+    expect(commandUsesProfileDir(command, [`${PROFILES}/work-2`])).toBe(true);
+  });
+
+  it('matches the flag at the end of the command line', () => {
+    expect(commandUsesProfileDir(`${CLOAK_BINARY} --user-data-dir=${PROFILES}/work`, [`${PROFILES}/work`])).toBe(true);
+  });
+});
+
+describe('isCloakBrowserCommand', () => {
+  it('ignores a Chromium that is not the Cloak build', () => {
+    expect(isCloakBrowserCommand(`/opt/google/chrome/chrome --user-data-dir=${PROFILES}/work`)).toBe(false);
+    expect(isCloakBrowserCommand(`${CLOAK_BINARY} --user-data-dir=${PROFILES}/work`)).toBe(true);
+  });
+});
+
+describe('findCloakProfileProcesses', () => {
+  it('returns only the Cloak process owning the exact profile dir', async () => {
+    mockPs([
+      `  ${OWNER_PID} ${CLOAK_BINARY} --user-data-dir=${PROFILES}/work about:blank`,
+      `  ${SIBLING_PID} ${CLOAK_BINARY} --user-data-dir=${PROFILES}/work-2 about:blank`,
+      `  ${USER_CHROME_PID} /opt/google/chrome/chrome --user-data-dir=${PROFILES}/work`,
+      `  ${process.pid} node webcmd daemon`,
+      '',
+    ].join('\n'));
+
+    expect(await findCloakProfileProcesses(`${PROFILES}/work`)).toEqual([OWNER_PID]);
+  });
+
+  it('reports no processes when ps fails', async () => {
+    mockExecFile.mockImplementation((_command, _args, _options, callback) => callback(new Error('ps failed'), ''));
+
+    expect(await findCloakProfileProcesses(`${PROFILES}/work`)).toEqual([]);
+  });
+});

--- a/src/browser/runtime/local-cloak/profile-processes.ts
+++ b/src/browser/runtime/local-cloak/profile-processes.ts
@@ -1,0 +1,76 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+
+/**
+ * Discovery and signalling of the Cloak Chromium processes that own a profile
+ * directory.
+ *
+ * Shared by launch recovery (`session-manager.ts`) and background-profile
+ * teardown (`darwin-background-launch.ts`) so both agree on which processes
+ * belong to a profile. `session-manager.ts` already imports
+ * `darwin-background-launch.ts`, so the matching cannot live in either of them
+ * without a cycle.
+ */
+
+export async function findCloakProfileProcesses(userDataDir: string): Promise<number[]> {
+  const profileDirs = profileDirAliases(userDataDir);
+  const stdout = await psOutput();
+  const pids: number[] = [];
+  for (const line of stdout.split('\n')) {
+    const match = line.match(/^\s*(\d+)\s+(.+)$/);
+    if (!match) continue;
+    const pid = Number(match[1]);
+    const command = match[2];
+    if (!Number.isInteger(pid) || pid === process.pid) continue;
+    if (!isCloakBrowserCommand(command)) continue;
+    if (!commandUsesProfileDir(command, profileDirs)) continue;
+    pids.push(pid);
+  }
+  return [...new Set(pids)];
+}
+
+export function signalPids(pids: number[], signal: NodeJS.Signals): void {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // Already exited or not signalable; the follow-up poll decides recovery.
+    }
+  }
+}
+
+export function commandUsesProfileDir(command: string, profileDirs: string[]): boolean {
+  for (const dir of profileDirs) {
+    const marker = `--user-data-dir=${dir}`;
+    const index = command.indexOf(marker);
+    if (index < 0) continue;
+    // The flag value must end here: profile ids may share a prefix
+    // (`work` / `work-2`), so a substring match would claim a sibling
+    // profile's Chromium.
+    const next = command[index + marker.length];
+    if (next === undefined || /\s/.test(next)) return true;
+  }
+  return false;
+}
+
+export function profileDirAliases(userDataDir: string): string[] {
+  const aliases = new Set([userDataDir]);
+  try {
+    aliases.add(fs.realpathSync.native(userDataDir));
+  } catch {
+    // The launch path is still useful even if realpath cannot resolve it.
+  }
+  return [...aliases];
+}
+
+export function isCloakBrowserCommand(command: string): boolean {
+  return command.includes('/.cloakbrowser/') || command.includes('\\.cloakbrowser\\');
+}
+
+function psOutput(): Promise<string> {
+  return new Promise((resolve) => {
+    execFile('ps', ['-axo', 'pid=,command='], { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024, timeout: 2000 }, (err, stdout) => {
+      resolve(err ? '' : String(stdout));
+    });
+  });
+}

--- a/src/browser/runtime/local-cloak/session-manager.ts
+++ b/src/browser/runtime/local-cloak/session-manager.ts
@@ -1,11 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { execFile } from 'node:child_process';
 import type { BrowserContext, Page as PlaywrightPage } from 'playwright-core';
 import { launchPersistentContext as cloakLaunchPersistentContext } from 'cloakbrowser';
 import type { BrowserSurface, BrowserWindowMode, SiteSessionMode } from '../../protocol.js';
 import { activateDarwinBackgroundContext, launchDarwinBackgroundPersistentContext } from './darwin-background-launch.js';
+import { findCloakProfileProcesses, signalPids } from './profile-processes.js';
 import { normalizeProfileId, resolveCloakProfileDir } from './profiles.js';
 import { CloakNetworkCapture } from './network.js';
 import { findPackageRoot } from '../../../package-paths.js';
@@ -606,64 +606,4 @@ async function waitForProfileProcessesToExit(userDataDir: string, timeoutMs: num
     if ((await findCloakProfileProcesses(userDataDir)).length === 0) return true;
   }
   return (await findCloakProfileProcesses(userDataDir)).length === 0;
-}
-
-function signalPids(pids: number[], signal: NodeJS.Signals): void {
-  for (const pid of pids) {
-    try {
-      process.kill(pid, signal);
-    } catch {
-      // Already exited or not signalable; the follow-up poll decides recovery.
-    }
-  }
-}
-
-async function findCloakProfileProcesses(userDataDir: string): Promise<number[]> {
-  const profileDirs = profileDirAliases(userDataDir);
-  const stdout = await psOutput();
-  const pids: number[] = [];
-  for (const line of stdout.split('\n')) {
-    const match = line.match(/^\s*(\d+)\s+(.+)$/);
-    if (!match) continue;
-    const pid = Number(match[1]);
-    const command = match[2];
-    if (!Number.isInteger(pid) || pid === process.pid) continue;
-    if (!isCloakBrowserCommand(command)) continue;
-    if (!commandUsesProfileDir(command, profileDirs)) continue;
-    pids.push(pid);
-  }
-  return [...new Set(pids)];
-}
-
-function commandUsesProfileDir(command: string, profileDirs: string[]): boolean {
-  for (const dir of profileDirs) {
-    const marker = `--user-data-dir=${dir}`;
-    const index = command.indexOf(marker);
-    if (index < 0) continue;
-    const next = command[index + marker.length];
-    if (next === undefined || /\s/.test(next)) return true;
-  }
-  return false;
-}
-
-function profileDirAliases(userDataDir: string): string[] {
-  const aliases = new Set([userDataDir]);
-  try {
-    aliases.add(fs.realpathSync.native(userDataDir));
-  } catch {
-    // The launch path is still useful even if realpath cannot resolve it.
-  }
-  return [...aliases];
-}
-
-function isCloakBrowserCommand(command: string): boolean {
-  return command.includes('/.cloakbrowser/') || command.includes('\\.cloakbrowser\\');
-}
-
-function psOutput(): Promise<string> {
-  return new Promise((resolve) => {
-    execFile('ps', ['-axo', 'pid=,command='], { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024, timeout: 2000 }, (err, stdout) => {
-      resolve(err ? '' : String(stdout));
-    });
-  });
 }


### PR DESCRIPTION

## Description

On macOS, `terminateProfile` picked the Chromium processes to `SIGTERM` with a bare
substring test on the `ps` command line
(`darwin-background-launch.ts:42-50`). Profiles are siblings under
`~/.webcmd/cloak/profiles/<id>` and ids may contain `-` and `.`, so
`--user-data-dir=…/profiles/work` matched `…/profiles/work-2` as well: tearing down
one background profile killed a healthy concurrent one. With no CloakBrowser binary
check, a user's own Chrome on a matching `--user-data-dir` was killed too. The
victim only ever surfaced `Target page, context or browser has been closed`.

Lock recovery in `session-manager.ts` already matched profile processes correctly —
requiring the flag value to end at an argument boundary, resolving realpath aliases,
and restricting matches to CloakBrowser binaries. This moves that matching into a
new `profile-processes.ts` and routes both call sites through it, so there is one
implementation instead of two that disagree.

The helpers cannot live in either existing module: `session-manager.ts` already
imports `darwin-background-launch.ts`, so either direction would create a cycle.
The new module is a straight move — no behavior change on the recovery path.

Teardown on the context-close path is now best-effort like the launch-failure path
beside it, so a `ps` or `kill` failure no longer replaces the outcome of
`browser.close()`.

Files in the commit:

- `src/browser/runtime/local-cloak/profile-processes.ts` — new; profile process
  discovery and signalling, moved from `session-manager.ts`.
- `src/browser/runtime/local-cloak/session-manager.ts` — imports the moved helpers.
- `src/browser/runtime/local-cloak/darwin-background-launch.ts` — `terminateProfile`
  uses the shared matching; teardown made best-effort.
- `src/browser/runtime/local-cloak/profile-processes.test.ts` — new; regression
  coverage.

Related issue: https://github.com/agentrhq/webcmd/issues/242

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR — `npm run typecheck`, plus the affected
      `src/browser/runtime/local-cloak` suites (see below)
- [x] I updated tests or docs if needed — added `profile-processes.test.ts`; no
      user-facing surface changed, so no docs or skills update
- [x] I included output or screenshots when useful

### Adapter Notes

Not an adapter change — this touches the local CloakBrowser runtime only.

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

The two boundary tests fail against the previous matching and pass with this
change, so they are genuine regression coverage.

```text
$ npx vitest run src/browser/runtime/local-cloak/profile-processes.test.ts --reporter=verbose

 ✓ commandUsesProfileDir > does not match a profile dir that is a prefix of another
 ✓ commandUsesProfileDir > matches the flag at the end of the command line
 ✓ isCloakBrowserCommand > ignores a Chromium that is not the Cloak build
 ✓ findCloakProfileProcesses > returns only the Cloak process owning the exact profile dir
 ✓ findCloakProfileProcesses > reports no processes when ps fails

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Reverting `commandUsesProfileDir` to the old substring test reproduces the bug in
those tests:

```text
FAIL  commandUsesProfileDir > does not match a profile dir that is a prefix of another
      AssertionError: expected true to be false

FAIL  findCloakProfileProcesses > returns only the Cloak process owning the exact profile dir
      AssertionError: expected [ 32818, 32819, 32820 ] to deeply equal [ 32818 ]
                               (sibling profile and the user's own Chrome also matched)
```

The neighbouring suites still pass, confirming the move did not change recovery
behaviour:

```text
$ npx vitest run src/browser/runtime/local-cloak/{profile-processes,session-manager,darwin-background-launch}.test.ts

 Test Files  3 passed (3)
      Tests  38 passed (38)

$ npm run typecheck
(clean)
```

**Note on CI:** these tests live under `src/browser/**`, which the vitest `unit`
project excludes — see #231 and PR #238. Until that lands they need a local vitest
config to run; CI will not report them.

**Note on #225:** distinct root cause (that one is in the CloakBrowser launch
layer), but it produces the same opaque
`Target page, context or browser has been closed` in concurrent-profile workflows,
so it may be a second contributing cause of what #225 describes.
