### PR TITLE
docs: streamline agent onboarding prompt across agent pages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/README.md
+++ b/README.md
@@ -49,46 +49,6 @@ https://github.com/user-attachments/assets/04eceadc-d398-4303-984d-ae3197bfa664
 
 ## Quick Start
 
-### Codex
-
-In Codex, open **Plugins**, choose **Add plugin marketplace**, and enter either
-`agentrhq/webcmd` or `https://github.com/agentrhq/webcmd`. Install **Webcmd**
-from that marketplace, then start a new task. On first use, the plugin installs
-the npm CLI automatically if `webcmd` is missing.
-
-The plugin includes all seven bundled Webcmd skills. Do not also add those
-skills with `webcmd skills add` in Codex.
-
-### Other agents or plugin-free setup
-
-Webcmd requires Node.js 20.6+.
-
-```bash
-npm install -g @agentrhq/webcmd
-```
-
-The npm package ships the Webcmd core and browser commands, but no site
-adapters. Search the plugin catalog and explicitly install the adapter you
-need:
-
-```bash
-webcmd plugin search <site> -f json
-webcmd plugin install <installSource-from-search>
-```
-
-```bash
-webcmd skills add
-```
-
-When prompted, choose Claude, Codex, another supported harness, or a custom
-skills path.
-
-In your agent harness, load or tag `webcmd-usage`, then describe the outcome you want.
-
-```text
-Use webcmd to research the latest discussions about browser automation across Hacker News and Reddit, then return a concise comparison with source links.
-```
-
 ### Agent prompt
 
 > Fetch and follow [https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ https://github.com/user-attachments/assets/04eceadc-d398-4303-984d-ae3197bfa664
 Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
 ```
 
+### Manual
+
+Refer to the [Quickstart](https://webcmd.dev/docs/quickstart) docs for step-by-step manual setup.
+
 ## What You Can Ask
 
 - “Use webcmd to research agentic browser automation on PubMed and return the title, authors, publication date, abstract, and URL for each result.”

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ https://github.com/user-attachments/assets/04eceadc-d398-4303-984d-ae3197bfa664
 
 ### Agent prompt
 
-> Fetch and follow [https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end.
+```text
+Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+```
 
 ## What You Can Ask
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ In your agent harness, load or tag `webcmd-usage`, then describe the outcome you
 Use webcmd to research the latest discussions about browser automation across Hacker News and Reddit, then return a concise comparison with source links.
 ```
 
+### Agent prompt
+
+> Fetch and follow [https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end.
+
 ## What You Can Ask
 
 - “Use webcmd to research agentic browser automation on PubMed and return the title, authors, publication date, abstract, and URL for each result.”

--- a/docs/agents/claude-code.md
+++ b/docs/agents/claude-code.md
@@ -5,15 +5,7 @@ sidebarTitle: Claude Code
 
 ## Agent prompt
 
-Use this prompt with a coding agent to set up Webcmd end to end:
-
-```text
-Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
-```
-
-> Use Webcmd with [Claude Code](https://code.claude.com) to replace its native `WebFetch` and `WebSearch` tools with the Webcmd browser surface.
-
-Claude Code's native web tools are lossy by design: `WebFetch` summarizes a page with a small extraction model and `WebSearch` returns result titles and URLs but cannot read the pages. Point Claude Code at Webcmd's browser CLI instead: adapters return exact, stable fields, and `webcmd browser` sessions render real pages with logged-in profiles. Claude Code runs `webcmd` through its Bash tool.
+> Fetch and follow [https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end.
 
 ## Manual
 

--- a/docs/agents/claude-code.md
+++ b/docs/agents/claude-code.md
@@ -5,7 +5,9 @@ sidebarTitle: Claude Code
 
 ## Agent prompt
 
-> Fetch and follow [https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end.
+```text
+Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+```
 
 ## Manual
 

--- a/docs/agents/claude-code.md
+++ b/docs/agents/claude-code.md
@@ -3,11 +3,13 @@ title: Claude Code Agent
 sidebarTitle: Claude Code
 ---
 
-> **Agent prompt**
->
-> ```text
-> Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
-> ```
+## Agent prompt
+
+Use this prompt with a coding agent to set up Webcmd end to end:
+
+```text
+Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+```
 
 > Use Webcmd with [Claude Code](https://code.claude.com) to replace its native `WebFetch` and `WebSearch` tools with the Webcmd browser surface.
 

--- a/docs/agents/claude-code.md
+++ b/docs/agents/claude-code.md
@@ -5,7 +5,9 @@ sidebarTitle: Claude Code
 
 > **Agent prompt**
 >
-> Fetch and follow [start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end, then read this page's Manual — especially [Override default tools](#override-default-tools) — before doing browser work.
+> ```text
+> Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+> ```
 
 > Use Webcmd with [Claude Code](https://code.claude.com) to replace its native `WebFetch` and `WebSearch` tools with the Webcmd browser surface.
 

--- a/docs/agents/codex-cli.md
+++ b/docs/agents/codex-cli.md
@@ -3,11 +3,13 @@ title: Codex CLI Agent
 sidebarTitle: Codex CLI
 ---
 
-> **Agent prompt**
->
-> ```text
-> Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
-> ```
+## Agent prompt
+
+Use this prompt with a coding agent to set up Webcmd end to end:
+
+```text
+Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+```
 
 > Use Webcmd with [Codex CLI](https://developers.openai.com/codex/) to replace its native `web_search` tool with the Webcmd browser surface.
 

--- a/docs/agents/codex-cli.md
+++ b/docs/agents/codex-cli.md
@@ -5,7 +5,9 @@ sidebarTitle: Codex CLI
 
 > **Agent prompt**
 >
-> Fetch and follow [start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end, then read this page's Manual — especially [Override default tools](#override-default-tools) — before doing browser work.
+> ```text
+> Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+> ```
 
 > Use Webcmd with [Codex CLI](https://developers.openai.com/codex/) to replace its native `web_search` tool with the Webcmd browser surface.
 

--- a/docs/agents/codex-cli.md
+++ b/docs/agents/codex-cli.md
@@ -5,7 +5,9 @@ sidebarTitle: Codex CLI
 
 ## Agent prompt
 
-> Fetch and follow [https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end.
+```text
+Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+```
 
 ## Manual
 

--- a/docs/agents/codex-cli.md
+++ b/docs/agents/codex-cli.md
@@ -5,15 +5,7 @@ sidebarTitle: Codex CLI
 
 ## Agent prompt
 
-Use this prompt with a coding agent to set up Webcmd end to end:
-
-```text
-Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
-```
-
-> Use Webcmd with [Codex CLI](https://developers.openai.com/codex/) to replace its native `web_search` tool with the Webcmd browser surface.
-
-Codex CLI's native `web_search` tool returns cached or indexed search results but cannot read pages or run authenticated sessions. Point Codex at Webcmd's browser CLI instead: adapters return exact, stable fields, and `webcmd browser` sessions render real pages with logged-in profiles. Codex runs `webcmd` through its shell tool.
+> Fetch and follow [https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end.
 
 ## Manual
 

--- a/docs/agents/cursor.md
+++ b/docs/agents/cursor.md
@@ -5,15 +5,7 @@ sidebarTitle: Cursor
 
 ## Agent prompt
 
-Use this prompt with a coding agent to set up Webcmd end to end:
-
-```text
-Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
-```
-
-> Use Webcmd with [Cursor](https://cursor.com) to replace its built-in Browser and Web tools with Webcmd's adapters and `webcmd browser` sessions.
-
-Point Cursor's agent at Webcmd's browser CLI to replace its native Browser (navigate/click/screenshot) and Web (search/fetch) tools with Webcmd's adapters and `webcmd browser` sessions. Cursor's agent drives Webcmd through its shell tool. Adapter-first commands and compact snapshots usually use fewer tokens than Cursor's native web tools.
+> Fetch and follow [https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end.
 
 ## Manual
 

--- a/docs/agents/cursor.md
+++ b/docs/agents/cursor.md
@@ -5,7 +5,9 @@ sidebarTitle: Cursor
 
 > **Agent prompt**
 >
-> Fetch and follow [start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end, then read this page's Manual — especially [Override default tools](#override-default-tools) — before doing browser work.
+> ```text
+> Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+> ```
 
 > Use Webcmd with [Cursor](https://cursor.com) to replace its built-in Browser and Web tools with Webcmd's adapters and `webcmd browser` sessions.
 

--- a/docs/agents/cursor.md
+++ b/docs/agents/cursor.md
@@ -5,7 +5,9 @@ sidebarTitle: Cursor
 
 ## Agent prompt
 
-> Fetch and follow [https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end.
+```text
+Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+```
 
 ## Manual
 

--- a/docs/agents/cursor.md
+++ b/docs/agents/cursor.md
@@ -3,11 +3,13 @@ title: Cursor Agent
 sidebarTitle: Cursor
 ---
 
-> **Agent prompt**
->
-> ```text
-> Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
-> ```
+## Agent prompt
+
+Use this prompt with a coding agent to set up Webcmd end to end:
+
+```text
+Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+```
 
 > Use Webcmd with [Cursor](https://cursor.com) to replace its built-in Browser and Web tools with Webcmd's adapters and `webcmd browser` sessions.
 

--- a/docs/agents/hermes.md
+++ b/docs/agents/hermes.md
@@ -5,7 +5,9 @@ sidebarTitle: Hermes
 
 > **Agent prompt**
 >
-> Fetch and follow [start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end, then read this page's Manual — especially [Override default tools](#override-default-tools) — before doing browser work.
+> ```text
+> Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+> ```
 
 > Use Webcmd with [Hermes Agent](https://hermes-agent.nousresearch.com/docs) to replace its built-in `browser_*` stack with Webcmd's adapters and `webcmd browser` sessions.
 

--- a/docs/agents/hermes.md
+++ b/docs/agents/hermes.md
@@ -5,15 +5,7 @@ sidebarTitle: Hermes
 
 ## Agent prompt
 
-Use this prompt with a coding agent to set up Webcmd end to end:
-
-```text
-Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
-```
-
-> Use Webcmd with [Hermes Agent](https://hermes-agent.nousresearch.com/docs) to replace its built-in `browser_*` stack with Webcmd's adapters and `webcmd browser` sessions.
-
-Point Hermes at Webcmd's browser CLI to replace its native browser toolset with Webcmd's adapters and `webcmd browser` sessions. Hermes drives Webcmd through its `terminal` toolset. Adapter-first commands and compact snapshots usually use fewer tokens than Hermes' native browser tools.
+> Fetch and follow [https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end.
 
 ## Manual
 

--- a/docs/agents/hermes.md
+++ b/docs/agents/hermes.md
@@ -3,11 +3,13 @@ title: Hermes Agent
 sidebarTitle: Hermes
 ---
 
-> **Agent prompt**
->
-> ```text
-> Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
-> ```
+## Agent prompt
+
+Use this prompt with a coding agent to set up Webcmd end to end:
+
+```text
+Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+```
 
 > Use Webcmd with [Hermes Agent](https://hermes-agent.nousresearch.com/docs) to replace its built-in `browser_*` stack with Webcmd's adapters and `webcmd browser` sessions.
 

--- a/docs/agents/hermes.md
+++ b/docs/agents/hermes.md
@@ -5,7 +5,9 @@ sidebarTitle: Hermes
 
 ## Agent prompt
 
-> Fetch and follow [https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end.
+```text
+Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+```
 
 ## Manual
 

--- a/docs/agents/openclaw.md
+++ b/docs/agents/openclaw.md
@@ -5,7 +5,9 @@ sidebarTitle: OpenClaw
 
 ## Agent prompt
 
-> Fetch and follow [https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end.
+```text
+Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+```
 
 ## Manual
 

--- a/docs/agents/openclaw.md
+++ b/docs/agents/openclaw.md
@@ -5,7 +5,9 @@ sidebarTitle: OpenClaw
 
 > **Agent prompt**
 >
-> Fetch and follow [start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end, then read this page's Manual — especially [Override default tools](#override-default-tools) — before doing browser work.
+> ```text
+> Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+> ```
 
 > Use Webcmd with [OpenClaw](https://openclaw.ai) to replace its built-in `web_search`, `web_fetch`, and `browser` tools with the Webcmd browser surface.
 

--- a/docs/agents/openclaw.md
+++ b/docs/agents/openclaw.md
@@ -3,11 +3,13 @@ title: OpenClaw Agent
 sidebarTitle: OpenClaw
 ---
 
-> **Agent prompt**
->
-> ```text
-> Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
-> ```
+## Agent prompt
+
+Use this prompt with a coding agent to set up Webcmd end to end:
+
+```text
+Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+```
 
 > Use Webcmd with [OpenClaw](https://openclaw.ai) to replace its built-in `web_search`, `web_fetch`, and `browser` tools with the Webcmd browser surface.
 

--- a/docs/agents/openclaw.md
+++ b/docs/agents/openclaw.md
@@ -5,15 +5,7 @@ sidebarTitle: OpenClaw
 
 ## Agent prompt
 
-Use this prompt with a coding agent to set up Webcmd end to end:
-
-```text
-Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
-```
-
-> Use Webcmd with [OpenClaw](https://openclaw.ai) to replace its built-in `web_search`, `web_fetch`, and `browser` tools with the Webcmd browser surface.
-
-OpenClaw ships core web tools (`web_search`, `web_fetch`, `browser`, `browser_visual`, `search_news`) plus a Playwright-based browser. Point OpenClaw at Webcmd's browser CLI instead: adapters return exact, stable fields, and `webcmd browser` sessions keep logged-in profiles. OpenClaw runs `webcmd` through its `exec` tool.
+> Fetch and follow [https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end.
 
 ## Manual
 

--- a/docs/agents/opencode.md
+++ b/docs/agents/opencode.md
@@ -5,7 +5,9 @@ sidebarTitle: OpenCode
 
 ## Agent prompt
 
-> Fetch and follow [https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end.
+```text
+Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+```
 
 ## Manual
 

--- a/docs/agents/opencode.md
+++ b/docs/agents/opencode.md
@@ -3,11 +3,13 @@ title: OpenCode Agent
 sidebarTitle: OpenCode
 ---
 
-> **Agent prompt**
->
-> ```text
-> Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
-> ```
+## Agent prompt
+
+Use this prompt with a coding agent to set up Webcmd end to end:
+
+```text
+Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+```
 
 > Use Webcmd with OpenCode to replace its built-in `webfetch` / `websearch` tools with the Webcmd browser surface.
 

--- a/docs/agents/opencode.md
+++ b/docs/agents/opencode.md
@@ -5,15 +5,7 @@ sidebarTitle: OpenCode
 
 ## Agent prompt
 
-Use this prompt with a coding agent to set up Webcmd end to end:
-
-```text
-Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
-```
-
-> Use Webcmd with OpenCode to replace its built-in `webfetch` / `websearch` tools with the Webcmd browser surface.
-
-Point OpenCode at Webcmd's browser CLI to replace its native browser tools with Webcmd's adapters and `webcmd browser` sessions. Adapter-first commands and compact snapshots usually use fewer tokens than OpenCode's native web tools, and logged-in profiles handle authenticated pages.
+> Fetch and follow [https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end.
 
 ## Manual
 

--- a/docs/agents/opencode.md
+++ b/docs/agents/opencode.md
@@ -5,7 +5,9 @@ sidebarTitle: OpenCode
 
 > **Agent prompt**
 >
-> Fetch and follow [start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end, then read this page's Manual — especially [Override default tools](#override-default-tools) — before doing browser work.
+> ```text
+> Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+> ```
 
 > Use Webcmd with OpenCode to replace its built-in `webfetch` / `websearch` tools with the Webcmd browser surface.
 

--- a/docs/agents/pi.md
+++ b/docs/agents/pi.md
@@ -5,7 +5,9 @@ sidebarTitle: Pi
 
 ## Agent prompt
 
-> Fetch and follow [https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end.
+```text
+Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+```
 
 ## Manual
 

--- a/docs/agents/pi.md
+++ b/docs/agents/pi.md
@@ -5,7 +5,9 @@ sidebarTitle: Pi
 
 > **Agent prompt**
 >
-> Fetch and follow [start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end, then read this page's Manual — especially [Override default tools](#override-default-tools) — before doing browser work.
+> ```text
+> Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+> ```
 
 > Use Webcmd with [Pi](https://pi.dev) to give it a browser surface. Pi ships no built-in web, search, or browser tools, so Webcmd is driven through Pi's default `bash` tool with no permission or config changes.
 

--- a/docs/agents/pi.md
+++ b/docs/agents/pi.md
@@ -5,15 +5,7 @@ sidebarTitle: Pi
 
 ## Agent prompt
 
-Use this prompt with a coding agent to set up Webcmd end to end:
-
-```text
-Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
-```
-
-> Use Webcmd with [Pi](https://pi.dev) to give it a browser surface. Pi ships no built-in web, search, or browser tools, so Webcmd is driven through Pi's default `bash` tool with no permission or config changes.
-
-Pi is a minimal terminal coding harness whose default tools are filesystem and shell only (`read`, `bash`, `edit`, `write`, with `grep`, `find`, and `ls` available). Its agent drives Webcmd through the `bash` tool. Adapter-first commands and compact snapshots usually use fewer tokens than the official `brave-search` and `browser-tools` skills, and logged-in profiles handle authenticated pages.
+> Fetch and follow [https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md](https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md) to set up Webcmd end to end.
 
 ## Manual
 

--- a/docs/agents/pi.md
+++ b/docs/agents/pi.md
@@ -3,11 +3,13 @@ title: Pi Agent
 sidebarTitle: Pi
 ---
 
-> **Agent prompt**
->
-> ```text
-> Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
-> ```
+## Agent prompt
+
+Use this prompt with a coding agent to set up Webcmd end to end:
+
+```text
+Fetch and follow https://raw.githubusercontent.com/agentrhq/webcmd/main/start.md to set up Webcmd end to end.
+```
 
 > Use Webcmd with [Pi](https://pi.dev) to give it a browser surface. Pi ships no built-in web, search, or browser tools, so Webcmd is driven through Pi's default `bash` tool with no permission or config changes.
 


### PR DESCRIPTION
Consolidates the agent prompt into a consistent, copyable format across all agent docs and the README quick start:

- Standardizes the agent prompt (heading + copyable text block + quickstart reference) across Claude Code, Codex CLI, Cursor, Hermes, OpenClaw, OpenCode, and Pi pages.
- Adds the agent prompt as the sole Quick Start subsection in the README, with a Manual pointer to the quickstart docs.
- Enforces LF line endings via .gitattributes.