### PR TITLE
ci: remove obsolete marketplace reconciliation call

### DIFF
--- a/.github/workflows/sync-community-plugins.yml
+++ b/.github/workflows/sync-community-plugins.yml
@@ -51,20 +51,3 @@ jobs:
             git commit -m "docs: sync community plugins [skip ci]"
             git push origin "HEAD:${{ github.ref_name }}"
           fi
-
-      - name: Reconcile hosted marketplace
-        shell: bash
-        env:
-          WEBCMD_CLOUD_API_BASE_URL: ${{ secrets.WEBCMD_CLOUD_API_BASE_URL }}
-          WEBCMD_ADMIN_PROMOTION_TOKEN: ${{ secrets.WEBCMD_ADMIN_PROMOTION_TOKEN }}
-        run: |
-          if [ -z "$WEBCMD_CLOUD_API_BASE_URL" ] || [ -z "$WEBCMD_ADMIN_PROMOTION_TOKEN" ]; then
-            echo "Hosted marketplace reconciliation skipped; cloud URL or admin token is not configured."
-            exit 0
-          fi
-
-          curl -fsS \
-            -X POST "$WEBCMD_CLOUD_API_BASE_URL/v1/admin/marketplace/reconciliations" \
-            -H "authorization: Bearer $WEBCMD_ADMIN_PROMOTION_TOKEN" \
-            -H "content-type: application/json" \
-            --data "{\"repository\":\"agentrhq/webcmd\",\"commit\":\"$(git rev-parse HEAD)\"}"


### PR DESCRIPTION
## Summary
- remove the legacy HTTP marketplace reconciliation call from the community plugin sync workflow
- keep the canonical Cloud Run reconciliation workflow as the single trigger
- prevent expected HTTP 501 responses from marking successful plugin syncs red

## Verification
- workflow YAML parse check
- `npm run check-community-plugins`
- `npm run build`
- `npm test`