### PR TITLE
fix: format CliError/ArgumentError instead of leaking a raw stack trace in web fetch

### DIFF
--- a/src/fetch/command.test.ts
+++ b/src/fetch/command.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { formatWebFetchMarkdown, runClientOwnedWebFetch } from './command.js';
+import { CliError } from '../errors.js';
 
 describe('web fetch command', () => {
   it('renders fetch metadata before content', () => {
@@ -9,5 +10,26 @@ describe('web fetch command', () => {
     const webFetch = vi.fn().mockResolvedValue({ status: 200, requestedUrl: 'https://a', finalUrl: 'https://a', contentType: 'text/plain', tier: 'plain', title: '', extractionSource: 'raw', truncated: false, content: 'ok' });
     await runClientOwnedWebFetch(['web', 'fetch', '--url', 'https://a'], { webFetch, stdout: { write: vi.fn() } as never });
     expect(webFetch).toHaveBeenCalledOnce();
+  });
+  it('formats a thrown CliError instead of letting it escape as a raw stack trace', async () => {
+    const webFetch = vi.fn().mockRejectedValue(new CliError('FETCH_BLOCKED', 'The site blocked non-browser fetches.', 'Use webcmd web fetch-browser for this URL.', 1));
+    const write = vi.fn();
+    const priorExitCode = process.exitCode;
+    await runClientOwnedWebFetch(['web', 'fetch', '--url', 'https://a'], { webFetch, stderr: { write } as never });
+    const output = write.mock.calls.map((call) => String(call[0])).join('');
+    expect(output).toContain('FETCH_BLOCKED');
+    expect(output).toContain('Use webcmd web fetch-browser for this URL.');
+    expect(process.exitCode).toBe(1);
+    process.exitCode = priorExitCode;
+  });
+  it('formats an ArgumentError from bad flags instead of letting it escape as a raw stack trace', async () => {
+    const write = vi.fn();
+    const priorExitCode = process.exitCode;
+    await runClientOwnedWebFetch(['web', 'fetch', '--url', 'not-a-url'], { stderr: { write } as never });
+    const output = write.mock.calls.map((call) => String(call[0])).join('');
+    expect(output).toContain('ARGUMENT');
+    expect(output).toContain('--url must be an http or https URL');
+    expect(process.exitCode).toBe(2);
+    process.exitCode = priorExitCode;
   });
 });

--- a/src/fetch/command.ts
+++ b/src/fetch/command.ts
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '../registry.js';
-import { ArgumentError } from '../errors.js';
+import { ArgumentError, CliError, EXIT_CODES, toEnvelope } from '../errors.js';
 import { webFetch, type WebFetchOptions, type WebFetchResult } from './client.js';
 
 export const webFetchCommand = cli({
@@ -31,7 +31,13 @@ function clientOptions(argv: readonly string[]): WebFetchOptions {
   return { url: values.url, timeoutSeconds: int('timeout', 30), maxChars: int('max-chars', 50000), allowPrivate: values['allow-private'] === true || values['allow-private'] === 'true' };
 }
 
-export async function runClientOwnedWebFetch(argv: readonly string[], dependencies: { webFetch?: typeof webFetch; stdout?: NodeJS.WritableStream } = {}): Promise<void> {
-  const result = await (dependencies.webFetch ?? webFetch)(clientOptions(argv));
-  (dependencies.stdout ?? process.stdout).write(`${formatWebFetchMarkdown(result)}\n`);
+export async function runClientOwnedWebFetch(argv: readonly string[], dependencies: { webFetch?: typeof webFetch; stdout?: NodeJS.WritableStream; stderr?: NodeJS.WritableStream } = {}): Promise<void> {
+  try {
+    const result = await (dependencies.webFetch ?? webFetch)(clientOptions(argv));
+    (dependencies.stdout ?? process.stdout).write(`${formatWebFetchMarkdown(result)}\n`);
+  } catch (err) {
+    const { formatErrorEnvelope } = await import('../output.js');
+    (dependencies.stderr ?? process.stderr).write(formatErrorEnvelope(toEnvelope(err), { cmdName: 'web/fetch' }));
+    process.exitCode = err instanceof CliError ? err.exitCode : EXIT_CODES.GENERIC_ERROR;
+  }
 }


### PR DESCRIPTION
## Description

`webcmd web fetch` is dispatched on the client-owned fast path in `src/main.ts` (`argv[0] === 'web' && argv[1] === 'fetch'`), before adapter discovery and before the hosted-mode branch, which calls `runClientOwnedWebFetch` directly. That function (`src/fetch/command.ts`) had no try/catch, and the call site is outside the `CliError` handling every other command routes through in `commanderAdapter.ts`. Any thrown `CliError` (e.g. `FETCH_BLOCKED`) or `ArgumentError` from `clientOptions()` therefore escaped straight to Node's default uncaught-exception handler as a raw stack trace, instead of the structured error output the rest of the CLI produces.

### Before

```
$ webcmd web fetch --url https://news.ycombinator.com
file:///…/dist/src/fetch/client.js:67
                throw new CliError('FETCH_BLOCKED', 'The site blocked non-browser fetches.', …);
                      ^
CliError: The site blocked non-browser fetches.
    at webFetch (file:///…/dist/src/fetch/client.js:67:23)
    at async runClientOwnedWebFetch (file:///…/dist/src/fetch/command.js:40:20)
    at async file:///…/dist/src/main.js:74:9 {
  code: 'FETCH_BLOCKED',
  hint: 'Use webcmd web fetch-browser for this URL.',
  exitCode: 1
}
```

### After

```
$ webcmd web fetch --url https://news.ycombinator.com
ok: false
error:
  code: FETCH_BLOCKED
  message: The site blocked non-browser fetches.
  help: Use webcmd web fetch-browser for this URL.
  exitCode: 1
```

Same shape as any other command's error — verified by reproducing a real command's `CliError` through the normal `commanderAdapter.ts` path and comparing the envelope byte-for-byte with what this fix now produces on the fast path.

### Fix

Wrapped the body of `runClientOwnedWebFetch` in a try/catch. On error, it now builds the same `ErrorEnvelope` (`toEnvelope`) and renders it with the same `formatErrorEnvelope` used by `commanderAdapter.ts`, writes to stderr, and sets `process.exitCode` from `err.exitCode` when it's a `CliError` (falling back to `EXIT_CODES.GENERIC_ERROR` otherwise) — matching `resolveExitCode`'s behavior. `output.js` is imported dynamically inside the catch block so the happy path (the common case) doesn't pay for `cli-table3`/`js-yaml` on this fast path.

This covers both cases called out in the issue: a `CliError` thrown from deep inside `webFetch()` (e.g. `FETCH_BLOCKED`), and an `ArgumentError` thrown synchronously by `clientOptions()` for bad flags.

Fixes #246

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

`npm run typecheck` and `npm run build` pass, generated artifacts stay byte-identical (`git diff --exit-code` clean after build).

Added two regression tests to `src/fetch/command.test.ts` (mocked `webFetch`/`clientOptions`, no real network calls) covering the `CliError` and `ArgumentError` paths:

```
$ npx vitest run --project unit src/fetch/command.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Full `src/fetch/` suite also passes (22/22).
