### PR TITLE
docs: unify agent harness setup under a single start guide

### DIFF
--- a/docs/agents/claude-code.md
+++ b/docs/agents/claude-code.md
@@ -1,0 +1,71 @@
+---
+title: Claude Code Agent
+sidebarTitle: Claude Code
+---
+
+> **Agent prompt**
+>
+> Fetch and follow [start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end, then read this page's Manual — especially [Override default tools](#override-default-tools) — before doing browser work.
+
+> Use Webcmd with [Claude Code](https://code.claude.com) to replace its native `WebFetch` and `WebSearch` tools with the Webcmd browser surface.
+
+Claude Code's native web tools are lossy by design: `WebFetch` summarizes a page with a small extraction model and `WebSearch` returns result titles and URLs but cannot read the pages. Point Claude Code at Webcmd's browser CLI instead: adapters return exact, stable fields, and `webcmd browser` sessions render real pages with logged-in profiles. Claude Code runs `webcmd` through its Bash tool.
+
+## Manual
+
+### Requirements
+
+* Node.js 20.6+
+* The `webcmd` npm CLI, installed globally or in the project
+* Claude Code (`claude`), installed globally or in the project
+* A browser runtime; confirm with `webcmd doctor` before browser work
+
+### Install and configure
+
+Install Webcmd and its skills:
+
+```bash
+npm install -g @agentrhq/webcmd
+webcmd doctor
+webcmd skills add
+```
+
+When `webcmd skills add` prompts, choose the `claude` provider. It installs into `~/.claude/skills/` (user) or `.claude/skills/` (project), which Claude Code reads on startup. Claude Code then surfaces `webcmd-usage` and `webcmd-browser` as skills when a task matches their descriptions.
+
+Restart Claude Code (or start a new session) after installing skills.
+
+### Override default tools
+
+Claude Code ships two native web tools — `WebFetch` (fetch a URL) and `WebSearch` (search). Both are permission-gated by default. Deny them so Claude Code cannot fall back to them while Webcmd is its web surface. Add to the user or project settings file (`.claude/settings.json` in the project, or `~/.claude/settings.json`):
+
+```json
+{
+  "permissions": {
+    "deny": ["WebFetch", "WebSearch"]
+  }
+}
+```
+
+Alternatively, pass the flag per invocation:
+
+```bash
+claude --disallowedTools WebFetch WebSearch
+```
+
+Denying these tools does not affect the Bash tool, which is how `webcmd` is driven.
+
+### Troubleshooting
+
+| Symptom | What to try |
+| --- | --- |
+| `webcmd doctor` is red | Fix the browser runtime first; browser commands depend on it. |
+| Skills not loading in Claude Code | Run `webcmd skills add` with the `claude` provider, then restart `claude`. |
+| Claude Code still uses `WebFetch` / `WebSearch` | Confirm `permissions.deny` lists both in the active settings file, then restart `claude`. |
+| `claude` requires permission prompts for `webcmd` | The Bash tool still asks before non-approved commands; run `claude --dangerously-skip-permissions` or allow the shell command if you accept the risk. |
+| Browser sessions stop working after idle | Ask the agent to open a fresh session or re-bind with `tabs` and `bind --page`. |
+
+## See also
+
+* [`start.md`](../../start.md) — common setup, [auth profiles and human handoff](../../start.md#auth-profiles-and-human-handoff), and [security](../../start.md#security).
+* [`webcmd-browser`](../../skills/webcmd-browser/SKILL.md) — the raw browser session surface.
+* [`webcmd-usage`](../../skills/webcmd-usage/SKILL.md) — adapter-first usage rules.

--- a/docs/agents/codex-cli.md
+++ b/docs/agents/codex-cli.md
@@ -1,0 +1,63 @@
+---
+title: Codex CLI Agent
+sidebarTitle: Codex CLI
+---
+
+> **Agent prompt**
+>
+> Fetch and follow [start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end, then read this page's Manual — especially [Override default tools](#override-default-tools) — before doing browser work.
+
+> Use Webcmd with [Codex CLI](https://developers.openai.com/codex/) to replace its native `web_search` tool with the Webcmd browser surface.
+
+Codex CLI's native `web_search` tool returns cached or indexed search results but cannot read pages or run authenticated sessions. Point Codex at Webcmd's browser CLI instead: adapters return exact, stable fields, and `webcmd browser` sessions render real pages with logged-in profiles. Codex runs `webcmd` through its shell tool.
+
+## Manual
+
+### Requirements
+
+* Node.js 20.6+
+* The `webcmd` npm CLI, installed globally or in the project
+* Codex CLI (`codex`), installed and authenticated
+* A browser runtime; confirm with `webcmd doctor` before browser work
+
+### Install and configure
+
+Install Webcmd and its skills:
+
+```bash
+npm install -g @agentrhq/webcmd
+webcmd doctor
+webcmd skills add
+```
+
+When `webcmd skills add` prompts, choose the `agents` provider. It installs into `~/.agents/skills/` (user) or `.agents/skills/` (project), which Codex CLI reads on startup. Codex then surfaces `webcmd-usage` and `webcmd-browser` as skills.
+
+Restart Codex (or start a new session) after installing skills.
+
+### Override default tools
+
+Codex CLI's native web tool is `web_search`, controlled by the top-level `web_search` setting in `~/.codex/config.toml`. Set it to `"disabled"` to remove the tool so Codex relies on Webcmd for web work:
+
+```toml
+web_search = "disabled"
+```
+
+Do not rely on the CLI flag `--dangerously-allow-web-search`; it only gates the tool and does not replace Webcmd's browser surface. Note that `web_search` defaults to `"cached"` (results from an OpenAI-maintained index without external web access) unless overridden.
+
+The setting removes only the search tool; it does not affect the shell tool, which is how `webcmd` is driven.
+
+### Troubleshooting
+
+| Symptom | What to try |
+| --- | --- |
+| `webcmd doctor` is red | Fix the browser runtime first; browser commands depend on it. |
+| Skills not loading in Codex | Run `webcmd skills add` with the `agents` provider, then restart `codex`. |
+| Codex still uses `web_search` | Confirm `web_search = "disabled"` in `~/.codex/config.toml`, then restart `codex`. |
+| `webcmd` not found in Codex shell | Confirm `webcmd` is on the PATH Codex uses; restart after installing the CLI. |
+| Browser sessions stop working after idle | Ask the agent to open a fresh session or re-bind with `tabs` and `bind --page`. |
+
+## See also
+
+* [`start.md`](../../start.md) — common setup, [auth profiles and human handoff](../../start.md#auth-profiles-and-human-handoff), and [security](../../start.md#security).
+* [`webcmd-browser`](../../skills/webcmd-browser/SKILL.md) — the raw browser session surface.
+* [`webcmd-usage`](../../skills/webcmd-usage/SKILL.md) — adapter-first usage rules.

--- a/docs/agents/cursor.md
+++ b/docs/agents/cursor.md
@@ -3,17 +3,23 @@ title: Cursor Agent
 sidebarTitle: Cursor
 ---
 
+> **Agent prompt**
+>
+> Fetch and follow [start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end, then read this page's Manual — especially [Override default tools](#override-default-tools) — before doing browser work.
+
 > Use Webcmd with [Cursor](https://cursor.com) to replace its built-in Browser and Web tools with Webcmd's adapters and `webcmd browser` sessions.
 
 Point Cursor's agent at Webcmd's browser CLI to replace its native Browser (navigate/click/screenshot) and Web (search/fetch) tools with Webcmd's adapters and `webcmd browser` sessions. Cursor's agent drives Webcmd through its shell tool. Adapter-first commands and compact snapshots usually use fewer tokens than Cursor's native web tools.
 
-## Requirements
+## Manual
+
+### Requirements
 
 * Node.js 20.6+
 * The `webcmd` npm CLI, installed globally or in the project
 * A browser runtime; confirm with `webcmd doctor` before browser work
 
-## Install and configure
+### Install and configure
 
 Install Webcmd and its skills:
 
@@ -27,7 +33,7 @@ When `webcmd skills add` prompts, choose the `agents` provider. It installs into
 
 For a project-scoped setup, copy the `webcmd-*` skill folders into the project's `.cursor/skills/` or `.agents/skills/` so the whole team gets them. Restart Cursor after installing skills.
 
-## Disable Cursor's built-in browser
+### Override default tools
 
 Cursor's agent ships two native web tools: **Browser** (navigate, click, screenshot running apps) and **Web** (search and fetch external documentation). Cursor has no single config key that removes them, so replace them with an always-applied rule that forces Webcmd usage.
 
@@ -53,17 +59,7 @@ Use Webcmd instead:
 
 The `alwaysApply: true` rule is injected into every Cursor session, so the agent does not fall back to its native Browser/Web tools. You can also set the Browser Automation dropdown in the agent window to **Off** so the built-in browser is not attached at all.
 
-## Auth profiles and human handoff
-
-Webcmd browser sessions keep signed-in state in profiles. To sign in once, run the session headed and complete login in the window yourself, then close the session; later headless runs reuse the cookies. Profile changes save only on a clean close.
-
-For login walls or CAPTCHA during a run, stop browser writes and hand off to the user with any `handoff.viewUrl` or `Webcmd browser:` link, then verify the post-action state before retrying. Never ask for or type passwords, OTPs, cookies, credentials, or session secrets.
-
-## Security
-
-`webcmd browser run` executes Playwright and JavaScript in the sandboxed browser runtime. Treat the machine running Webcmd as the trust boundary. Do not share profile directories across untrusted users.
-
-## Troubleshooting
+### Troubleshooting
 
 | Symptom | What to try |
 | --- | --- |
@@ -75,6 +71,6 @@ For login walls or CAPTCHA during a run, stop browser writes and hand off to the
 
 ## See also
 
-* [`start.md`](../../start.md) — bootstrap Webcmd end to end.
+* [`start.md`](../../start.md) — common setup, [auth profiles and human handoff](../../start.md#auth-profiles-and-human-handoff), and [security](../../start.md#security).
 * [`webcmd-browser`](../../skills/webcmd-browser/SKILL.md) — the raw browser session surface.
 * [`webcmd-usage`](../../skills/webcmd-usage/SKILL.md) — adapter-first usage rules.

--- a/docs/agents/cursor.md
+++ b/docs/agents/cursor.md
@@ -1,0 +1,80 @@
+---
+title: Cursor Agent
+sidebarTitle: Cursor
+---
+
+> Use Webcmd with [Cursor](https://cursor.com) to replace its built-in Browser and Web tools with Webcmd's adapters and `webcmd browser` sessions.
+
+Point Cursor's agent at Webcmd's browser CLI to replace its native Browser (navigate/click/screenshot) and Web (search/fetch) tools with Webcmd's adapters and `webcmd browser` sessions. Cursor's agent drives Webcmd through its shell tool. Adapter-first commands and compact snapshots usually use fewer tokens than Cursor's native web tools.
+
+## Requirements
+
+* Node.js 20.6+
+* The `webcmd` npm CLI, installed globally or in the project
+* A browser runtime; confirm with `webcmd doctor` before browser work
+
+## Install and configure
+
+Install Webcmd and its skills:
+
+```bash
+npm install -g @agentrhq/webcmd
+webcmd doctor
+webcmd skills add
+```
+
+When `webcmd skills add` prompts, choose the `agents` provider. It installs into `~/.agents/skills/`, which Cursor reads on startup along with `.cursor/skills/`, `.agents/skills/`, and `~/.cursor/skills/`. Cursor then surfaces `webcmd-usage` and `webcmd-browser` as skills when a task matches their descriptions.
+
+For a project-scoped setup, copy the `webcmd-*` skill folders into the project's `.cursor/skills/` or `.agents/skills/` so the whole team gets them. Restart Cursor after installing skills.
+
+## Disable Cursor's built-in browser
+
+Cursor's agent ships two native web tools: **Browser** (navigate, click, screenshot running apps) and **Web** (search and fetch external documentation). Cursor has no single config key that removes them, so replace them with an always-applied rule that forces Webcmd usage.
+
+Add `.cursor/rules/webcmd-browser.mdc`:
+
+```markdown
+---
+description: Use Webcmd for all browser automation instead of Cursor's built-in Browser and Web tools.
+globs:
+  - "**/*"
+alwaysApply: true
+---
+
+Do not use your native Browser tool (navigate/click/screenshot) or your Web tool (search/fetch) for browser work.
+
+Use Webcmd instead:
+
+- Check `webcmd list -f json` for an adapter that covers the task; use it first.
+- Otherwise drive a live browser with `webcmd browser <session> ...` via the shell tool.
+- Run `webcmd doctor` first and keep the session lifecycle (`tabs`, `bind`, `snapshot`, `run`, `close`).
+- For login walls, use Webcmd's human handoff; never type passwords, OTPs, cookies, or credentials.
+```
+
+The `alwaysApply: true` rule is injected into every Cursor session, so the agent does not fall back to its native Browser/Web tools. You can also set the Browser Automation dropdown in the agent window to **Off** so the built-in browser is not attached at all.
+
+## Auth profiles and human handoff
+
+Webcmd browser sessions keep signed-in state in profiles. To sign in once, run the session headed and complete login in the window yourself, then close the session; later headless runs reuse the cookies. Profile changes save only on a clean close.
+
+For login walls or CAPTCHA during a run, stop browser writes and hand off to the user with any `handoff.viewUrl` or `Webcmd browser:` link, then verify the post-action state before retrying. Never ask for or type passwords, OTPs, cookies, credentials, or session secrets.
+
+## Security
+
+`webcmd browser run` executes Playwright and JavaScript in the sandboxed browser runtime. Treat the machine running Webcmd as the trust boundary. Do not share profile directories across untrusted users.
+
+## Troubleshooting
+
+| Symptom | What to try |
+| --- | --- |
+| `webcmd doctor` is red | Fix the browser runtime first; browser commands depend on it. |
+| Skills not surfacing in Cursor | Confirm the `webcmd-*` skill folders are under `.cursor/skills/`, `.agents/skills/`, or `~/.agents/skills/`, then restart Cursor. |
+| Cursor still uses its Browser/Web tools | Confirm `.cursor/rules/webcmd-browser.mdc` has `alwaysApply: true`, and set Browser Automation to Off. |
+| `webcmd` not found in Cursor shell | Confirm `webcmd` is on the PATH the Cursor shell uses; restart Cursor after installing the CLI. |
+| Browser sessions stop working after idle | Ask the agent to open a fresh session or re-bind with `tabs` and `bind --page`. |
+
+## See also
+
+* [`start.md`](../../start.md) — bootstrap Webcmd end to end.
+* [`webcmd-browser`](../../skills/webcmd-browser/SKILL.md) — the raw browser session surface.
+* [`webcmd-usage`](../../skills/webcmd-usage/SKILL.md) — adapter-first usage rules.

--- a/docs/agents/custom-sdk.md
+++ b/docs/agents/custom-sdk.md
@@ -1,0 +1,8 @@
+---
+title: Custom SDK Integration
+sidebarTitle: Custom SDKs
+---
+
+> Webcmd's programmatic SDK is not available yet. Integration through a custom SDK is coming soon; this page will document it when it ships.
+
+There is no setup to run yet. Do not point agents at `start.md` for this integration type. If your harness is a coding agent, use the matching page under `docs/agents/`; if it is MCP-based, MCP integration is also coming soon.

--- a/docs/agents/hermes.md
+++ b/docs/agents/hermes.md
@@ -3,18 +3,24 @@ title: Hermes Agent
 sidebarTitle: Hermes
 ---
 
+> **Agent prompt**
+>
+> Fetch and follow [start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end, then read this page's Manual — especially [Override default tools](#override-default-tools) — before doing browser work.
+
 > Use Webcmd with [Hermes Agent](https://hermes-agent.nousresearch.com/docs) to replace its built-in `browser_*` stack with Webcmd's adapters and `webcmd browser` sessions.
 
 Point Hermes at Webcmd's browser CLI to replace its native browser toolset with Webcmd's adapters and `webcmd browser` sessions. Hermes drives Webcmd through its `terminal` toolset. Adapter-first commands and compact snapshots usually use fewer tokens than Hermes' native browser tools.
 
-## Requirements
+## Manual
+
+### Requirements
 
 * Node.js 20.6+ on the Hermes host
 * The `webcmd` npm CLI, installed globally on the Hermes host
 * Hermes `terminal` toolset enabled (needed to run `webcmd`)
 * A browser runtime; confirm with `webcmd doctor` before browser work
 
-## Install and configure
+### Install and configure
 
 Install Webcmd and its skills on the Hermes host:
 
@@ -34,7 +40,7 @@ skills:
 
 Hermes then reads `webcmd-usage` and `webcmd-browser` as skills. Restart Hermes after changing config and confirm the skills are discoverable.
 
-## Disable Hermes' built-in browser
+### Override default tools
 
 Hermes' native browser toolset is `browser` (`browser_navigate`, `browser_snapshot`, `browser_click`, `browser_type`, `browser_scroll`, and the rest). Disable it so Hermes does not keep its native browser tools alongside Webcmd:
 
@@ -50,21 +56,13 @@ agent:
     - browser
 ```
 
+Recommended: use `hermes tools disable browser` so the terminal toolset stays available.
+
 Note: Hermes' `browser` toolset statically bundles `web_search`, so disabling `browser` also removes `web_search` from every session. `web_extract` and the rest of the `web` toolset are unaffected. That is acceptable here: Webcmd's `smart-search` skill and adapters cover search, so Hermes should rely on Webcmd for browser work and search.
 
 Do not disable the `terminal` toolset — that is how Hermes runs `webcmd`.
 
-## Auth profiles and human handoff
-
-Webcmd browser sessions keep signed-in state in profiles. To sign in once, run the session headed and complete login in the window yourself, then close the session; later headless runs reuse the cookies. Profile changes save only on a clean close.
-
-For login walls or CAPTCHA during a run, stop browser writes and hand off to the user with any `handoff.viewUrl` or `Webcmd browser:` link, then verify the post-action state before retrying. Never ask for or type passwords, OTPs, cookies, credentials, or session secrets.
-
-## Security
-
-`webcmd browser run` executes Playwright and JavaScript in the sandboxed browser runtime. Treat the Hermes host as the trust boundary. Do not share profile directories across untrusted users.
-
-## Troubleshooting
+### Troubleshooting
 
 | Symptom | What to try |
 | --- | --- |
@@ -77,6 +75,6 @@ For login walls or CAPTCHA during a run, stop browser writes and hand off to the
 
 ## See also
 
-* [`start.md`](../../start.md) — bootstrap Webcmd end to end.
+* [`start.md`](../../start.md) — common setup, [auth profiles and human handoff](../../start.md#auth-profiles-and-human-handoff), and [security](../../start.md#security).
 * [`webcmd-browser`](../../skills/webcmd-browser/SKILL.md) — the raw browser session surface.
 * [`webcmd-usage`](../../skills/webcmd-usage/SKILL.md) — adapter-first usage rules.

--- a/docs/agents/hermes.md
+++ b/docs/agents/hermes.md
@@ -1,0 +1,82 @@
+---
+title: Hermes Agent
+sidebarTitle: Hermes
+---
+
+> Use Webcmd with [Hermes Agent](https://hermes-agent.nousresearch.com/docs) to replace its built-in `browser_*` stack with Webcmd's adapters and `webcmd browser` sessions.
+
+Point Hermes at Webcmd's browser CLI to replace its native browser toolset with Webcmd's adapters and `webcmd browser` sessions. Hermes drives Webcmd through its `terminal` toolset. Adapter-first commands and compact snapshots usually use fewer tokens than Hermes' native browser tools.
+
+## Requirements
+
+* Node.js 20.6+ on the Hermes host
+* The `webcmd` npm CLI, installed globally on the Hermes host
+* Hermes `terminal` toolset enabled (needed to run `webcmd`)
+* A browser runtime; confirm with `webcmd doctor` before browser work
+
+## Install and configure
+
+Install Webcmd and its skills on the Hermes host:
+
+```bash
+npm install -g @agentrhq/webcmd
+webcmd doctor
+webcmd skills add
+```
+
+When `webcmd skills add` prompts, choose the `agents` provider (installs into `~/.agents/skills/`). Then make Hermes load those skills by adding the external skills directory to `~/.hermes/config.yaml`:
+
+```yaml
+skills:
+  external_dirs:
+    - ~/.agents/skills
+```
+
+Hermes then reads `webcmd-usage` and `webcmd-browser` as skills. Restart Hermes after changing config and confirm the skills are discoverable.
+
+## Disable Hermes' built-in browser
+
+Hermes' native browser toolset is `browser` (`browser_navigate`, `browser_snapshot`, `browser_click`, `browser_type`, `browser_scroll`, and the rest). Disable it so Hermes does not keep its native browser tools alongside Webcmd:
+
+```bash
+hermes tools disable browser
+```
+
+Or in `~/.hermes/config.yaml`:
+
+```yaml
+agent:
+  disabled_toolsets:
+    - browser
+```
+
+Note: Hermes' `browser` toolset statically bundles `web_search`, so disabling `browser` also removes `web_search` from every session. `web_extract` and the rest of the `web` toolset are unaffected. That is acceptable here: Webcmd's `smart-search` skill and adapters cover search, so Hermes should rely on Webcmd for browser work and search.
+
+Do not disable the `terminal` toolset — that is how Hermes runs `webcmd`.
+
+## Auth profiles and human handoff
+
+Webcmd browser sessions keep signed-in state in profiles. To sign in once, run the session headed and complete login in the window yourself, then close the session; later headless runs reuse the cookies. Profile changes save only on a clean close.
+
+For login walls or CAPTCHA during a run, stop browser writes and hand off to the user with any `handoff.viewUrl` or `Webcmd browser:` link, then verify the post-action state before retrying. Never ask for or type passwords, OTPs, cookies, credentials, or session secrets.
+
+## Security
+
+`webcmd browser run` executes Playwright and JavaScript in the sandboxed browser runtime. Treat the Hermes host as the trust boundary. Do not share profile directories across untrusted users.
+
+## Troubleshooting
+
+| Symptom | What to try |
+| --- | --- |
+| `webcmd doctor` is red | Fix the browser runtime first; browser commands depend on it. |
+| Skills not loading in Hermes | Confirm `skills.external_dirs` includes `~/.agents/skills`, restart Hermes, and check skill discovery. |
+| Hermes still uses `browser_*` tools | Confirm `agent.disabled_toolsets` includes `browser`, then restart Hermes. |
+| `web_search` missing after disabling `browser` | Expected: Hermes bundles `web_search` inside the `browser` toolset. Use Webcmd's `smart-search` skill or adapters instead. |
+| `webcmd` not found in Hermes terminal | Confirm `webcmd` is on the host PATH that Hermes' `terminal` toolset uses; non-interactive shells may skip shell init files. |
+| Browser sessions stop working after idle | Ask the agent to open a fresh session or re-bind with `tabs` and `bind --page`. |
+
+## See also
+
+* [`start.md`](../../start.md) — bootstrap Webcmd end to end.
+* [`webcmd-browser`](../../skills/webcmd-browser/SKILL.md) — the raw browser session surface.
+* [`webcmd-usage`](../../skills/webcmd-usage/SKILL.md) — adapter-first usage rules.

--- a/docs/agents/openclaw.md
+++ b/docs/agents/openclaw.md
@@ -1,0 +1,65 @@
+---
+title: OpenClaw Agent
+sidebarTitle: OpenClaw
+---
+
+> **Agent prompt**
+>
+> Fetch and follow [start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end, then read this page's Manual — especially [Override default tools](#override-default-tools) — before doing browser work.
+
+> Use Webcmd with [OpenClaw](https://openclaw.ai) to replace its built-in `web_search`, `web_fetch`, and `browser` tools with the Webcmd browser surface.
+
+OpenClaw ships core web tools (`web_search`, `web_fetch`, `browser`, `browser_visual`, `search_news`) plus a Playwright-based browser. Point OpenClaw at Webcmd's browser CLI instead: adapters return exact, stable fields, and `webcmd browser` sessions keep logged-in profiles. OpenClaw runs `webcmd` through its `exec` tool.
+
+## Manual
+
+### Requirements
+
+* Node.js 20.6+
+* The `webcmd` npm CLI, installed globally or in the project
+* An OpenClaw Gateway + an agent session where `exec` is enabled
+* A browser runtime; confirm with `webcmd doctor` before browser work
+
+### Install and configure
+
+Install Webcmd and its skills:
+
+```bash
+npm install -g @agentrhq/webcmd
+webcmd doctor
+webcmd skills add
+```
+
+When `webcmd skills add` prompts, choose the `agents` provider. It installs into `~/.agents/skills/` (user) or `.agents/skills/` (project), both of which OpenClaw checks for skills. OpenClaw then surfaces `webcmd-usage` and `webcmd-browser` as skills.
+
+Restart the Gateway (or start a new session) after installing skills.
+
+### Override default tools
+
+OpenClaw's built-in web tools are `web_search`, `web_fetch`, `browser`, `browser_visual`, and `search_news`. Deny the ones that overlap with Webcmd in the Gateway config (`~/.openclaw/openclaw.json`) so OpenClaw relies on Webcmd for browser work:
+
+```json
+{
+  "tools": {
+    "deny": ["web_search", "web_fetch", "browser", "browser_visual"]
+  }
+}
+```
+
+`search_news` only covers news queries; deny it too if you want all web access through Webcmd. The Gateway watches the config file and applies changes automatically. Denying these tools does not affect the `exec` tool, which is how `webcmd` is driven.
+
+### Troubleshooting
+
+| Symptom | What to try |
+| --- | --- |
+| `webcmd doctor` is red | Fix the browser runtime first; browser commands depend on it. |
+| Skills not loading in OpenClaw | Run `webcmd skills add` with the `agents` provider, then restart the Gateway. |
+| OpenClaw still uses its native web tools | Confirm `tools.deny` lists the tool IDs in `~/.openclaw/openclaw.json`; the Gateway hot-reloads config. |
+| `webcmd` not found in OpenClaw exec | Confirm `webcmd` is on the PATH the Gateway's `exec` tool uses; restart after installing the CLI. |
+| Browser sessions stop working after idle | Ask the agent to open a fresh session or re-bind with `tabs` and `bind --page`. |
+
+## See also
+
+* [`start.md`](../../start.md) — common setup, [auth profiles and human handoff](../../start.md#auth-profiles-and-human-handoff), and [security](../../start.md#security).
+* [`webcmd-browser`](../../skills/webcmd-browser/SKILL.md) — the raw browser session surface.
+* [`webcmd-usage`](../../skills/webcmd-usage/SKILL.md) — adapter-first usage rules.

--- a/docs/agents/opencode.md
+++ b/docs/agents/opencode.md
@@ -1,0 +1,71 @@
+---
+title: OpenCode Agent
+sidebarTitle: OpenCode
+---
+
+> Use Webcmd with OpenCode to replace its built-in `webfetch` / `websearch` tools with the Webcmd browser surface.
+
+Point OpenCode at Webcmd's browser CLI to replace its native browser tools with Webcmd's adapters and `webcmd browser` sessions. Adapter-first commands and compact snapshots usually use fewer tokens than OpenCode's native web tools, and logged-in profiles handle authenticated pages.
+
+## Requirements
+
+* Node.js 20.6+
+* The `webcmd` npm CLI, installed globally or in the project
+* OpenCode config access (`./opencode.json` or `~/.config/opencode/opencode.json`)
+* A browser runtime; confirm with `webcmd doctor` before browser work
+
+## Install and configure
+
+Install Webcmd and its skills:
+
+```bash
+npm install -g @agentrhq/webcmd
+webcmd doctor
+webcmd skills add
+```
+
+When `webcmd skills add` prompts, choose the `agents` provider (installs into `~/.agents/skills/`, which OpenCode auto-loads). OpenCode then reads `webcmd-usage` and `webcmd-browser` as skills.
+
+Add the Webcmd skills path and the browser-tool permissions to `opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "webfetch": "deny",
+    "websearch": "deny"
+  }
+}
+```
+
+Restart OpenCode after changing config. Confirm the skill loads with `/skills` and the permissions are active before starting browser work.
+
+## Disable OpenCode's built-in browser
+
+OpenCode's native web tools are `webfetch` (fetch a URL) and `websearch` (search). Deny both so OpenCode cannot fall back to them while Webcmd is its browser surface. Do not add a legacy `tools` block as well; `permission` is the supported field. Denying the tools does not turn off the Bash tool, which is how `webcmd browser` is driven.
+
+## Auth profiles and human handoff
+
+Webcmd browser sessions keep signed-in state in profiles. To sign in once, run the session headed and complete login in the window yourself, then close the session; later headless runs reuse the cookies. Profile changes save only on a clean close.
+
+For login walls or CAPTCHA during a run, stop browser writes and hand off to the user with any `handoff.viewUrl` or `Webcmd browser:` link, then verify the post-action state before retrying. Never ask for or type passwords, OTPs, cookies, credentials, or session secrets.
+
+## Security
+
+`webcmd browser run` executes Playwright and JavaScript in the sandboxed browser runtime. Treat the machine running Webcmd as the trust boundary. Do not share profile directories across untrusted users.
+
+## Troubleshooting
+
+| Symptom | What to try |
+| --- | --- |
+| `webcmd doctor` is red | Fix the browser runtime first; browser commands depend on it. |
+| Skills not loading in OpenCode | Run `webcmd skills add` with the `agents` provider, restart OpenCode, and check `/skills`. |
+| OpenCode still uses `webfetch` / `websearch` | Confirm `permission.webfetch` and `permission.websearch` are `deny` in the active config, then restart OpenCode. |
+| `webcmd browser` errors | Read `webcmd-usage` and `webcmd-browser` skills; sessions require a `<session>` name after `browser`. |
+| Browser sessions stop working after idle | Ask the agent to open a fresh session or re-bind with `tabs` and `bind --page`. |
+
+## See also
+
+* [`start.md`](../../start.md) — bootstrap Webcmd end to end.
+* [`webcmd-browser`](../../skills/webcmd-browser/SKILL.md) — the raw browser session surface.
+* [`webcmd-usage`](../../skills/webcmd-usage/SKILL.md) — adapter-first usage rules.

--- a/docs/agents/opencode.md
+++ b/docs/agents/opencode.md
@@ -3,18 +3,24 @@ title: OpenCode Agent
 sidebarTitle: OpenCode
 ---
 
+> **Agent prompt**
+>
+> Fetch and follow [start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end, then read this page's Manual — especially [Override default tools](#override-default-tools) — before doing browser work.
+
 > Use Webcmd with OpenCode to replace its built-in `webfetch` / `websearch` tools with the Webcmd browser surface.
 
 Point OpenCode at Webcmd's browser CLI to replace its native browser tools with Webcmd's adapters and `webcmd browser` sessions. Adapter-first commands and compact snapshots usually use fewer tokens than OpenCode's native web tools, and logged-in profiles handle authenticated pages.
 
-## Requirements
+## Manual
+
+### Requirements
 
 * Node.js 20.6+
 * The `webcmd` npm CLI, installed globally or in the project
 * OpenCode config access (`./opencode.json` or `~/.config/opencode/opencode.json`)
 * A browser runtime; confirm with `webcmd doctor` before browser work
 
-## Install and configure
+### Install and configure
 
 Install Webcmd and its skills:
 
@@ -26,7 +32,13 @@ webcmd skills add
 
 When `webcmd skills add` prompts, choose the `agents` provider (installs into `~/.agents/skills/`, which OpenCode auto-loads). OpenCode then reads `webcmd-usage` and `webcmd-browser` as skills.
 
-Add the Webcmd skills path and the browser-tool permissions to `opencode.json`:
+Restart OpenCode after changing config. Confirm the skill loads with `/skills` and the permissions are active before starting browser work.
+
+### Override default tools
+
+OpenCode's native web tools are `webfetch` (fetch a URL) and `websearch` (search). Deny both so OpenCode cannot fall back to them while Webcmd is its browser surface. Do not add a legacy `tools` block as well; `permission` is the supported field. Denying the tools does not turn off the Bash tool, which is how `webcmd browser` is driven.
+
+Add to `opencode.json`:
 
 ```json
 {
@@ -38,23 +50,7 @@ Add the Webcmd skills path and the browser-tool permissions to `opencode.json`:
 }
 ```
 
-Restart OpenCode after changing config. Confirm the skill loads with `/skills` and the permissions are active before starting browser work.
-
-## Disable OpenCode's built-in browser
-
-OpenCode's native web tools are `webfetch` (fetch a URL) and `websearch` (search). Deny both so OpenCode cannot fall back to them while Webcmd is its browser surface. Do not add a legacy `tools` block as well; `permission` is the supported field. Denying the tools does not turn off the Bash tool, which is how `webcmd browser` is driven.
-
-## Auth profiles and human handoff
-
-Webcmd browser sessions keep signed-in state in profiles. To sign in once, run the session headed and complete login in the window yourself, then close the session; later headless runs reuse the cookies. Profile changes save only on a clean close.
-
-For login walls or CAPTCHA during a run, stop browser writes and hand off to the user with any `handoff.viewUrl` or `Webcmd browser:` link, then verify the post-action state before retrying. Never ask for or type passwords, OTPs, cookies, credentials, or session secrets.
-
-## Security
-
-`webcmd browser run` executes Playwright and JavaScript in the sandboxed browser runtime. Treat the machine running Webcmd as the trust boundary. Do not share profile directories across untrusted users.
-
-## Troubleshooting
+### Troubleshooting
 
 | Symptom | What to try |
 | --- | --- |
@@ -66,6 +62,6 @@ For login walls or CAPTCHA during a run, stop browser writes and hand off to the
 
 ## See also
 
-* [`start.md`](../../start.md) — bootstrap Webcmd end to end.
+* [`start.md`](../../start.md) — common setup, [auth profiles and human handoff](../../start.md#auth-profiles-and-human-handoff), and [security](../../start.md#security).
 * [`webcmd-browser`](../../skills/webcmd-browser/SKILL.md) — the raw browser session surface.
 * [`webcmd-usage`](../../skills/webcmd-usage/SKILL.md) — adapter-first usage rules.

--- a/docs/agents/pi.md
+++ b/docs/agents/pi.md
@@ -1,0 +1,69 @@
+---
+title: Pi Agent
+sidebarTitle: Pi
+---
+
+> **Agent prompt**
+>
+> Fetch and follow [start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end, then read this page's Manual — especially [Override default tools](#override-default-tools) — before doing browser work.
+
+> Use Webcmd with [Pi](https://pi.dev) to give it a browser surface. Pi ships no built-in web, search, or browser tools, so Webcmd is driven through Pi's default `bash` tool with no permission or config changes.
+
+Pi is a minimal terminal coding harness whose default tools are filesystem and shell only (`read`, `bash`, `edit`, `write`, with `grep`, `find`, and `ls` available). Its agent drives Webcmd through the `bash` tool. Adapter-first commands and compact snapshots usually use fewer tokens than the official `brave-search` and `browser-tools` skills, and logged-in profiles handle authenticated pages.
+
+## Manual
+
+### Requirements
+
+* Node.js 20.6+
+* The `webcmd` npm CLI, installed globally or in the project
+* Pi (`@earendil-works/pi-coding-agent`), running in a terminal session
+* A browser runtime; confirm with `webcmd doctor` before browser work
+
+### Install and configure
+
+Install Webcmd and its skills:
+
+```bash
+npm install -g @agentrhq/webcmd
+webcmd doctor
+webcmd skills add
+```
+
+When `webcmd skills add` prompts, choose the `agents` provider. It links skills into `~/.agents/skills/` (user) or `.agents/skills/` (project), both of which Pi scans for skills on startup alongside its own `~/.pi/agent/skills/` and `.pi/skills/` directories. Pi then surfaces `webcmd-usage` and `webcmd-browser` as skills.
+
+To install into Pi's own skill directories instead, pass a custom path:
+
+```bash
+webcmd skills add --path ~/.pi/agent/skills   # user level
+webcmd skills add --path .pi/skills           # project level
+```
+
+Project skills under `.pi/skills` and `.agents/skills` load only after the project is trusted. Accept Pi's trust prompt on first run in the project, or set `defaultProjectTrust` to `always` in `~/.pi/agent/settings.json`. Restart Pi after installing skills so the new skill descriptions are picked up at startup.
+
+### Override default tools
+
+Pi has no built-in web, search, or browser tools, so there is nothing to turn off. Webcmd works through the default `bash` tool as soon as the CLI is on PATH.
+
+If you also installed the official [pi-skills](https://github.com/badlogic/pi-skills) collection, two skills overlap with Webcmd:
+
+* `brave-search` — web search and content extraction via the Brave Search API
+* `browser-tools` — browser automation via the Chrome DevTools Protocol (Chrome on `:9222`)
+
+If both are present, tell Pi to prefer Webcmd, or remove the competing folders (for example `~/.pi/agent/skills/pi-skills/browser-tools`) so the model does not fall back to them.
+
+### Troubleshooting
+
+| Symptom | What to try |
+| --- | --- |
+| `webcmd doctor` is red | Fix the browser runtime first; browser commands depend on it. |
+| Skills not surfacing in Pi | Confirm links exist under `~/.agents/skills/`, `.agents/skills/`, `~/.pi/agent/skills/`, or `.pi/skills/` (rerun `webcmd skills add`), ensure the project is trusted, then restart Pi. |
+| Pi still uses `brave-search` / `browser-tools` | Remove those skill folders or prompt Pi to prefer Webcmd. |
+| `webcmd` not found in Pi's shell | Confirm `webcmd` is on the PATH Pi's `bash` tool uses; restart Pi after installing the CLI. |
+| Browser sessions stop working after idle | Ask the agent to open a fresh session or re-bind with `tabs` and `bind --page`. |
+
+## See also
+
+* [`start.md`](../../start.md) — common setup, [auth profiles and human handoff](../../start.md#auth-profiles-and-human-handoff), and [security](../../start.md#security).
+* [`webcmd-browser`](../../skills/webcmd-browser/SKILL.md) — the raw browser session surface.
+* [`webcmd-usage`](../../skills/webcmd-usage/SKILL.md) — adapter-first usage rules.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -47,6 +47,19 @@
             ]
           },
           {
+            "group": "Agent Harnesses",
+            "pages": [
+              "agents/cursor",
+              "agents/opencode",
+              "agents/claude-code",
+              "agents/codex-cli",
+              "agents/hermes",
+              "agents/pi",
+              "agents/openclaw",
+              "agents/custom-sdk"
+            ]
+          },
+          {
             "group": "Understand Webcmd",
             "pages": [
               "concepts",

--- a/start.md
+++ b/start.md
@@ -2,12 +2,29 @@
 
 Install Webcmd and verify that it runs end to end.
 
-## 1. Choose the target
+This is the common setup guide for every agent harness. Per-agent pages under `docs/agents/` cover harness-specific configuration; each has a *Manual* section ending with an *Override default tools* section that differs per agent. Start here, then follow the page for your harness.
 
-Inspect the current environment and ask only for missing information:
+## 1. Determine your agent type
 
-- Install globally (recommended) or into a project package?
-- Which agent harness is in use: opencode, claude, codex, hermes, cursor, or another? Each has a per-agent guide under `docs/agents/`.
+Inspect the current environment and ask only for missing information. Ask which harness is in use and classify it:
+
+- **Coding agent** — a terminal- or shell-driven harness that runs commands (Cursor, OpenCode, Claude Code, Codex CLI, Hermes Agent, Pi, OpenClaw). Fully supported by this guide; each has a per-agent page below.
+- **MCP-based agent** — a harness that consumes tools only through an MCP server. Not implemented yet; support is coming soon.
+- **Custom SDK** — programmatic integration through the Webcmd SDK. Not available yet; see [custom-sdk.md](docs/agents/custom-sdk.md).
+
+### Coding agent harnesses
+
+| Harness | Native tools Webcmd replaces | Page |
+| --- | --- | --- |
+| Cursor | `Browser`, `Web` | [cursor.md](docs/agents/cursor.md#override-default-tools) |
+| OpenCode | `webfetch`, `websearch` | [opencode.md](docs/agents/opencode.md#override-default-tools) |
+| Claude Code | `WebFetch`, `WebSearch` | [claude-code.md](docs/agents/claude-code.md#override-default-tools) |
+| Codex CLI | `web_search` | [codex-cli.md](docs/agents/codex-cli.md#override-default-tools) |
+| Hermes Agent | `browser_*` | [hermes.md](docs/agents/hermes.md#override-default-tools) |
+| Pi | none (optional `pi-skills`) | [pi.md](docs/agents/pi.md#override-default-tools) |
+| OpenClaw | `web_search`, `web_fetch`, `browser` | [openclaw.md](docs/agents/openclaw.md#override-default-tools) |
+
+For MCP-based and Custom SDK harnesses, the per-agent page's *Agent prompt* does not point here yet; follow the page directly.
 
 If the user already chose a path, location, name, or harness, treat that as binding.
 
@@ -32,15 +49,15 @@ Install the Webcmd skills for your harness:
 webcmd skills add
 ```
 
-When prompted, choose the provider that matches your agent. Then read the repo-level skill that was copied into the project before creating or editing browser automation. Use whichever path exists:
+When prompted, choose the provider that matches your agent (`agents`, `codex`, or `claude`). Then read the repo-level skill that was copied into the project before creating or editing browser automation. Use whichever path exists:
 
 ```text
 .agents/skills/webcmd-usage/SKILL.md
-.claude/skills/webcmd-usage/SKILL.md
 .codex/skills/webcmd-usage/SKILL.md
+.claude/skills/webcmd-usage/SKILL.md
 ```
 
-If none of those paths exist because the project has no `.agents/`, `.claude/`, or `.codex/` directory, create the appropriate agent directory and rerun `webcmd skills add`. Follow the per-agent guide under `docs/agents/` for harness-specific configuration, including disabling the agent's native browser tools.
+If none of those paths exist because the project has no `.agents/`, `.codex/`, or `.claude/` directory, create the appropriate agent directory and rerun `webcmd skills add`. Follow the per-agent page under `docs/agents/` for harness-specific configuration, including the *Override default tools* section that disables the agent's native browser tools.
 
 ## 4. Verify
 
@@ -69,6 +86,16 @@ After verifying Webcmd is set up and working properly, summarize the steps you t
 - Collect bookmarks, messages, or profile data using a logged-in profile.
 - Check product prices, availability, or delivery options.
 - Turn a proven browser workflow into a reusable `webcmd <site>` command.
+
+## Auth profiles and human handoff
+
+Webcmd browser sessions keep signed-in state in profiles. To sign in once, run the session headed and complete login in the window yourself, then close the session; later headless runs reuse the cookies. Profile changes save only on a clean close.
+
+For login walls or CAPTCHA during a run, stop browser writes and hand off to the user with any `handoff.viewUrl` or `Webcmd browser:` link, then verify the post-action state before retrying. Never ask for or type passwords, OTPs, cookies, credentials, or session secrets.
+
+## Security
+
+`webcmd browser run` executes Playwright and JavaScript in the sandboxed browser runtime. Treat the machine running Webcmd as the trust boundary. Do not share profile directories across untrusted users.
 
 ## Important Instructions and Constraints to be Successful
 

--- a/start.md
+++ b/start.md
@@ -1,0 +1,78 @@
+# Set Up Webcmd
+
+Install Webcmd and verify that it runs end to end.
+
+## 1. Choose the target
+
+Inspect the current environment and ask only for missing information:
+
+- Install globally (recommended) or into a project package?
+- Which agent harness is in use: opencode, claude, codex, hermes, cursor, or another? Each has a per-agent guide under `docs/agents/`.
+
+If the user already chose a path, location, name, or harness, treat that as binding.
+
+## 2. Set up the package
+
+For a global install:
+
+```bash
+npm install -g @agentrhq/webcmd
+webcmd doctor
+```
+
+For a project install, run the equivalent commands with the project's package manager (npm, pnpm, yarn, bun).
+
+`webcmd doctor` must be green before browser commands will work. Fix only the setup issue `doctor` reports; do not proceed until it passes.
+
+## 3. Read installed guidance
+
+Install the Webcmd skills for your harness:
+
+```bash
+webcmd skills add
+```
+
+When prompted, choose the provider that matches your agent. Then read the repo-level skill that was copied into the project before creating or editing browser automation. Use whichever path exists:
+
+```text
+.agents/skills/webcmd-usage/SKILL.md
+.claude/skills/webcmd-usage/SKILL.md
+.codex/skills/webcmd-usage/SKILL.md
+```
+
+If none of those paths exist because the project has no `.agents/`, `.claude/`, or `.codex/` directory, create the appropriate agent directory and rerun `webcmd skills add`. Follow the per-agent guide under `docs/agents/` for harness-specific configuration, including disabling the agent's native browser tools.
+
+## 4. Verify
+
+For this smoke check, copy the program below directly; do not inspect additional references unless validation fails. Run it against a real page:
+
+```bash
+webcmd browser work run --stdin <<'JS'
+await page.goto('https://example.com');
+return { title: await page.title(), url: page.url() };
+JS
+```
+
+Then release the session:
+
+```bash
+webcmd browser work close
+```
+
+The run must return the page title and URL.
+
+## 5. Finish
+
+After verifying Webcmd is set up and working properly, summarize the steps you took and offer some sample browser automations you could build next, such as:
+
+- Research a topic across a site and return a concise comparison with source links.
+- Collect bookmarks, messages, or profile data using a logged-in profile.
+- Check product prices, availability, or delivery options.
+- Turn a proven browser workflow into a reusable `webcmd <site>` command.
+
+## Important Instructions and Constraints to be Successful
+
+- Fix only setup-related failures.
+- Do not make unrelated changes or invent secrets.
+- Adapter first, browser second: before opening a raw browser session, check `webcmd list -f json` for an adapter that covers the task. Use raw `webcmd browser` only when no adapter exists.
+- Never ask for or type passwords, OTPs, cookies, credentials, or session secrets. Use Webcmd's human handoff for login walls.


### PR DESCRIPTION
## Summary

Restructures the per-agent documentation so every harness follows a single setup flow and a shared structure.

- **start.md** now routes setup by agent type (coding agent / MCP-based / custom SDK), keeps the common install-verify-skills flow, and single-sources the auth/handoff and security sections.
- Each per-agent page now uses the **Agent prompt + Manual** structure with an **Override default tools** section that disables the harness's native browser/web tools.
- New pages for **Claude Code**, **Codex CLI**, **Pi**, and **OpenClaw**, plus a **custom-sdk** stub.
- Existing Cursor, Hermes, and OpenCode pages restructured to the same format.
- Adds the **Agent Harnesses** group to the docs navigation.

Override methods were verified against each harness's official docs/source.

| Harness | Native tools | Override |
| --- | --- | --- |
| Cursor | Browser, Web | `.cursor/rules/webcmd-browser.mdc` alwaysApply rule |
| OpenCode | webfetch, websearch | `permission` deny in opencode.json |
| Claude Code | WebFetch, WebSearch | `permissions.deny` in settings.json |
| Codex CLI | web_search | `web_search = "disabled"` in config.toml |
| Hermes Agent | browser_* | `hermes tools disable browser` / disabled_toolsets |
| Pi | none (optional pi-skills) | nothing built-in to disable |
| OpenClaw | web_search, web_fetch, browser | `tools.deny` in openclaw.json |