### PR TITLE
feat: migrate release tooling to openai

### DIFF
--- a/.github/workflows/docs-sync-review.yml
+++ b/.github/workflows/docs-sync-review.yml
@@ -37,6 +37,6 @@ jobs:
       - name: Review documentation sync
         env:
           GH_TOKEN: ${{ github.token }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GEMINI_DOCS_REVIEW_MODEL: ${{ vars.GEMINI_DOCS_REVIEW_MODEL }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_DOCS_REVIEW_MODEL: ${{ vars.OPENAI_DOCS_REVIEW_MODEL }}
         run: npm --silent run docs-sync-review -- "${{ github.event.pull_request.number }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,8 +105,8 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GEMINI_RELEASE_NOTES_MODEL: ${{ vars.GEMINI_RELEASE_NOTES_MODEL }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_RELEASE_NOTES_MODEL: ${{ vars.OPENAI_RELEASE_NOTES_MODEL }}
         run: |
           set -euo pipefail
           npm --silent run generate-release-notes -- "${{ steps.release.outputs.tag_name || inputs.publish_tag }}" > "$RUNNER_TEMP/release-notes.md"

--- a/scripts/docs-sync-review.ts
+++ b/scripts/docs-sync-review.ts
@@ -1,10 +1,8 @@
 import { appendFileSync, lstatSync, readFileSync } from 'node:fs';
 import { isAbsolute, resolve, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { GoogleGenAI } from '@google/genai';
 import {
   REVIEW_COMMENT_MARKER,
-  REVIEW_JSON_SCHEMA,
   buildReviewPrompts,
   classifyPullRequest,
   createDeferredResult,
@@ -60,23 +58,6 @@ interface IssueCommentResponse {
   body?: string | null;
   user?: { login?: string } | null;
 }
-
-interface GeminiClientLike {
-  models: {
-    generateContent: (request: {
-      model: string;
-      contents: string;
-      config: {
-        responseMimeType: string;
-        responseJsonSchema: unknown;
-        temperature: number;
-        abortSignal: AbortSignal;
-      };
-    }) => Promise<{ text?: string }>;
-  };
-}
-
-export type GeminiClientFactory = (apiKey: string) => GeminiClientLike;
 
 const GITHUB_API_ROOT = 'https://api.github.com';
 const GITHUB_API_VERSION = '2022-11-28';
@@ -200,38 +181,35 @@ export function loadDocumentation(
   return excerpts;
 }
 
-const defaultGeminiClient: GeminiClientFactory = (apiKey) => {
-  const client = new GoogleGenAI({ apiKey });
-  return {
-    models: {
-      generateContent: (request) => client.models.generateContent(request),
-    },
-  };
-};
-
-export async function generateGeminiReview(
+export async function generateOpenAIReview(
   prompt: string,
   model: string,
   apiKey: string,
-  createClient: GeminiClientFactory = defaultGeminiClient,
+  fetchImpl: FetchLike = fetch,
 ): Promise<unknown> {
-  const client = createClient(apiKey);
-  const response = await client.models.generateContent({
-    model,
-    contents: prompt,
-    config: {
-      responseMimeType: 'application/json',
-      responseJsonSchema: REVIEW_JSON_SCHEMA,
-      temperature: 0.1,
-      abortSignal: AbortSignal.timeout(180_000),
+  const response = await fetchImpl('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      'content-type': 'application/json',
     },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0.1,
+    }),
+    signal: AbortSignal.timeout(180_000),
   });
-  const text = response.text?.trim();
-  if (!text) throw new Error('Gemini returned empty content.');
+  if (!response.ok) throw new Error(`OpenAI request failed with HTTP ${response.status}.`);
+  const data = await response.json() as {
+    choices?: Array<{ message?: { content?: string | null } }>;
+  };
+  const text = data.choices?.[0]?.message?.content?.trim();
+  if (!text) throw new Error('OpenAI returned empty content.');
   try {
     return JSON.parse(text) as unknown;
   } catch {
-    throw new Error('Gemini returned invalid JSON.');
+    throw new Error('OpenAI returned invalid JSON.');
   }
 }
 
@@ -265,7 +243,7 @@ export async function runDocsSyncReview(
 
   const loadContext = deps.loadContext ?? loadPullRequestContext;
   const readDocumentation = deps.loadDocumentation ?? loadDocumentation;
-  const generateReview = deps.generateReview ?? generateGeminiReview;
+  const generateReview = deps.generateReview ?? generateOpenAIReview;
   const upsertComment = deps.upsertComment ?? upsertReviewComment;
   const writeSummary = deps.writeSummary ?? defaultWriteSummary;
 
@@ -287,7 +265,7 @@ export async function runDocsSyncReview(
     if (routing.route === 'resolved') {
       result = createResolvedResult(routing);
     } else {
-      const apiKey = env.GEMINI_API_KEY?.trim();
+      const apiKey = env.OPENAI_API_KEY?.trim();
       if (!apiKey) {
         io.writeStderr('Semantic review API key is not configured.\n');
         result = createUnavailableResult();
@@ -295,7 +273,7 @@ export async function runDocsSyncReview(
         const documentation = readDocumentation(selectDocumentationPaths(context.files));
         const prompts = buildReviewPrompts(context, documentation);
         const reviews: ReviewResult[] = [];
-        const model = env.GEMINI_DOCS_REVIEW_MODEL?.trim() || 'gemini-3.5-flash';
+        const model = env.OPENAI_DOCS_REVIEW_MODEL?.trim() || 'gpt-5.6-sol';
         for (const [index, prompt] of prompts.entries()) {
           try {
             const raw = await generateReview(prompt.prompt, model, apiKey);

--- a/scripts/generate-release-notes.ts
+++ b/scripts/generate-release-notes.ts
@@ -1,7 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
-import { GoogleGenAI } from '@google/genai';
 import {
   buildReleaseNotesPrompt,
   extractPullRequestNumber,
@@ -65,7 +64,7 @@ interface LoadReleaseContextOptions {
   maxDiffCharacters?: number;
 }
 
-const DEFAULT_MODEL = 'gemini-2.5-pro';
+const DEFAULT_MODEL = 'gpt-5.6-sol';
 const DEFAULT_MAX_DIFF_CHARACTERS = 24_000;
 const DEFAULT_IO: Io = {
   writeStdout: (chunk) => process.stdout.write(chunk),
@@ -180,14 +179,27 @@ export async function loadReleaseContext(tag: string, env: NodeJS.ProcessEnv, op
 }
 
 async function generateText(prompt: string, model: string, apiKey: string): Promise<string> {
-  const client = new GoogleGenAI({ apiKey });
-  const response = await client.models.generateContent({
-    model,
-    contents: prompt,
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0.1,
+    }),
   });
-  const text = response.text?.trim();
+  if (!response.ok) {
+    throw new Error(`OpenAI request failed with HTTP ${response.status}`);
+  }
+  const data = await response.json() as {
+    choices?: Array<{ message?: { content?: string | null } }>;
+  };
+  const text = data.choices?.[0]?.message?.content?.trim();
   if (!text) {
-    throw new Error('Gemini returned empty content');
+    throw new Error('OpenAI returned empty content');
   }
 
   return text;
@@ -234,15 +246,15 @@ export async function runGenerateReleaseNotes(
     return 1;
   }
 
-  const apiKey = env.GEMINI_API_KEY?.trim();
+  const apiKey = env.OPENAI_API_KEY?.trim();
   if (!apiKey) {
-    io.writeStderr('GEMINI_API_KEY is not set; leaving release-please notes unchanged.\n');
+    io.writeStderr('OPENAI_API_KEY is not set; leaving release-please notes unchanged.\n');
     return 0;
   }
 
   try {
     const context = await (deps.loadContext ?? loadReleaseContext)(tag, env);
-    const model = env.GEMINI_RELEASE_NOTES_MODEL || DEFAULT_MODEL;
+    const model = env.OPENAI_RELEASE_NOTES_MODEL || DEFAULT_MODEL;
     const prompt = buildReleaseNotesPrompt(context);
     const raw = await (deps.generateText ?? generateText)(prompt, model, apiKey);
     const normalized = normalizeReleaseNotes(raw, { context });
@@ -252,7 +264,7 @@ export async function runGenerateReleaseNotes(
     return 0;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    io.writeStderr(`Gemini release notes failed: ${message}\n`);
+    io.writeStderr(`OpenAI release notes failed: ${message}\n`);
     return 0;
   }
 }

--- a/src/docs-sync-review-cli.test.ts
+++ b/src/docs-sync-review-cli.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import {
-  generateGeminiReview,
+  generateOpenAIReview,
   loadDocumentation,
   loadPullRequestContext,
   runDocsSyncReview,
@@ -13,7 +13,6 @@ import {
 import {
   MAX_DIFF_CHARACTERS,
   REVIEW_COMMENT_MARKER,
-  REVIEW_JSON_SCHEMA,
   type PullRequestReviewContext,
 } from './docs-sync-review.js';
 
@@ -75,7 +74,7 @@ function baseDependencies(pr = context()) {
 const ENV = {
   GITHUB_REPOSITORY: 'acme/webcmd',
   GH_TOKEN: 'github-token',
-  GEMINI_API_KEY: 'gemini-key',
+  OPENAI_API_KEY: 'openai-key',
   GITHUB_STEP_SUMMARY: '/tmp/summary.md',
 };
 
@@ -128,9 +127,9 @@ describe('runDocsSyncReview', () => {
     );
   });
 
-  it('posts unavailable orange without a Gemini key', async () => {
+  it('posts unavailable orange without an OpenAI key', async () => {
     const deps = baseDependencies();
-    const { GEMINI_API_KEY: _key, ...env } = ENV;
+    const { OPENAI_API_KEY: _key, ...env } = ENV;
 
     const exitCode = await runDocsSyncReview(['node', 'script', '72'], env, deps);
 
@@ -141,7 +140,7 @@ describe('runDocsSyncReview', () => {
     );
   });
 
-  it('posts a validated Gemini review', async () => {
+  it('posts a validated OpenAI review', async () => {
     const deps = baseDependencies();
 
     const exitCode = await runDocsSyncReview(['node', 'script', '72'], ENV, deps);
@@ -155,7 +154,7 @@ describe('runDocsSyncReview', () => {
 
   it('turns provider errors into a neutral non-blocking orange comment', async () => {
     const deps = baseDependencies();
-    deps.generateReview.mockRejectedValueOnce(new Error('Gemini quota exceeded'));
+    deps.generateReview.mockRejectedValueOnce(new Error('OpenAI quota exceeded'));
 
     const exitCode = await runDocsSyncReview(['node', 'script', '72'], ENV, deps);
 
@@ -341,35 +340,33 @@ describe('GitHub API boundaries', () => {
   });
 });
 
-describe('Gemini and documentation boundaries', () => {
-  it('requests structured Gemini JSON with the selected model', async () => {
-    const generateContent = vi.fn(async () => ({
-      text: JSON.stringify({ verdict: 'no_update_needed', summary: 'Covered.', findings: [] }),
+describe('OpenAI and documentation boundaries', () => {
+  it('requests JSON from OpenAI with the selected model', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({
+      choices: [{ message: { content: JSON.stringify({ verdict: 'no_update_needed', summary: 'Covered.', findings: [] }) } }],
     }));
-    const createClient = vi.fn(() => ({ models: { generateContent } }));
 
-    const result = await generateGeminiReview('review prompt', 'gemini-test', 'api-key', createClient);
+    const result = await generateOpenAIReview('review prompt', 'gpt-test', 'api-key', fetchImpl);
 
-    expect(createClient).toHaveBeenCalledWith('api-key');
-    expect(generateContent).toHaveBeenCalledWith({
-      model: 'gemini-test',
-      contents: 'review prompt',
-      config: expect.objectContaining({
-        responseMimeType: 'application/json',
-        responseJsonSchema: REVIEW_JSON_SCHEMA,
-        temperature: 0.1,
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/chat/completions',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ authorization: 'Bearer api-key' }),
       }),
-    });
+    );
     expect(result).toEqual({ verdict: 'no_update_needed', summary: 'Covered.', findings: [] });
   });
 
   it.each([
     ['empty', ''],
     ['invalid JSON', '{not json'],
-  ])('rejects %s Gemini output', async (_name, text) => {
-    const createClient = () => ({ models: { generateContent: async () => ({ text }) } });
+  ])('rejects %s OpenAI output', async (_name, text) => {
+    const fetchImpl = vi.fn(async () => jsonResponse({
+      choices: [{ message: { content: text || null } }],
+    }));
 
-    await expect(generateGeminiReview('prompt', 'model', 'key', createClient)).rejects.toThrow();
+    await expect(generateOpenAIReview('prompt', 'model', 'key', fetchImpl)).rejects.toThrow();
   });
 
   it('reads only regular documentation files inside the repository root', () => {
@@ -412,8 +409,8 @@ describe('documentation sync workflow', () => {
     expect(workflow).toContain('issues: write');
     expect(workflow).toContain('ref: ${{ github.event.repository.default_branch }}');
     expect(workflow).toContain('GH_TOKEN: ${{ github.token }}');
-    expect(workflow).toContain('GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}');
-    expect(workflow).toContain('GEMINI_DOCS_REVIEW_MODEL: ${{ vars.GEMINI_DOCS_REVIEW_MODEL }}');
+    expect(workflow).toContain('OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}');
+    expect(workflow).toContain('OPENAI_DOCS_REVIEW_MODEL: ${{ vars.OPENAI_DOCS_REVIEW_MODEL }}');
     expect(workflow).toContain('npm --silent run docs-sync-review -- "${{ github.event.pull_request.number }}"');
     expect(workflow).not.toMatch(/pull_request\.head|head\.sha|github\.head_ref/);
   });

--- a/src/generate-release-notes-cli.test.ts
+++ b/src/generate-release-notes-cli.test.ts
@@ -38,7 +38,7 @@ describe('runGenerateReleaseNotes', () => {
     });
   });
 
-  it('exits 0 and leaves stdout empty when GEMINI_API_KEY is missing', async () => {
+  it('exits 0 and leaves stdout empty when OPENAI_API_KEY is missing', async () => {
     const { io, read } = createIo();
 
     const exitCode = await runGenerateReleaseNotes(['node', 'script', 'v0.0.0'], {}, {}, io);
@@ -46,7 +46,7 @@ describe('runGenerateReleaseNotes', () => {
     expect(exitCode).toBe(0);
     expect(read()).toEqual({
       stdout: '',
-      stderr: 'GEMINI_API_KEY is not set; leaving release-please notes unchanged.\n',
+      stderr: 'OPENAI_API_KEY is not set; leaving release-please notes unchanged.\n',
     });
   });
 
@@ -72,13 +72,13 @@ describe('runGenerateReleaseNotes', () => {
 
     const exitCode = await runGenerateReleaseNotes(
       ['node', 'script', 'v1.2.3'],
-      { GEMINI_API_KEY: 'test-key' },
+      { OPENAI_API_KEY: 'test-key' },
       { loadContext, generateText },
       io,
     );
 
     expect(exitCode).toBe(0);
-    expect(loadContext).toHaveBeenCalledWith('v1.2.3', { GEMINI_API_KEY: 'test-key' });
+    expect(loadContext).toHaveBeenCalledWith('v1.2.3', { OPENAI_API_KEY: 'test-key' });
     expect(generateText).toHaveBeenCalledOnce();
     expect(read()).toEqual({
       stdout: [
@@ -126,7 +126,7 @@ describe('runGenerateReleaseNotes', () => {
 
     const exitCode = await runGenerateReleaseNotes(
       ['node', 'script', 'v1.2.3'],
-      { GEMINI_API_KEY: 'test-key' },
+      { OPENAI_API_KEY: 'test-key' },
       { loadContext, generateText },
       io,
     );
@@ -146,7 +146,7 @@ describe('runGenerateReleaseNotes', () => {
 
     const exitCode = await runGenerateReleaseNotes(
       ['node', 'script', 'v1.2.3'],
-      { GEMINI_API_KEY: 'test-key' },
+      { OPENAI_API_KEY: 'test-key' },
       { loadContext },
       io,
     );
@@ -154,7 +154,7 @@ describe('runGenerateReleaseNotes', () => {
     expect(exitCode).toBe(0);
     expect(read()).toEqual({
       stdout: '',
-      stderr: 'Gemini release notes failed: gh timed out\n',
+      stderr: 'OpenAI release notes failed: gh timed out\n',
     });
   });
 


### PR DESCRIPTION
Migrates the release-notes and docs-sync-review OpenCLI scripts plus GitHub Actions from Gemini env vars to OpenAI env vars and API calls.\n\nVerification:\n- npx vitest run src/generate-release-notes-cli.test.ts src/docs-sync-review-cli.test.ts\n- npm run typecheck