### PR TITLE
feat: add Claude Code plugin marketplace manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-marketplace.json",
+  "name": "webcmd",
+  "description": "Turn websites, browser sessions, desktop apps, and local tools into deterministic CLI surfaces for humans and AI agents.",
+  "owner": {
+    "name": "AgentRHQ",
+    "url": "https://github.com/agentrhq"
+  },
+  "plugins": [
+    {
+      "name": "webcmd",
+      "description": "Webcmd CLI, browser, search, authoring, sitemap, and repair skills. Requires the @agentrhq/webcmd npm CLI.",
+      "source": "./",
+      "category": "productivity"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "webcmd",
+  "version": "0.6.0",
+  "description": "Turn websites, browser sessions, desktop apps, and local tools into deterministic CLI surfaces for humans and AI agents.",
+  "author": {
+    "name": "AgentRHQ",
+    "url": "https://github.com/agentrhq"
+  },
+  "homepage": "https://webcmd.dev/docs",
+  "repository": "https://github.com/agentrhq/webcmd",
+  "license": "Apache-2.0",
+  "keywords": [
+    "webcmd",
+    "browser-automation",
+    "cli",
+    "agent-skills"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ the npm CLI automatically if `webcmd` is missing.
 The plugin includes all seven bundled Webcmd skills. Do not also add those
 skills with `webcmd skills add` in Codex.
 
+### Claude Code
+
+```bash
+claude plugin marketplace add agentrhq/webcmd
+claude plugin install webcmd@webcmd
+```
+
+This installs all seven bundled Webcmd skills. Do not also add those skills
+with `webcmd skills add` in Claude Code.
+
 ### Other agents or plugin-free setup
 
 Webcmd requires Node.js 20.6+.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -15,6 +15,16 @@ the npm CLI automatically if `webcmd` is missing.
 The plugin includes all seven bundled Webcmd skills. Do not also add those
 skills with `webcmd skills add` in Codex.
 
+## Install the Claude Code Plugin
+
+```bash
+claude plugin marketplace add agentrhq/webcmd
+claude plugin install webcmd@webcmd
+```
+
+This installs all seven bundled Webcmd skills. Do not also add those skills
+with `webcmd skills add` in Claude Code.
+
 ## Other Agents or Plugin-Free Setup
 
 Webcmd requires Node.js 20.6+ and a place where your agent harness can run its

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,6 +12,11 @@
           "type": "json",
           "path": ".codex-plugin/plugin.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
         }
       ]
     }

--- a/scripts/check-codex-plugin.mjs
+++ b/scripts/check-codex-plugin.mjs
@@ -13,6 +13,9 @@ const packageJson = readJson('package.json');
 const manifest = readJson('.codex-plugin/plugin.json');
 const marketplace = readJson('.agents/plugins/marketplace.json');
 const marketplacePlugin = marketplace.plugins?.[0];
+const claudeManifest = readJson('.claude-plugin/plugin.json');
+const claudeMarketplace = readJson('.claude-plugin/marketplace.json');
+const claudeMarketplacePlugin = claudeMarketplace.plugins?.[0];
 
 assert.equal(manifest.name, 'webcmd');
 assert.equal(manifest.version, packageJson.version);
@@ -26,6 +29,15 @@ assert.deepEqual(marketplacePlugin?.source, {
   source: 'url',
   url: './',
 });
+
+assert.equal(claudeManifest.name, 'webcmd');
+assert.equal(claudeManifest.version, packageJson.version);
+assert.equal(claudeManifest.author?.name, 'AgentRHQ');
+assert.equal(claudeMarketplace.name, 'webcmd');
+assert.equal(claudeMarketplace.owner?.name, 'AgentRHQ');
+assert.equal(claudeMarketplace.plugins?.length, 1);
+assert.equal(claudeMarketplacePlugin?.name, 'webcmd');
+assert.equal(claudeMarketplacePlugin?.source, './');
 
 const expectedSkills = [
   'smart-search',
@@ -54,4 +66,6 @@ assert.match(usageSkill, /## CLI Preflight/);
 assert.match(usageSkill, /webcmd --version/);
 assert.match(usageSkill, /npm install -g @agentrhq\/webcmd/);
 
-console.log(`Codex plugin metadata valid: ${actualSkills.length} skills`);
+console.log(
+  `Codex and Claude Code plugin metadata valid: ${actualSkills.length} skills`,
+);


### PR DESCRIPTION
## Problem

`claude plugin marketplace add agentrhq/webcmd` fails today. Claude Code looks for `.claude-plugin/marketplace.json` at the repo root; we only ship the Codex manifests (`.codex-plugin/plugin.json` + `.agents/plugins/marketplace.json`). Claude Code users had to fall back to `npm i -g @agentrhq/webcmd && webcmd skills add`.

## Change

- `.claude-plugin/marketplace.json` — marketplace with a single `webcmd` plugin sourced from `./`
- `.claude-plugin/plugin.json` — plugin manifest; skills auto-discover from the repo-root `skills/`
- `release-please-config.json` — bump `.claude-plugin/plugin.json` `$.version` alongside the Codex one, so the version can't drift
- `scripts/check-codex-plugin.mjs` — assert the Claude manifests match `package.json` and each other
- README + quickstart — Claude Code install section

## Verification

`npm run check:codex-plugin` passes. Installed end to end against a local checkout:

```
claude plugin marketplace add <repo>   -> Successfully added marketplace: webcmd
claude plugin install webcmd@webcmd    -> Successfully installed plugin: webcmd@webcmd
```

All seven skills resolved in the plugin cache (`smart-search`, `webcmd-adapter-author`, `webcmd-autofix`, `webcmd-browser`, `webcmd-browser-sitemap`, `webcmd-sitemap-author`, `webcmd-usage`). The verification install was uninstalled afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)