### PR TITLE
fix(browser): serialize undefined run results as null

### DIFF
--- a/src/browser/run/runner.test.ts
+++ b/src/browser/run/runner.test.ts
@@ -405,6 +405,14 @@ describe('runBrowserProgram', () => {
     expect(output.result).toBe('undefined');
   });
 
+  it('serializes a program with no explicit return as null', async () => {
+    const output = await run(`
+      await page.getByRole('button', { name: 'Save' }).click();
+    `);
+
+    expect(output.result).toBeNull();
+  });
+
   it('keeps time, memory, output, redaction, and serialization limits', async () => {
     await expect(run('while (true) {}', { timeoutMs: 25 })).rejects.toMatchObject({
       code: 'BROWSER_RUN_TIMEOUT',

--- a/src/browser/run/runner.ts
+++ b/src/browser/run/runner.ts
@@ -446,7 +446,7 @@ export async function runBrowserProgram(
             rejectRun = undefined;
           }
           try {
-            const serialized = JSON.stringify(value);
+            const serialized = JSON.stringify(value === undefined ? null : value);
             if (serialized === undefined) throw new TypeError('Result is not JSON serializable.');
             return serialized;
           } catch (cause) {


### PR DESCRIPTION
## Description

<!-- Briefly describe your changes and link to any related issues. -->

Related issue:

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [ ] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

### Adapter Notes

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

<!-- If applicable, paste CLI output or screenshots here. -->
