### PR TITLE
test: stop the oversized-file guard test writing 31 MB for real

### DIFF
--- a/plugins/claude/test/utils.test.js
+++ b/plugins/claude/test/utils.test.js
@@ -82,7 +82,10 @@ describe('claude sendWithFile', () => {
         const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-claude-'));
         tempDirs.push(dir);
         const filePath = path.join(dir, 'big.bin');
-        fs.writeFileSync(filePath, Buffer.alloc(31 * 1024 * 1024));
+        // Sparse: the guard only reads stats.size, and writing 31 MB for real
+        // timed out the 5s default on Windows CI.
+        fs.writeFileSync(filePath, '');
+        fs.truncateSync(filePath, 31 * 1024 * 1024);
 
         const page = { setFileInput: vi.fn(), evaluate: vi.fn(), wait: vi.fn() };
         const result = await sendWithFile(page, filePath, 'hi');


### PR DESCRIPTION
Fixes the Windows CI flake seen on #267. No issue filed.

## The problem

A test wrote a real 31 MB file to disk just to have something bigger than `sendWithFile`'s 30 MB limit. On a slow Windows runner that write alone can exceed the 5-second default timeout:

```
FAIL  plugin  plugins/claude/test/utils.test.js > claude sendWithFile > rejects oversized files before any upload attempt
Error: Test timed out in 5000ms.
```

It is a flake, not a regression: commit `4eb9c549` failed this job in its `push` run (31402668177) and passed the same job in its `pull_request` run (31402676413).

## What I changed

`plugins/claude/test/utils.test.js` — the size guard only reads `stats.size` ([plugins/claude/utils.js:378](../blob/main/plugins/claude/utils.js)), so the test now truncates an empty file to 31 MB instead of writing 31 MB of data. Same assertion, no bulk write.

## Proof

`npx vitest run plugins/claude/test/utils.test.js` → 12 passed, test time **5 ms** (previously dominated by the write). The `/too large/` assertion still fires, so the file really is over the limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
