### PR TITLE
fix: stop the plugin update guard firing on npm install artifacts

### DIFF
--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -1917,7 +1917,7 @@ describe('getDirtyFiles', () => {
   it('ignores the node_modules/package-lock.json that install itself created', () => {
     mockExecFileSync.mockImplementation((cmd, args) => {
       if (Array.isArray(args) && args[0] === 'rev-parse') return '.git\n';
-      return '?? node_modules/\n?? package-lock.json\n?? packages/alpha/node_modules/\n M packages/alpha/package-lock.json\n';
+      return '?? node_modules/\n?? package-lock.json\n?? packages/alpha/node_modules/\n?? packages/alpha/package-lock.json\n';
     });
     expect(pluginModule.getDirtyFiles('/some/dir')).toEqual([]);
   });
@@ -1928,6 +1928,26 @@ describe('getDirtyFiles', () => {
       return '?? node_modules_notes.md\n M src/package-lock.json.bak\n';
     });
     expect(pluginModule.getDirtyFiles('/some/dir')).toEqual(['?? node_modules_notes.md', 'M src/package-lock.json.bak']);
+  });
+
+  // Only `??` is npm's own output. Every tracked status at the same path is
+  // user work that updatePlugin would destroy, so it must keep blocking.
+  it.each([
+    [' M package-lock.json', 'M package-lock.json'],
+    ['M  package-lock.json', 'M  package-lock.json'],
+    [' D package-lock.json', 'D package-lock.json'],
+    ['D  package-lock.json', 'D  package-lock.json'],
+    ['A  package-lock.json', 'A  package-lock.json'],
+    [' M packages/alpha/package-lock.json', 'M packages/alpha/package-lock.json'],
+    [' M node_modules/vendored/patch.js', 'M node_modules/vendored/patch.js'],
+    ['R  old-lock.json -> package-lock.json', 'R  old-lock.json -> package-lock.json'],
+    ['UU package-lock.json', 'UU package-lock.json'],
+  ])('keeps tracked entry %j dirty', (porcelain, expected) => {
+    mockExecFileSync.mockImplementation((cmd, args) => {
+      if (Array.isArray(args) && args[0] === 'rev-parse') return '.git\n';
+      return `${porcelain}\n`;
+    });
+    expect(pluginModule.getDirtyFiles('/some/dir')).toEqual([expected]);
   });
 
   it('does not pass --untracked-files=no, so untracked files are reported (git already omits gitignored paths)', () => {

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -1914,6 +1914,22 @@ describe('getDirtyFiles', () => {
     expect(pluginModule.getDirtyFiles('/some/dir')).toEqual(['M foo.js', '?? untracked.js']);
   });
 
+  it('ignores the node_modules/package-lock.json that install itself created', () => {
+    mockExecFileSync.mockImplementation((cmd, args) => {
+      if (Array.isArray(args) && args[0] === 'rev-parse') return '.git\n';
+      return '?? node_modules/\n?? package-lock.json\n?? packages/alpha/node_modules/\n M packages/alpha/package-lock.json\n';
+    });
+    expect(pluginModule.getDirtyFiles('/some/dir')).toEqual([]);
+  });
+
+  it('still reports user work that merely looks like an install artifact', () => {
+    mockExecFileSync.mockImplementation((cmd, args) => {
+      if (Array.isArray(args) && args[0] === 'rev-parse') return '.git\n';
+      return '?? node_modules_notes.md\n M src/package-lock.json.bak\n';
+    });
+    expect(pluginModule.getDirtyFiles('/some/dir')).toEqual(['?? node_modules_notes.md', 'M src/package-lock.json.bak']);
+  });
+
   it('does not pass --untracked-files=no, so untracked files are reported (git already omits gitignored paths)', () => {
     mockExecFileSync.mockImplementation((cmd, args) => {
       expect(args).not.toContain('--untracked-files=no');

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -533,11 +533,10 @@ function describeGitError(error: unknown): string {
 /**
  * Report tracked-file modifications and untracked files within `dir` in a git checkout.
  *
- * Untracked files are included on purpose: `git status` already excludes
- * gitignored paths (build output like node_modules/dist never shows up), so
- * anything untracked that does show up is real, unsaved user work — e.g. a
- * new command file that hasn't been `git add`ed yet — which updating would
- * destroy just as surely as an uncommitted edit to a tracked file.
+ * Untracked files are included on purpose: anything untracked is real, unsaved
+ * user work — e.g. a new command file that hasn't been `git add`ed yet — which
+ * updating would destroy just as surely as an uncommitted edit to a tracked
+ * file. The exception is `installArtifacts`: those are ours, not the user's.
  *
  * The `-- .` pathspec on `git status` restricts the report to `dir` itself.
  * Without it, git reports the *entire enclosing repository* — e.g. a plugin
@@ -572,7 +571,8 @@ export function getDirtyFiles(dir: string): string[] {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });
-    return out.split('\n').map((line) => line.trim()).filter(Boolean);
+    return out.split('\n').map((line) => line.trim()).filter(Boolean)
+      .filter((entry) => !installArtifacts.test(dirtyEntryPath(entry)));
   } catch (error) {
     throw new PluginError(
       `Could not determine whether "${dir}" has uncommitted changes: git failed with: ${describeGitError(error)}`,
@@ -581,10 +581,23 @@ export function getDirtyFiles(dir: string): string[] {
   }
 }
 
+/**
+ * Artifacts `installDependencies` creates by running `npm install` in the
+ * checkout, at the repo root and in every sub-plugin of a monorepo. A plugin
+ * repo without a .gitignore reports them as dirty, so without this the guard
+ * fires on webcmd's own output and every such plugin is permanently
+ * un-updatable — blaming the user for work they never did.
+ */
+const installArtifacts = /(?:^|\/)(?:node_modules(?:\/|$)|package-lock\.json$)/;
+
+/** Path portion of a `git status --porcelain` entry (already trimmed of its leading space). */
+function dirtyEntryPath(entry: string): string {
+  return entry.startsWith('??') ? entry.slice(2).trim() : entry.replace(/^[MADRCU!]{1,2}\s+/, '');
+}
+
 function describeDirtyEntry(entry: string): string {
-  const isUntracked = entry.startsWith('??');
-  const file = entry.replace(/^\?\?\s*/, '').replace(/^[MADRCU! ]+\s*/, '');
-  return isUntracked ? `${file} (new, unstaged)` : `${file} (modified)`;
+  const file = dirtyEntryPath(entry);
+  return entry.startsWith('??') ? `${file} (new, unstaged)` : `${file} (modified)`;
 }
 
 function assertPluginNotDirty(name: string, dir: string, force: boolean): void {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -571,8 +571,9 @@ export function getDirtyFiles(dir: string): string[] {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });
-    return out.split('\n').map((line) => line.trim()).filter(Boolean)
-      .filter((entry) => !installArtifacts.test(dirtyEntryPath(entry)));
+    return out.split('\n').filter((line) => line.trim())
+      .filter((line) => !isInstallArtifact(line))
+      .map((line) => line.trim());
   } catch (error) {
     throw new PluginError(
       `Could not determine whether "${dir}" has uncommitted changes: git failed with: ${describeGitError(error)}`,
@@ -589,6 +590,18 @@ export function getDirtyFiles(dir: string): string[] {
  * un-updatable — blaming the user for work they never did.
  */
 const installArtifacts = /(?:^|\/)(?:node_modules(?:\/|$)|package-lock\.json$)/;
+
+/**
+ * True only for an artifact npm itself created: a `??` (untracked) porcelain
+ * entry at an artifact path. The status columns are read from the raw line
+ * before any trimming, because every other status — ` M`, `M `, ` D`, `A `,
+ * `R `, `UU` — is tracked work the user could lose when `updatePlugin`
+ * replaces the directory, no matter what the path looks like.
+ */
+function isInstallArtifact(line: string): boolean {
+  if (line.slice(0, 2) !== '??') return false;
+  return installArtifacts.test(line.slice(2).trim());
+}
 
 /** Path portion of a `git status --porcelain` entry (already trimmed of its leading space). */
 function dirtyEntryPath(entry: string): string {


### PR DESCRIPTION
No issue filed — found while investigating a failing test on #266, and unrelated to that PR, so it is on its own branch.

## The problem

`webcmd plugin update` refuses to run on a plugin that the user never touched.

`plugin install` runs `npm install --omit=dev --ignore-scripts` inside the cloned plugin ([src/plugin.ts](../blob/main/src/plugin.ts)). If that plugin repo has no `.gitignore`, git then reports `node_modules/` and `package-lock.json` as untracked changes, and the "don't destroy uncommitted work" guard blocks the update:

```
$ webcmd plugin install github:rishabhraj36/webcmd-plugin-bookmyshow
✅ Plugin "bookmyshow" installed successfully.
$ webcmd plugin update bookmyshow
Error: Plugin "bookmyshow" has uncommitted changes that updating would destroy:
  node_modules/ (new, unstaged)
  package-lock.json (new, unstaged)
```

The guard is firing on webcmd's own output and blaming the user for work they never did. Such a plugin is permanently un-updatable short of `--force`, which is documented as "discard uncommitted changes" — an alarming flag to need on a clean checkout.

This is also what fails `tests/e2e/plugin-management.test.ts > plugin update succeeds on an installed plugin` on `main`.

## What I changed

1. `src/plugin.ts` — `getDirtyFiles` now ignores `node_modules/` and `package-lock.json` at **any** depth. Depth matters because monorepo installs run `npm install` at the repo root *and* in each sub-plugin.
2. `src/plugin.ts` — pulled the porcelain path parsing into one `dirtyEntryPath` helper, now shared with `describeDirtyEntry`.
3. Anything else untracked is still treated as real user work and still blocks the update. A file merely *named* like an artifact (`node_modules_notes.md`) still blocks — there is a test for that.

Deliberately **not** filtered: the `.js` files `transpilePluginTs` emits next to `.ts` sources. Those are indistinguishable from hand-written files, so failing closed is the right default.

## Proof

- `npx vitest run` → **405 files, 4854 passed, 1 skipped, 0 failed** — the E2E test now passes.
- `npm run typecheck` clean.
- By hand: install → update against the real bookmyshow plugin now succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
