### PR TITLE
Retry background Chromium launch via lsregister on stale LaunchServices cache

### DIFF
--- a/src/browser/runtime/local-cloak/darwin-background-launch.test.ts
+++ b/src/browser/runtime/local-cloak/darwin-background-launch.test.ts
@@ -30,6 +30,7 @@ function fakeDependencies(browser: Browser) {
     connectOverCDP: vi.fn().mockResolvedValue(browser),
     terminateProfile: vi.fn().mockResolvedValue(undefined),
     removePortFile: vi.fn().mockResolvedValue(undefined),
+    registerBundle: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -77,5 +78,50 @@ describe('launchDarwinBackgroundPersistentContext', () => {
     await expect(launchDarwinBackgroundPersistentContext(options, deps)).rejects.toThrow('connect failed');
 
     expect(deps.terminateProfile).toHaveBeenCalledWith(options.userDataDir);
+  });
+
+  it('re-registers a stale LaunchServices bundle and retries once on kLSNoExecutableErr', async () => {
+    const { browser, context } = fakeRuntime();
+    const deps = fakeDependencies(browser);
+    const lsError = new Error(
+      'Command failed: /usr/bin/open -g -n /Applications/Cloak Chromium.app --args ...\n' +
+      'The application cannot be opened for an unexpected reason, error=Error Domain=NSOSStatusErrorDomain ' +
+      'Code=-10827 "kLSNoExecutableErr: The executable is missing"',
+    );
+    deps.openApplication.mockRejectedValueOnce(lsError).mockResolvedValueOnce(undefined);
+
+    const result = await launchDarwinBackgroundPersistentContext(options, deps);
+
+    expect(deps.registerBundle).toHaveBeenCalledWith('/Applications/Cloak Chromium.app');
+    expect(deps.openApplication).toHaveBeenCalledTimes(2);
+    expect(result).toBe(context);
+  });
+
+  it('surfaces a remediation error when re-registering does not fix kLSNoExecutableErr', async () => {
+    const { browser } = fakeRuntime();
+    const deps = fakeDependencies(browser);
+    const lsError = new Error('kLSNoExecutableErr: The executable is missing');
+    deps.openApplication.mockRejectedValue(lsError);
+
+    await expect(launchDarwinBackgroundPersistentContext(options, deps)).rejects.toThrow(
+      /lsregister -f "\/Applications\/Cloak Chromium\.app"/,
+    );
+
+    expect(deps.registerBundle).toHaveBeenCalledWith('/Applications/Cloak Chromium.app');
+    expect(deps.openApplication).toHaveBeenCalledTimes(2);
+    // Never "launched" (both attempts failed before the app came up), so no
+    // stray terminateProfile call for a process that never started.
+    expect(deps.terminateProfile).not.toHaveBeenCalled();
+  });
+
+  it('does not attempt lsregister remediation for unrelated open failures', async () => {
+    const { browser } = fakeRuntime();
+    const deps = fakeDependencies(browser);
+    deps.openApplication.mockRejectedValue(new Error('some other launch failure'));
+
+    await expect(launchDarwinBackgroundPersistentContext(options, deps)).rejects.toThrow('some other launch failure');
+
+    expect(deps.registerBundle).not.toHaveBeenCalled();
+    expect(deps.openApplication).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/browser/runtime/local-cloak/darwin-background-launch.test.ts
+++ b/src/browser/runtime/local-cloak/darwin-background-launch.test.ts
@@ -101,10 +101,12 @@ describe('launchDarwinBackgroundPersistentContext', () => {
     const { browser } = fakeRuntime();
     const deps = fakeDependencies(browser);
     const lsError = new Error('kLSNoExecutableErr: The executable is missing');
-    deps.openApplication.mockRejectedValue(lsError);
+    deps.openApplication
+      .mockRejectedValueOnce(lsError)
+      .mockRejectedValueOnce(new Error('retry failed: bundle executable is invalid'));
 
     await expect(launchDarwinBackgroundPersistentContext(options, deps)).rejects.toThrow(
-      /lsregister -f "\/Applications\/Cloak Chromium\.app"/,
+      /retry failed: bundle executable is invalid[\s\S]*lsregister -f "\/Applications\/Cloak Chromium\.app"/,
     );
 
     expect(deps.registerBundle).toHaveBeenCalledWith('/Applications/Cloak Chromium.app');

--- a/src/browser/runtime/local-cloak/darwin-background-launch.ts
+++ b/src/browser/runtime/local-cloak/darwin-background-launch.ts
@@ -11,6 +11,14 @@ import { findExactCloakProfileProcesses } from './process-matcher.js';
 
 const execFileAsync = promisify(execFile);
 
+// macOS LaunchServices' registration database for `.app` bundles. A script-driven
+// unzip of a new/updated Chromium bundle (rather than a Finder/.pkg install) can
+// land outside the triggers that make LS pick it up, leaving `open` unable to
+// resolve a bundle that runs fine when executed directly (kLSNoExecutableErr).
+const LSREGISTER_PATH =
+  '/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister';
+const LS_NO_EXECUTABLE_MARKER = 'kLSNoExecutableErr';
+
 type Dependencies = {
   buildLaunchOptions: typeof buildLaunchOptions;
   humanizeBrowser: typeof humanizeBrowser;
@@ -20,10 +28,47 @@ type Dependencies = {
   connectOverCDP: (endpoint: string) => Promise<Browser>;
   terminateProfile: (userDataDir: string) => Promise<void>;
   removePortFile: (portFile: string) => Promise<void>;
+  /** Force LaunchServices to re-scan a bundle after a stale-cache `open` failure. */
+  registerBundle: (appPath: string) => Promise<void>;
 };
 
 async function openApplication(appPath: string, args: string[]): Promise<void> {
   await execFileAsync('/usr/bin/open', ['-g', '-n', appPath, '--args', ...args]);
+}
+
+async function registerBundle(appPath: string): Promise<void> {
+  await execFileAsync(LSREGISTER_PATH, ['-f', appPath]);
+}
+
+function isStaleLaunchServicesError(err: unknown): boolean {
+  return err instanceof Error && err.message.includes(LS_NO_EXECUTABLE_MARKER);
+}
+
+/**
+ * Open the app, retrying once via `lsregister -f` when macOS reports the bundle
+ * as missing due to a stale LaunchServices cache entry rather than an actually
+ * missing executable (see #220).
+ */
+async function openApplicationWithLsRegisterRetry(
+  deps: Dependencies,
+  appPath: string,
+  args: string[],
+): Promise<void> {
+  try {
+    await deps.openApplication(appPath, args);
+  } catch (err) {
+    if (!isStaleLaunchServicesError(err)) throw err;
+    try {
+      await deps.registerBundle(appPath);
+      await deps.openApplication(appPath, args);
+    } catch {
+      throw new Error(
+        `Cloak Chromium bundle exists but macOS LaunchServices has a stale record for it (${LS_NO_EXECUTABLE_MARKER}): ${appPath}\n` +
+        `Re-registering it automatically did not resolve the issue. Fix it manually with:\n` +
+        `  ${LSREGISTER_PATH} -f "${appPath}"`,
+      );
+    }
+  }
 }
 
 export async function waitForDevToolsPort(portFile: string, timeoutMs = 10_000): Promise<number> {
@@ -55,6 +100,7 @@ const defaultDependencies: Dependencies = {
   connectOverCDP: endpoint => chromium.connectOverCDP(endpoint),
   terminateProfile,
   removePortFile: portFile => rm(portFile, { force: true }),
+  registerBundle,
 };
 
 const contextActivators = new WeakMap<BrowserContext, () => Promise<void>>();
@@ -83,7 +129,7 @@ export async function launchDarwinBackgroundPersistentContext(
   let browser: Browser | undefined;
   let launched = false;
   try {
-    await deps.openApplication(appPath, [
+    await openApplicationWithLsRegisterRetry(deps, appPath, [
       ...(launchOptions.args ?? []),
       '--password-store=basic',
       '--use-mock-keychain',

--- a/src/browser/runtime/local-cloak/darwin-background-launch.ts
+++ b/src/browser/runtime/local-cloak/darwin-background-launch.ts
@@ -61,11 +61,14 @@ async function openApplicationWithLsRegisterRetry(
     try {
       await deps.registerBundle(appPath);
       await deps.openApplication(appPath, args);
-    } catch {
+    } catch (retryError) {
+      const retryMessage = retryError instanceof Error ? retryError.message : String(retryError);
       throw new Error(
         `Cloak Chromium bundle exists but macOS LaunchServices has a stale record for it (${LS_NO_EXECUTABLE_MARKER}): ${appPath}\n` +
+        `Automatic remediation failed: ${retryMessage}\n` +
         `Re-registering it automatically did not resolve the issue. Fix it manually with:\n` +
         `  ${LSREGISTER_PATH} -f "${appPath}"`,
+        { cause: retryError },
       );
     }
   }


### PR DESCRIPTION
## Summary
- Fixes #220 — `webcmd doctor`'s browser connectivity check can fail with `kLSNoExecutableErr` even though the managed Chromium bundle under `~/.cloakbrowser/<version>/Chromium.app` is intact and executable (verified: valid codesign, no quarantine xattr, runs fine when invoked directly). The failure is a stale macOS LaunchServices cache entry for the bundle path — likely because the bundle is unzipped into a hidden dotfile directory by webcmd's own tooling rather than installed via Finder/a `.pkg`, which can land outside the triggers that make LS pick it up.
- `launchDarwinBackgroundPersistentContext` (`darwin-background-launch.ts`) now detects `kLSNoExecutableErr` from the `open` failure, runs `lsregister -f` on the bundle, and retries the launch once.
- If the retry still fails, the thrown error includes the exact manual remediation command (`lsregister -f "<bundle>"`) instead of the generic connectivity failure text — this flows through to `webcmd doctor`'s `Issues:` section automatically since it already surfaces the underlying error message verbatim.
- Any other `open` failure (unrelated to a stale LS cache) is untouched — no remediation attempt, same behavior as before.

## Test plan
- [x] `npx vitest run src/browser/runtime/local-cloak/darwin-background-launch.test.ts` — new coverage: successful retry after re-registering, remediation error surfaced when retry still fails, unrelated failures skip remediation entirely (regression guard)
- [x] `npx tsc --build --force` — clean
- [x] Full `unit` vitest project (147 files / 2356 tests) passes with this change in the tree