### PR TITLE
Improve Codex plugin example prompts

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -29,10 +29,9 @@
     ],
     "websiteURL": "https://webcmd.dev/",
     "defaultPrompt": [
-      "Find and rank today’s most-discussed AI agent launches across Hacker News, Reddit, Product Hunt, and arXiv.",
       "Create a Zillow rental-search plugin for WebCMD with city, max rent, and bedroom filters. Test it and show me the command.",
       "Compare MacBook Air M5 prices and availability on Amazon, Walmart, and Best Buy.",
-      ""
+      "Find and rank today’s most-discussed AI agent launches across Hacker News, Reddit, Product Hunt, and arXiv."
     ],
     "brandColor": "#56C5FF",
     "composerIcon": "./docs/webcmd.svg",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -29,9 +29,9 @@
     ],
     "websiteURL": "https://webcmd.dev/",
     "defaultPrompt": [
-      "Use Webcmd to complete this task with an existing command.",
-      "Use Webcmd to research this topic and return source links.",
-      "Use Webcmd to turn this browser workflow into a reusable CLI."
+      "Create a Zillow rental-search plugin for WebCMD with city, max rent, and bedroom filters. Test it and show me the command.",
+      "Compare MacBook Air M5 prices and availability on Amazon, Walmart, and Best Buy.",
+      "Find and rank today’s most-discussed AI agent launches across Hacker News, Reddit, Product Hunt, and arXiv."
     ],
     "brandColor": "#56C5FF",
     "composerIcon": "./docs/webcmd.svg",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -29,9 +29,10 @@
     ],
     "websiteURL": "https://webcmd.dev/",
     "defaultPrompt": [
+      "Find and rank today’s most-discussed AI agent launches across Hacker News, Reddit, Product Hunt, and arXiv.",
       "Create a Zillow rental-search plugin for WebCMD with city, max rent, and bedroom filters. Test it and show me the command.",
       "Compare MacBook Air M5 prices and availability on Amazon, Walmart, and Best Buy.",
-      "Find and rank today’s most-discussed AI agent launches across Hacker News, Reddit, Product Hunt, and arXiv."
+      ""
     ],
     "brandColor": "#56C5FF",
     "composerIcon": "./docs/webcmd.svg",

--- a/scripts/check-codex-plugin.mjs
+++ b/scripts/check-codex-plugin.mjs
@@ -22,6 +22,13 @@ assert.equal(manifest.version, packageJson.version);
 assert.equal(manifest.skills, './skills/');
 assert.equal(manifest.author?.name, 'AgentRHQ');
 assert.equal(manifest.interface?.developerName, 'AgentRHQ');
+const expectedDefaultPrompts = [
+  'Create a Zillow rental-search plugin for WebCMD with city, max rent, and bedroom filters. Test it and show me the command.',
+  'Compare MacBook Air M5 prices and availability on Amazon, Walmart, and Best Buy.',
+  'Find and rank today\u2019s most-discussed AI agent launches across Hacker News, Reddit, Product Hunt, and arXiv.',
+];
+assert.deepEqual(manifest.interface?.defaultPrompt, expectedDefaultPrompts);
+assert.ok(expectedDefaultPrompts.every((prompt) => prompt.length <= 128));
 assert.equal(marketplace.name, 'webcmd');
 assert.equal(marketplace.plugins?.length, 1);
 assert.equal(marketplacePlugin?.name, 'webcmd');


### PR DESCRIPTION
## Description

Replace the generic Codex plugin prompts with three concrete examples for Zillow plugin creation, MacBook price comparison, and AI-agent launch research. Add a manifest check that locks the examples and enforces the 128-character limit.

Related issue: N/A

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [x] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

### Adapter Notes

Not applicable.

## Screenshots / Output

- `npm test`: 394 files passed; 4,781 tests passed; 1 skipped
- `npm run check:codex-plugin`: passed
- Plugin validator: passed
- Prompt lengths: 122, 80, and 107 characters