### PR TITLE
fix(browser): repair doctor session and first cloak window

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text eol=lf
+*.png binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 * text eol=lf
-*.png binary

--- a/src/browser/protocol.ts
+++ b/src/browser/protocol.ts
@@ -67,6 +67,8 @@ export interface BrowserRuntimeCommand {
   deadlineAt?: number;
   /** Force Session lifecycle actions such as close past active work/handoff guards. */
   force?: boolean;
+  /** Remove an explicit Session record after closing it. Internal probes only. */
+  discard?: boolean;
   /** Maximum Session rows returned by session-list. */
   limit?: number;
   cdpMethod?: string;

--- a/src/browser/runtime/local-cloak/provider.test.ts
+++ b/src/browser/runtime/local-cloak/provider.test.ts
@@ -187,6 +187,33 @@ describe('LocalCloakRuntimeProvider', () => {
     }
   });
 
+  it('does not discard a Session record unless close is forced', async () => {
+    const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-provider-session-'));
+    try {
+      const provider = new LocalCloakRuntimeProvider({ baseDir });
+      const session = await provider.createSession({
+        id: 'create-user-session',
+        action: 'session-create',
+        contextId: 'default',
+      });
+
+      await provider.closeSession({
+        id: 'close-user-session',
+        action: 'session-close',
+        contextId: 'default',
+        session: session.id,
+        surface: 'browser',
+        discard: true,
+      });
+
+      await expect(provider.listSessions({ profileId: 'default' })).resolves.toMatchObject([
+        { id: session.id, kind: 'explicit' },
+      ]);
+    } finally {
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+
   it('navigates and returns page identity', async () => {
     const { provider, page } = makeProviderWithFakePage();
     const result = await provider.dispatch({

--- a/src/browser/runtime/local-cloak/provider.test.ts
+++ b/src/browser/runtime/local-cloak/provider.test.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { LocalCloakRuntimeProvider } from './provider.js';
 import { BrowserRunError } from '../../run/types.js';
@@ -156,6 +159,32 @@ describe('LocalCloakRuntimeProvider', () => {
       profiles: [],
       pending: 0,
     });
+  });
+
+  it('discards a temporary Session record after closing it', async () => {
+    const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-provider-session-'));
+    try {
+      const provider = new LocalCloakRuntimeProvider({ baseDir });
+      const session = await provider.createSession({
+        id: 'create-doctor-session',
+        action: 'session-create',
+        contextId: 'default',
+      });
+
+      await provider.closeSession({
+        id: 'close-doctor-session',
+        action: 'session-close',
+        contextId: 'default',
+        session: session.id,
+        surface: 'browser',
+        force: true,
+        discard: true,
+      });
+
+      await expect(provider.listSessions({ profileId: 'default' })).resolves.toEqual([]);
+    } finally {
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    }
   });
 
   it('navigates and returns page identity', async () => {

--- a/src/browser/runtime/local-cloak/provider.ts
+++ b/src/browser/runtime/local-cloak/provider.ts
@@ -85,7 +85,7 @@ export class LocalCloakRuntimeProvider implements BrowserRuntimeProvider {
   async closeSession(command: BrowserRuntimeCommand): Promise<{ closed: boolean; alreadyIdle: boolean; session: string }> {
     const record = this.sessions.require(this.resolveProfileId(command), command.session);
     const closedCount = await this.manager.closeSession(record.profileId, record.id);
-    if (command.discard === true && record.kind === 'explicit' && !record.handoff) this.sessions.remove(record.profileId, record.id);
+    if (command.force && command.discard === true && record.kind === 'explicit' && !record.handoff) this.sessions.remove(record.profileId, record.id);
     else if (command.force && record.handoff) this.sessions.clearHandoff(record.profileId, record.id);
     else this.sessions.touch(record.profileId, record.id);
     return { closed: closedCount > 0, alreadyIdle: closedCount === 0, session: record.id };

--- a/src/browser/runtime/local-cloak/provider.ts
+++ b/src/browser/runtime/local-cloak/provider.ts
@@ -85,7 +85,8 @@ export class LocalCloakRuntimeProvider implements BrowserRuntimeProvider {
   async closeSession(command: BrowserRuntimeCommand): Promise<{ closed: boolean; alreadyIdle: boolean; session: string }> {
     const record = this.sessions.require(this.resolveProfileId(command), command.session);
     const closedCount = await this.manager.closeSession(record.profileId, record.id);
-    if (command.force && record.handoff) this.sessions.clearHandoff(record.profileId, record.id);
+    if (command.discard === true && record.kind === 'explicit' && !record.handoff) this.sessions.remove(record.profileId, record.id);
+    else if (command.force && record.handoff) this.sessions.clearHandoff(record.profileId, record.id);
     else this.sessions.touch(record.profileId, record.id);
     return { closed: closedCount > 0, alreadyIdle: closedCount === 0, session: record.id };
   }

--- a/src/browser/runtime/local-cloak/session-manager.test.ts
+++ b/src/browser/runtime/local-cloak/session-manager.test.ts
@@ -207,6 +207,24 @@ describe('CloakSessionManager', () => {
       .map(tab => tab.sessionId)).toEqual(['session_a']);
   });
 
+  it('reuses the fresh launch about:blank page for the first Session window', async () => {
+    const launched = fakeContext();
+    await launched.page.goto('about:blank');
+    const manager = new CloakSessionManager({
+      baseDir: '/tmp/webcmd-test',
+      platform: 'darwin',
+      launchPersistentContext: vi.fn().mockResolvedValue(launched.context),
+    });
+
+    const lease = await manager.getPage({ profileId: 'default', session: 'session_a', sessionId: 'session_a', surface: 'browser' });
+
+    expect(lease.page).toBe(launched.page);
+    expect(launched.cdp.send.mock.calls.filter(([method, params]) => method === 'Target.createTarget' && !(params as { hidden?: boolean })?.hidden))
+      .toHaveLength(0);
+    expect((await manager.listPages({ profileId: 'default', session: 'session_a', sessionId: 'session_a' }))
+      .map(tab => tab.sessionId)).toEqual(['session_a']);
+  });
+
   it('matches Target.createTarget by target id instead of adopting the next context page', async () => {
     const launched = fakeContext();
     const unrelated = launched.makePage();

--- a/src/browser/runtime/local-cloak/session-manager.ts
+++ b/src/browser/runtime/local-cloak/session-manager.ts
@@ -943,7 +943,7 @@ export class CloakSessionManager {
     windowMode?: BrowserWindowMode,
   ): Promise<PlaywrightPage> {
     const openerEntry = this.openEntries(session)[0]?.[1];
-    if (!openerEntry) return this.createWindowPage(runtime, windowMode);
+    if (!openerEntry) return await this.findReusableLaunchPage(runtime, session.id) ?? this.createWindowPage(runtime, windowMode);
     await this.assertOwnedWindow(runtime, session.id, openerEntry);
     const opener = openerEntry.page;
     const openerWindowId = await this.windowIdForTarget(runtime, openerEntry.targetId, opener);
@@ -958,6 +958,19 @@ export class CloakSessionManager {
     const page = await openedPage;
     if (page) return page;
     return this.createWindowPage(runtime, windowMode);
+  }
+
+  private async findReusableLaunchPage(runtime: ProfileRuntime, sessionId: string): Promise<PlaywrightPage | undefined> {
+    for (const page of runtime.context.pages()) {
+      if (pageIsClosed(page) || page === runtime.parkingPage || page.url() !== 'about:blank') continue;
+      const targetId = await this.targetIdForPage(runtime, page).catch(() => undefined);
+      if (!targetId || targetId === runtime.anchorTargetId || runtime.targetPages.has(targetId)) continue;
+      const windowId = await this.windowIdForTarget(runtime, targetId, page).catch(() => undefined);
+      if (windowId === undefined) continue;
+      const owner = runtime.windowOwners.get(windowId);
+      if (owner === undefined || owner === sessionId) return page;
+    }
+    return undefined;
   }
 
   private async waitForContextPageForSession(

--- a/src/browser/sessions.ts
+++ b/src/browser/sessions.ts
@@ -136,6 +136,14 @@ export class LocalBrowserSessionStore {
     return { ...record };
   }
 
+  remove(profileId: string, sessionId: string): BrowserSessionRecord {
+    const state = this.load();
+    const record = this.requireMutable(state, profileId, sessionId);
+    state.sessions = state.sessions.filter((row) => row !== record);
+    this.save(state);
+    return { ...record };
+  }
+
   private newRecord(
     profileId: string,
     kind: BrowserSessionRecord['kind'],

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -5,12 +5,14 @@ const {
   mockConnect,
   mockClose,
   mockFindShadowedUserAdapters,
+  mockSendCommand,
   mockSetDaemonCommandTimeoutSeconds,
 } = vi.hoisted(() => ({
   mockGetDaemonHealth: vi.fn(),
   mockConnect: vi.fn(),
   mockClose: vi.fn(),
   mockFindShadowedUserAdapters: vi.fn(),
+  mockSendCommand: vi.fn(),
   mockSetDaemonCommandTimeoutSeconds: vi.fn(),
 }));
 
@@ -26,6 +28,7 @@ vi.mock('./browser/index.js', () => ({
 }));
 
 vi.mock('./browser/daemon-client.js', () => ({
+  sendCommand: mockSendCommand,
   setDaemonCommandTimeoutSeconds: mockSetDaemonCommandTimeoutSeconds,
 }));
 
@@ -52,6 +55,11 @@ describe('doctor report rendering', () => {
       closeWindow: vi.fn().mockResolvedValue(undefined),
     });
     mockClose.mockResolvedValue(undefined);
+    mockSendCommand.mockImplementation(async (action: string) => {
+      if (action === 'session-create') return { id: 'session_doctor_11111111' };
+      if (action === 'session-close') return { closed: true };
+      throw new Error(`Unexpected doctor command: ${action}`);
+    });
   });
 
   it('renders OK-style report when daemon and runtime connected', () => {
@@ -268,12 +276,12 @@ describe('doctor report rendering', () => {
     ]));
   });
 
-  it('uses the fast default timeout for live connectivity checks', async () => {
+  it('uses a temporary opaque Session for live connectivity checks', async () => {
     let timeoutSeen: number | undefined;
     const closeWindow = vi.fn().mockResolvedValue(undefined);
     mockConnect.mockImplementationOnce(async (opts?: { timeout?: number; session?: string; surface?: string }) => {
       timeoutSeen = opts?.timeout;
-      expect(opts?.session).toBe('__doctor__');
+      expect(opts?.session).toBe('session_doctor_11111111');
       expect(opts?.surface).toBe('browser');
       return {
         evaluate: vi.fn().mockResolvedValue(2),
@@ -286,6 +294,12 @@ describe('doctor report rendering', () => {
 
     expect(timeoutSeen).toBe(8);
     expect(closeWindow).toHaveBeenCalledTimes(1);
+    expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'session-create', {});
+    expect(mockSendCommand).toHaveBeenLastCalledWith('session-close', {
+      session: 'session_doctor_11111111',
+      surface: 'browser',
+      force: true,
+    });
     expect(mockSetDaemonCommandTimeoutSeconds).toHaveBeenNthCalledWith(1, 8);
     expect(mockSetDaemonCommandTimeoutSeconds).toHaveBeenLastCalledWith(null);
   });

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -299,6 +299,7 @@ describe('doctor report rendering', () => {
       session: 'session_doctor_11111111',
       surface: 'browser',
       force: true,
+      discard: true,
     });
     expect(mockSetDaemonCommandTimeoutSeconds).toHaveBeenNthCalledWith(1, 8);
     expect(mockSetDaemonCommandTimeoutSeconds).toHaveBeenLastCalledWith(null);

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -6,7 +6,7 @@
 
 import { DEFAULT_DAEMON_PORT } from './constants.js';
 import { BrowserBridge } from './browser/index.js';
-import { setDaemonCommandTimeoutSeconds } from './browser/daemon-client.js';
+import { sendCommand, setDaemonCommandTimeoutSeconds } from './browser/daemon-client.js';
 import { getDaemonHealth } from './browser/daemon-transport.js';
 import { getErrorMessage } from './errors.js';
 import { getRuntimeLabel } from './runtime-detect.js';
@@ -16,7 +16,6 @@ import { formatDaemonVersion, isDaemonStale, staleDaemonIssue } from './browser/
 import { findShadowedUserAdapters, formatAdapterShadowIssue, type AdapterShadow } from './adapter-shadow.js';
 
 const DOCTOR_LIVE_TIMEOUT_SECONDS = 8;
-const DOCTOR_SESSION = '__doctor__';
 
 export type DoctorOptions = {
   yes?: boolean;
@@ -53,11 +52,15 @@ export async function checkConnectivity(opts?: { timeout?: number }): Promise<Co
   const start = Date.now();
   const timeoutSeconds = opts?.timeout ?? DOCTOR_LIVE_TIMEOUT_SECONDS;
   setDaemonCommandTimeoutSeconds(timeoutSeconds);
+  let sessionId: string | undefined;
   try {
+    const session = await sendCommand('session-create', {}) as { id?: unknown };
+    if (typeof session.id !== 'string') throw new Error('Doctor could not create a browser Session.');
+    sessionId = session.id;
     const bridge = new BrowserBridge();
     const page = await bridge.connect({
       timeout: timeoutSeconds,
-      session: DOCTOR_SESSION,
+      session: sessionId,
       surface: 'browser',
       // Without this, windowMode is undefined, which skips the darwin `open -g`
       // launcher AND trips the explicit bringToFront() in the session manager —
@@ -75,6 +78,9 @@ export async function checkConnectivity(opts?: { timeout?: number }): Promise<Co
   } catch (err) {
     return { ok: false, error: getErrorMessage(err), durationMs: Date.now() - start };
   } finally {
+    if (sessionId) {
+      await sendCommand('session-close', { session: sessionId, surface: 'browser', force: true }).catch(() => undefined);
+    }
     setDaemonCommandTimeoutSeconds(null);
   }
 }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -79,7 +79,7 @@ export async function checkConnectivity(opts?: { timeout?: number }): Promise<Co
     return { ok: false, error: getErrorMessage(err), durationMs: Date.now() - start };
   } finally {
     if (sessionId) {
-      await sendCommand('session-close', { session: sessionId, surface: 'browser', force: true }).catch(() => undefined);
+      await sendCommand('session-close', { session: sessionId, surface: 'browser', force: true, discard: true }).catch(() => undefined);
     }
     setDaemonCommandTimeoutSeconds(null);
   }

--- a/src/hosted/runner.test.ts
+++ b/src/hosted/runner.test.ts
@@ -706,6 +706,20 @@ describe('runHostedCli', () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it('rejects doctor in hosted mode without an API call', async () => {
+    const stderr = sink();
+    const fetchImpl = vi.fn<typeof fetch>();
+    const result = await runHostedCli(['doctor'], {
+      config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
+      stderr: stderr.stream,
+      fetchImpl,
+    });
+
+    expect(result).toEqual({ handled: true, exitCode: 78 });
+    expect(stderr.text()).toContain('webcmd doctor is local-only. Hosted mode has no local browser bridge.');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it.each(['list', 'rename', 'use'])('leaves profile %s to the existing local command surface', async (command) => {
     const result = await runHostedCli(['profile', command, 'value'], {
       config: makeLocalConfig(),

--- a/src/hosted/runner.ts
+++ b/src/hosted/runner.ts
@@ -192,6 +192,12 @@ async function dispatchHosted(
       LOCAL_ONLY_COMMAND_HELP,
     );
   }
+  if (args[0] === 'doctor') {
+    throw new ConfigError(
+      'webcmd doctor is local-only. Hosted mode has no local browser bridge.',
+      LOCAL_ONLY_COMMAND_HELP,
+    );
+  }
   if (args[0] === 'session') {
     const parsed = parseHostedSessionSurface(args.slice(1), normalized.literal);
     if (parsed.kind === 'help') {


### PR DESCRIPTION
## Summary
- create a temporary opaque Session for `webcmd doctor` connectivity probes instead of the old `__doctor__` sentinel
- reuse Cloak's fresh launch `about:blank` page for the first Session window, avoiding an extra empty window after all Cloak windows are closed

## Verification
- `npx vitest run src/doctor.test.ts src/browser/runtime/local-cloak/session-manager.test.ts`
- `npm run typecheck`
- `npx vitest run src/browser/sessions.test.ts src/browser/runtime/local-cloak/provider.test.ts src/daemon/server.test.ts src/browser.test.ts`
- `npm test`
- `npm run build`