### PR TITLE
fix: ship web fetch-browser so the blocked-fetch escalation works (#247)

### DIFF
--- a/scripts/check-package-bin.mjs
+++ b/scripts/check-package-bin.mjs
@@ -4,7 +4,7 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import {
   formatPackageBinSpawnFailure,
   packageBinSpawnOptions,
@@ -112,6 +112,33 @@ try {
       fail(`global install did not create executable: ${binPath}`);
     }
     run(binPath, ['--version'], { cwd: tmp });
+    // Presence in the tarball is not executability. Every manifest command must
+    // also be discoverable and loadable *from the installed layout*, which a
+    // repository checkout never exercises: there the builtin tree is clis/ at
+    // the package root, and only the installed package takes the dist/src/clis
+    // fallback. #247 was exactly this gap — advertised, then ADAPTER_LOAD on
+    // first use.
+    const installedMain = path.join(prefix, 'lib', 'node_modules', pkg.name, pkg.main);
+    for (const entry of manifest) {
+      if (!entry.modulePath) continue;
+      const help = run(binPath, [entry.site, entry.name, '--help'], { cwd: tmp });
+      if (/ADAPTER_LOAD/.test(`${help.stdout}${help.stderr}`)) {
+        fail(`installed package cannot present ${entry.site}/${entry.name}: ADAPTER_LOAD\n${help.stdout}${help.stderr}`);
+      }
+      // --help is served from the staged manifest and never imports the module;
+      // the import below is what execution does, through the CLI's own resolver.
+      const load = [
+        `const { resolveBuiltinClisDir } = await import(${JSON.stringify(pathToFileURL(path.join(path.dirname(installedMain), 'package-paths.js')).href)});`,
+        `const { pathToFileURL } = await import('node:url');`,
+        `const { join } = await import('node:path');`,
+        `const dir = resolveBuiltinClisDir(${JSON.stringify(installedMain)});`,
+        `await import(pathToFileURL(join(dir, ${JSON.stringify(entry.modulePath)})).href);`,
+      ].join('\n');
+      const result = spawnSync(process.execPath, ['--input-type=module', '-e', load], { cwd: tmp, encoding: 'utf8' });
+      if (result.status !== 0) {
+        fail(`installed package cannot load ${entry.site}/${entry.name} (${entry.modulePath}) — this is the ADAPTER_LOAD failure users hit:\n${result.stderr}`);
+      }
+    }
   }
 } finally {
   fs.rmSync(tmp, { recursive: true, force: true });

--- a/scripts/check-package-bin.mjs
+++ b/scripts/check-package-bin.mjs
@@ -118,7 +118,15 @@ try {
     // the package root, and only the installed package takes the dist/src/clis
     // fallback. #247 was exactly this gap — advertised, then ADAPTER_LOAD on
     // first use.
-    const installedMain = path.join(prefix, 'lib', 'node_modules', pkg.name, pkg.main);
+    // npm -g --prefix puts packages under <prefix>/lib/node_modules on POSIX
+    // and directly under <prefix>/node_modules on Windows.
+    const installedRoot = process.platform === 'win32'
+      ? path.join(prefix, 'node_modules', pkg.name)
+      : path.join(prefix, 'lib', 'node_modules', pkg.name);
+    const installedMain = path.join(installedRoot, pkg.main);
+    if (!fs.existsSync(installedMain)) {
+      fail(`global install did not create the package entry point: ${installedMain}`);
+    }
     for (const entry of manifest) {
       if (!entry.modulePath) continue;
       const help = run(binPath, [entry.site, entry.name, '--help'], { cwd: tmp });

--- a/scripts/check-package-bin.mjs
+++ b/scripts/check-package-bin.mjs
@@ -78,6 +78,22 @@ try {
   if (packedPaths.has('scripts/fetch-adapters.js')) {
     fail('packed tarball contains the retired adapter fetch lifecycle');
   }
+
+  // Every command the core manifest advertises must be in the tarball. A
+  // manifest entry whose module was left behind is discoverable but dies with
+  // ADAPTER_LOAD on first use — see #247, where web/fetch-browser was the only
+  // escalation path FETCH_BLOCKED knew how to recommend.
+  const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'cli-manifest.json'), 'utf8'));
+  for (const entry of manifest) {
+    if (!entry.modulePath) continue;
+    const packedModule = `dist/src/clis/${entry.modulePath}`;
+    if (!packedPaths.has(packedModule)) {
+      fail(`packed tarball is missing manifest module for ${entry.site}/${entry.name}: ${packedModule}`);
+    }
+  }
+  if (manifest.length > 0 && !packedPaths.has('dist/src/cli-manifest.json')) {
+    fail('packed tarball is missing the staged core manifest: dist/src/cli-manifest.json');
+  }
   for (const [name, target] of binEntries) {
     if (!packedPaths.has(String(target))) {
       fail(`packed tarball is missing bin "${name}" target: ${target}`);

--- a/scripts/copy-yaml.cjs
+++ b/scripts/copy-yaml.cjs
@@ -2,7 +2,8 @@
  * Copy YAML support files to dist/.
  * (Adapters are JS-first and no longer need yaml copying.)
  */
-const { copyFileSync, mkdirSync, existsSync } = require('fs');
+const { copyFileSync, cpSync, mkdirSync, existsSync } = require('fs');
+const { sep } = require('path');
 
 // Copy external CLI registry to dist/
 const extSrc = 'src/external-clis.yaml';
@@ -14,3 +15,13 @@ if (existsSync(extSrc)) {
 const playwrightClient = 'src/browser/run/generated/playwright-client.js';
 mkdirSync('dist/src/browser/run/generated', { recursive: true });
 copyFileSync(playwrightClient, 'dist/src/browser/run/generated/playwright-client.js');
+
+// Stage the builtin adapter tree next to the compiled output. package.json
+// `files` ships dist/src/ but not the repo-root clis/, so without this the
+// core manifest points at modules the published package does not contain.
+if (existsSync('clis')) {
+  cpSync('clis', 'dist/src/clis', {
+    recursive: true,
+    filter: (src) => !src.split(sep).includes('test'),
+  });
+}

--- a/src/build-manifest.ts
+++ b/src/build-manifest.ts
@@ -27,7 +27,7 @@ import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { getErrorMessage } from './errors.js';
 import { fullName, getRegistry, type CliCommand } from './registry.js';
-import { findPackageRoot } from './package-paths.js';
+import { findPackageRoot, getCliManifestPath } from './package-paths.js';
 import type { ManifestEntry } from './manifest-types.js';
 import { isRecord } from './utils.js';
 import {
@@ -450,6 +450,13 @@ async function main(): Promise<void> {
 
   fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
   fs.writeFileSync(OUTPUT, artifacts.manifestJson);
+  // The published package resolves the builtin tree to dist/src/clis/, and the
+  // manifest lookup is always clisDir/../cli-manifest.json — keep the staged
+  // copy in step so an installed CLI does not fall back to a filesystem scan.
+  const stagedClis = path.join(PACKAGE_ROOT, 'dist', 'src', 'clis');
+  if (fs.existsSync(stagedClis)) {
+    fs.writeFileSync(getCliManifestPath(stagedClis), artifacts.manifestJson);
+  }
   fs.writeFileSync(HOSTED_CONTRACT_OUTPUT, artifacts.hostedContractJson);
   console.error(`✅ Manifest compiled: ${entries.length} entries → ${OUTPUT}`);
   console.error(`✅ Hosted contract compiled: ${packageMetadata.name}@${packageMetadata.version} → ${HOSTED_CONTRACT_OUTPUT}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,9 +26,13 @@ import { CONFIG_DIR_NAME } from './brand.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-// The empty core manifest remains next to the retired clis/ location so older
-// user-local adapter manifests keep the same lookup contract.
-const BUILTIN_CLIS = path.join(findPackageRoot(__filename), 'clis');
+// The core manifest sits next to the builtin clis/ tree so user-local adapter
+// manifests keep the same lookup contract. In a repo checkout that tree is
+// clis/ at the package root; the published package cannot ship adapter source
+// at the root, so the build stages a copy next to the compiled output and this
+// resolves to dist/src/clis/ there.
+const REPO_BUILTIN_CLIS = path.join(findPackageRoot(__filename), 'clis');
+const BUILTIN_CLIS = fs.existsSync(REPO_BUILTIN_CLIS) ? REPO_BUILTIN_CLIS : path.join(__dirname, 'clis');
 const USER_CLIS = path.join(os.homedir(), CONFIG_DIR_NAME, 'clis');
 const USER_PLUGINS = path.join(os.homedir(), CONFIG_DIR_NAME, 'plugins');
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getCompletionScriptFast, getCompletionsFromManifest, hasAllManifests } from './completion-fast.js';
-import { findPackageRoot, getCliManifestPath } from './package-paths.js';
+import { findPackageRoot, getCliManifestPath, resolveBuiltinClisDir } from './package-paths.js';
 import { PKG_VERSION } from './version.js';
 import { EXIT_CODES } from './errors.js';
 import { isSupportedNodeVersion, MIN_SUPPORTED_NODE_MAJOR } from './runtime-detect.js';
@@ -27,12 +27,8 @@ import { CONFIG_DIR_NAME } from './brand.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 // The core manifest sits next to the builtin clis/ tree so user-local adapter
-// manifests keep the same lookup contract. In a repo checkout that tree is
-// clis/ at the package root; the published package cannot ship adapter source
-// at the root, so the build stages a copy next to the compiled output and this
-// resolves to dist/src/clis/ there.
-const REPO_BUILTIN_CLIS = path.join(findPackageRoot(__filename), 'clis');
-const BUILTIN_CLIS = fs.existsSync(REPO_BUILTIN_CLIS) ? REPO_BUILTIN_CLIS : path.join(__dirname, 'clis');
+// manifests keep the same lookup contract.
+const BUILTIN_CLIS = resolveBuiltinClisDir(__filename);
 const USER_CLIS = path.join(os.homedir(), CONFIG_DIR_NAME, 'clis');
 const USER_PLUGINS = path.join(os.homedir(), CONFIG_DIR_NAME, 'plugins');
 

--- a/src/package-paths.ts
+++ b/src/package-paths.ts
@@ -49,6 +49,20 @@ export function getBuiltEntryCandidates(
   return [...new Set(candidates)];
 }
 
+/**
+ * Directory holding the builtin adapter modules, given the running entry file.
+ *
+ * In a repo checkout that is `clis/` at the package root. The published package
+ * cannot ship adapter source at the root, so the build stages a copy next to the
+ * compiled output and this resolves to `dist/src/clis/` there. Shared so the
+ * packaging check can load manifest modules through the same resolution the CLI
+ * uses at execution time, rather than a copy of it that can drift.
+ */
+export function resolveBuiltinClisDir(entryFile: string, fileExists: (candidate: string) => boolean = fs.existsSync): string {
+  const repoClis = path.join(findPackageRoot(entryFile, fileExists), 'clis');
+  return fileExists(repoClis) ? repoClis : path.join(path.dirname(entryFile), 'clis');
+}
+
 export function getCliManifestPath(clisDir: string): string {
   return path.resolve(clisDir, '..', 'cli-manifest.json');
 }


### PR DESCRIPTION
Fixes #247

## The problem

When a plain fetch is blocked, webcmd tells the agent to escalate to `webcmd web fetch-browser` — and on a fresh install that command does not work. The escalation path is a dead end.

The symptom has moved since the issue was filed. On 0.6.0 the generated `cli-manifest.json` **does** ship and advertise `web/fetch-browser`, so the command is now discoverable and instead dies when it runs (reproduced against a globally installed 0.6.0):

```
code: ADAPTER_LOAD
message: Cannot find module .../@agentrhq/webcmd/clis/web/fetch-browser.js
```

Same root cause, same dead end.

**Root cause:** [0470ac43](https://github.com/agentrhq/webcmd/commit/0470ac43) (#216) removed `"clis/"` from `package.json` `files` while moving adapters into plugins. `clis/web` went to neither place — it is not in the package and there is no `web` plugin either (`webcmd-plugin.json` registers 122 plugins; none is `web`), so `webcmd plugin search web` offers no way out.

## What I changed

Ship it in the core package — the issue's first option. The published package cannot carry adapter source at the root, because [check-package-bin.mjs:73](scripts/check-package-bin.mjs:73) fails the build on a top-level `clis/` or `plugins/` in the tarball, and that policy stays. So the build stages the tree next to the compiled output instead:

1. `scripts/copy-yaml.cjs` — copies `clis/` → `dist/src/clis/` (tests excluded), the same staging it already does for `playwright-client.js`. `files` already ships `dist/src/`.
2. `src/main.ts` — `BUILTIN_CLIS` uses the repo-root `clis/` when it exists (dev, `tsx src/main.ts`) and falls back to `<compiled dir>/clis` in an installed package.
3. `src/build-manifest.ts` — writes a second copy of the manifest to `dist/src/cli-manifest.json`, because the lookup contract is `clisDir/../cli-manifest.json`. Without it, an installed CLI falls back to a filesystem scan and eagerly imports every adapter at startup.
4. `scripts/check-package-bin.mjs` — new assertion: **every `modulePath` in `cli-manifest.json` must exist in the packed tarball.** That is exactly the regression this bug was, so it cannot come back silently.

## Proof

- `npm pack` → install the tarball into a temp prefix → `webcmd web fetch-browser --url https://example.com --stdout` returns the extracted Markdown. Before: `ADAPTER_LOAD`.
- `check:package-bin` passes. With the staging step reverted it fails with `packed tarball is missing manifest module for web/fetch-browser` — the new guard bites on the real regression.
- `cli-manifest.json` and `hosted-contract.json` regenerate byte-identical (`check:hosted-contract` passes). `check:plugin-parity`, `typecheck` and `npm test` (394 files, 4781 tests) all pass.

## Not in this PR

- **Reimplementing `fetch-browser` as a client-owned fast path next to `web fetch`.** The browser lifecycle it needs (page provisioning, session, cloak, pre-nav, observation, tab cleanup) lives in `execution.ts` around the adapter, so a literal port would duplicate all of it. This delivers what the core option promised — ships in the package, zero install steps, the pair works out of the box — with one browser lifecycle. Say the word if you want the literal port instead.

## Review notes

- No conflict with #263: that PR changes the *content* of `clis/web/fetch.js`, not its location. It also benefits — its discoverability entry for `web fetch` pointed at a file fresh installs did not contain, and now they do.
- #269 (`#248`, smart-search) is the other half of that session's wasted cost; different files, no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
