### PR TITLE
Distinguish missing browser binary from generic connectivity failure in doctor

### DIFF
--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   mockGetDaemonHealth,
@@ -51,6 +54,12 @@ vi.mock('./adapter-shadow.js', async () => {
 
 import { checkBrowserBinary, checkConnectivity, renderBrowserDoctorReport, runBrowserDoctor } from './doctor.js';
 
+const managedBinaryDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-managed-binary-'));
+const managedBinaryPath = path.join(managedBinaryDir, process.platform === 'win32' ? 'chrome.exe' : 'chrome');
+fs.writeFileSync(managedBinaryPath, '#!/bin/sh\n');
+if (process.platform !== 'win32') fs.chmodSync(managedBinaryPath, 0o755);
+afterAll(() => fs.rmSync(managedBinaryDir, { recursive: true, force: true }));
+
 describe('doctor report rendering', () => {
   const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
 
@@ -66,7 +75,7 @@ describe('doctor report rendering', () => {
       bundledVersion: '146.0.7680.177.5',
       tier: 'free',
       platform: 'linux-x64',
-      binaryPath: '/home/test/.cloakbrowser/chromium-146.0.7680.177.5/chrome',
+      binaryPath: managedBinaryPath,
       installed: true,
       cacheDir: '/home/test/.cloakbrowser/chromium-146.0.7680.177.5',
       downloadUrl: 'https://cloakbrowser.dev/chromium-v146.0.7680.177.5/cloakbrowser-linux-x64.tar.gz',
@@ -500,9 +509,14 @@ describe('doctor report rendering', () => {
       expect(report.issues).toEqual(expect.arrayContaining([
         expect.stringContaining('Browser connectivity test failed: page.goto: Target page, context or browser has been closed'),
       ]));
+      const issueText = report.issues.join('\n');
+      expect(issueText).not.toContain('CloakBrowser Chromium is not installed');
+      expect(issueText).not.toContain('not launchable');
+      expect(issueText).not.toContain('Download URL:');
+      expect(issueText).not.toContain('CLOAKBROWSER_BINARY_PATH');
     });
 
-    it('distinguishes a missing/undownloaded binary from a generic connectivity failure', async () => {
+    it('reports a missing binary without claiming a download was attempted', async () => {
       mockBinaryInfo.mockReturnValue({
         version: '146.0.7680.177.5',
         bundledVersion: '146.0.7680.177.5',
@@ -520,21 +534,119 @@ describe('doctor report rendering', () => {
 
       expect(report.binary?.installed).toBe(false);
       const issueText = report.issues.join('\n');
-      expect(issueText).toContain('CloakBrowser Chromium is not installed and could not be downloaded');
+      expect(issueText).toContain('CloakBrowser Chromium is not installed');
       expect(issueText).toContain('/home/test/.cloakbrowser/chromium-146.0.7680.177.5/chrome');
       expect(issueText).toContain('https://cloakbrowser.dev/chromium-v146.0.7680.177.5/cloakbrowser-linux-x64.tar.gz');
-      expect(issueText).toContain('Underlying error: fetch failed');
+      expect(issueText).toContain('Browser connectivity test failed: fetch failed');
       expect(issueText).toContain('CLOAKBROWSER_BINARY_PATH');
-      // The old generic message must not also appear — one clear diagnostic, not two.
-      expect(issueText).not.toContain('Browser connectivity test failed: fetch failed');
+      expect(issueText).not.toContain('could not be downloaded');
+      expect(issueText).not.toContain('download failed');
+    });
+
+    it('preserves a session-create connectivity failure alongside missing-binary facts', async () => {
+      mockBinaryInfo.mockReturnValue({
+        version: '146.0.7680.177.5',
+        bundledVersion: '146.0.7680.177.5',
+        tier: 'free',
+        platform: 'linux-x64',
+        binaryPath: '/home/test/.cloakbrowser/chromium-146.0.7680.177.5/chrome',
+        installed: false,
+        cacheDir: '/home/test/.cloakbrowser/chromium-146.0.7680.177.5',
+        downloadUrl: 'https://cloakbrowser.dev/chromium-v146.0.7680.177.5/cloakbrowser-linux-x64.tar.gz',
+      });
+      mockSendCommand.mockRejectedValueOnce(new Error('session-create refused'));
+      mockGetDaemonHealth.mockResolvedValueOnce({ state: 'ready', status: { runtimeConnected: true, runtimeName: 'Cloak' } });
+
+      const report = await runBrowserDoctor();
+      const issueText = report.issues.join('\n');
+
+      expect(report.connectivity).toMatchObject({ ok: false, error: 'session-create refused' });
+      expect(issueText).toContain('Browser connectivity test failed: session-create refused');
+      expect(issueText).toContain('/home/test/.cloakbrowser/chromium-146.0.7680.177.5/chrome');
+      expect(issueText).toContain('https://cloakbrowser.dev/chromium-v146.0.7680.177.5/cloakbrowser-linux-x64.tar.gz');
+      expect(issueText).not.toContain('could not be downloaded');
+      expect(issueText).not.toContain('download failed');
+      expect(mockConnect).not.toHaveBeenCalled();
+    });
+
+    it('reports the binary state after connectivity auto-installs Chromium', async () => {
+      let installed = false;
+      mockBinaryInfo.mockImplementation(() => ({
+        version: '146.0.7680.177.5',
+        bundledVersion: '146.0.7680.177.5',
+        tier: 'free',
+        platform: 'linux-x64',
+        binaryPath: managedBinaryPath,
+        installed,
+        cacheDir: '/home/test/.cloakbrowser/chromium-146.0.7680.177.5',
+        downloadUrl: 'https://cloakbrowser.dev/chromium-v146.0.7680.177.5/cloakbrowser-linux-x64.tar.gz',
+      }));
+      mockConnect.mockImplementationOnce(async () => {
+        installed = true;
+        return {
+          evaluate: vi.fn().mockResolvedValue(2),
+          closeWindow: vi.fn().mockResolvedValue(undefined),
+        };
+      });
+      mockGetDaemonHealth.mockResolvedValueOnce({ state: 'ready', status: { runtimeConnected: true, runtimeName: 'Cloak' } });
+
+      const report = await runBrowserDoctor();
+      const text = strip(renderBrowserDoctorReport(report));
+
+      expect(report.binary?.installed).toBe(true);
+      expect(report.issues).toEqual([]);
+      expect(text).toContain('[OK] Browser binary: installed at');
+      expect(text).not.toContain('[MISSING] Browser binary');
+      expect(text).toContain('Everything looks good!');
+      expect(mockBinaryInfo).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports a final missing binary even when connectivity succeeds', async () => {
+      mockBinaryInfo.mockReturnValue({
+        version: '146.0.7680.177.5',
+        bundledVersion: '146.0.7680.177.5',
+        tier: 'free',
+        platform: 'linux-x64',
+        binaryPath: '/home/test/.cloakbrowser/chromium-146.0.7680.177.5/chrome',
+        installed: false,
+        cacheDir: '/home/test/.cloakbrowser/chromium-146.0.7680.177.5',
+        downloadUrl: 'https://cloakbrowser.dev/chromium-v146.0.7680.177.5/cloakbrowser-linux-x64.tar.gz',
+      });
+      mockGetDaemonHealth.mockResolvedValueOnce({ state: 'ready', status: { runtimeConnected: true, runtimeName: 'Cloak' } });
+
+      const report = await runBrowserDoctor();
+      const text = strip(renderBrowserDoctorReport(report));
+
+      expect(report.connectivity?.ok).toBe(true);
+      expect(report.binary?.installed).toBe(false);
+      expect(report.issues.join('\n')).toContain('CloakBrowser Chromium is not installed');
+      expect(text).toContain('[MISSING] Browser binary');
+      expect(text).not.toContain('Everything looks good!');
+    });
+
+    it('reports binary probe failures as unknown warnings', async () => {
+      mockBinaryInfo.mockImplementation(() => {
+        throw new Error('corrupt CloakBrowser metadata');
+      });
+      mockGetDaemonHealth.mockResolvedValueOnce({ state: 'ready', status: { runtimeConnected: true, runtimeName: 'Cloak' } });
+
+      const report = await runBrowserDoctor();
+      const text = strip(renderBrowserDoctorReport(report));
+
+      expect(report.binary?.installed).toBeUndefined();
+      expect(report.issues.join('\n')).toContain('Could not check CloakBrowser Chromium binary: corrupt CloakBrowser metadata');
+      expect(text).toContain('[WARN] Browser binary: status unknown');
+      expect(text).not.toContain('[OK] Browser binary');
+      expect(text).not.toContain('Everything looks good!');
     });
 
     it('treats CLOAKBROWSER_BINARY_PATH as the effective binary check, not the managed cache', async () => {
-      const fs = await import('node:fs');
-      const os = await import('node:os');
-      const path = await import('node:path');
-      const overridePath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-binary-override-')), 'chrome');
+      const overridePath = path.join(
+        fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-binary-override-')),
+        process.platform === 'win32' ? 'chrome.exe' : 'chrome',
+      );
       fs.writeFileSync(overridePath, '#!/bin/sh\n');
+      if (process.platform !== 'win32') fs.chmodSync(overridePath, 0o755);
       vi.stubEnv('CLOAKBROWSER_BINARY_PATH', overridePath);
       try {
         // Managed cache would report "not installed" — the override should win.
@@ -555,6 +667,62 @@ describe('doctor report rendering', () => {
       }
     });
 
+    it('rejects a CLOAKBROWSER_BINARY_PATH directory', async () => {
+      const overridePath = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-binary-directory-'));
+      vi.stubEnv('CLOAKBROWSER_BINARY_PATH', overridePath);
+      try {
+        expect(checkBrowserBinary().installed).toBe(false);
+      } finally {
+        vi.unstubAllEnvs();
+        fs.rmSync(overridePath, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects a non-executable CLOAKBROWSER_BINARY_PATH file on POSIX', async () => {
+      if (process.platform === 'win32') return;
+      const overridePath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-binary-non-executable-')), 'chrome');
+      fs.writeFileSync(overridePath, '#!/bin/sh\n', { mode: 0o644 });
+      vi.stubEnv('CLOAKBROWSER_BINARY_PATH', overridePath);
+      try {
+        expect(checkBrowserBinary().installed).toBe(false);
+      } finally {
+        vi.unstubAllEnvs();
+        fs.rmSync(path.dirname(overridePath), { recursive: true, force: true });
+      }
+    });
+
+    it('rejects a managed non-executable binary on POSIX', () => {
+      if (process.platform === 'win32') return;
+      const binaryDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-managed-non-executable-'));
+      const binaryPath = path.join(binaryDir, 'chrome');
+      fs.writeFileSync(binaryPath, '#!/bin/sh\n', { mode: 0o644 });
+      mockBinaryInfo.mockReturnValue({
+        version: '1.0.0', bundledVersion: '1.0.0', tier: 'free', platform: 'linux-x64',
+        binaryPath, installed: true, cacheDir: binaryDir, downloadUrl: 'https://example.test/download',
+      });
+      try {
+        expect(checkBrowserBinary().installed).toBe(false);
+      } finally {
+        fs.rmSync(binaryDir, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects a non-exe binary file on Windows', () => {
+      const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+      const binaryDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-windows-binary-'));
+      const binaryPath = path.join(binaryDir, 'chrome.txt');
+      fs.writeFileSync(binaryPath, 'not an executable');
+      vi.stubEnv('CLOAKBROWSER_BINARY_PATH', binaryPath);
+      try {
+        Object.defineProperty(process, 'platform', { ...platformDescriptor, value: 'win32' });
+        expect(checkBrowserBinary().installed).toBe(false);
+      } finally {
+        if (platformDescriptor) Object.defineProperty(process, 'platform', platformDescriptor);
+        vi.unstubAllEnvs();
+        fs.rmSync(binaryDir, { recursive: true, force: true });
+      }
+    });
+
     it('reports override-specific guidance when CLOAKBROWSER_BINARY_PATH points nowhere', async () => {
       vi.stubEnv('CLOAKBROWSER_BINARY_PATH', '/does/not/exist/chrome');
       try {
@@ -566,8 +734,10 @@ describe('doctor report rendering', () => {
         expect(report.binary?.installed).toBe(false);
         expect(report.binary?.override).toBe(true);
         const issueText = report.issues.join('\n');
+        const text = strip(renderBrowserDoctorReport(report));
         expect(issueText).toContain('CLOAKBROWSER_BINARY_PATH (/does/not/exist/chrome)');
         expect(issueText).toContain('compatible local Chromium executable');
+        expect(text).toContain('[MISSING] Browser binary: not launchable (/does/not/exist/chrome)');
       } finally {
         vi.unstubAllEnvs();
       }

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -7,6 +7,7 @@ const {
   mockFindShadowedUserAdapters,
   mockSendCommand,
   mockSetDaemonCommandTimeoutSeconds,
+  mockBinaryInfo,
 } = vi.hoisted(() => ({
   mockGetDaemonHealth: vi.fn(),
   mockConnect: vi.fn(),
@@ -14,10 +15,18 @@ const {
   mockFindShadowedUserAdapters: vi.fn(),
   mockSendCommand: vi.fn(),
   mockSetDaemonCommandTimeoutSeconds: vi.fn(),
+  mockBinaryInfo: vi.fn(),
 }));
 
 vi.mock('./browser/daemon-transport.js', () => ({
   getDaemonHealth: mockGetDaemonHealth,
+}));
+
+// Real binaryInfo() reads this machine's actual CloakBrowser cache dir, which
+// varies by dev box/CI runner — mock it so doctor tests are hermetic and the
+// #239 binary-missing path can be exercised deterministically.
+vi.mock('cloakbrowser', () => ({
+  binaryInfo: mockBinaryInfo,
 }));
 
 vi.mock('./browser/index.js', () => ({
@@ -40,15 +49,28 @@ vi.mock('./adapter-shadow.js', async () => {
   };
 });
 
-import { checkConnectivity, renderBrowserDoctorReport, runBrowserDoctor } from './doctor.js';
+import { checkBrowserBinary, checkConnectivity, renderBrowserDoctorReport, runBrowserDoctor } from './doctor.js';
 
 describe('doctor report rendering', () => {
   const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
     mockFindShadowedUserAdapters.mockReturnValue([]);
     mockSetDaemonCommandTimeoutSeconds.mockClear();
+    // Installed by default so pre-existing tests exercise the generic
+    // connectivity-failure path, not the #239 binary-missing path.
+    mockBinaryInfo.mockReturnValue({
+      version: '146.0.7680.177.5',
+      bundledVersion: '146.0.7680.177.5',
+      tier: 'free',
+      platform: 'linux-x64',
+      binaryPath: '/home/test/.cloakbrowser/chromium-146.0.7680.177.5/chrome',
+      installed: true,
+      cacheDir: '/home/test/.cloakbrowser/chromium-146.0.7680.177.5',
+      downloadUrl: 'https://cloakbrowser.dev/chromium-v146.0.7680.177.5/cloakbrowser-linux-x64.tar.gz',
+    });
     // Doctor always runs live connectivity. Tests that want connect to fail override.
     mockConnect.mockResolvedValue({
       evaluate: vi.fn().mockResolvedValue(2),
@@ -131,6 +153,30 @@ describe('doctor report rendering', () => {
     expect(text).toContain('[OK] Runtime: Cloak connected (version unknown)');
     expect(text).not.toContain('Cloak runtime is connected but did not report a version.');
     expect(text).toContain('Everything looks good!');
+  });
+
+  it('renders the browser binary status line when installed', () => {
+    const text = strip(renderBrowserDoctorReport({
+      daemonRunning: true,
+      runtimeConnected: true,
+      runtimeName: 'Cloak',
+      binary: { installed: true, path: '/home/test/.cloakbrowser/chromium-1.0.0/chrome', override: false },
+      issues: [],
+    }));
+
+    expect(text).toContain('[OK] Browser binary: installed at /home/test/.cloakbrowser/chromium-1.0.0/chrome');
+  });
+
+  it('renders the browser binary status line as MISSING when not installed', () => {
+    const text = strip(renderBrowserDoctorReport({
+      daemonRunning: true,
+      runtimeConnected: true,
+      runtimeName: 'Cloak',
+      binary: { installed: false, path: '/home/test/.cloakbrowser/chromium-1.0.0/chrome', override: false },
+      issues: ['CloakBrowser Chromium is not installed and could not be downloaded at ...'],
+    }));
+
+    expect(text).toContain('[MISSING] Browser binary: not installed (/home/test/.cloakbrowser/chromium-1.0.0/chrome)');
   });
 
   it('renders connectivity OK when live test succeeds', () => {
@@ -441,6 +487,91 @@ describe('doctor report rendering', () => {
     expect(report.issues).toEqual(expect.arrayContaining([
       expect.stringContaining('Multiple Chrome profiles are connected'),
     ]));
+  });
+
+  describe('#239 — missing browser binary', () => {
+    it('reports the binary as installed and does not alter the generic failure message when present', async () => {
+      mockConnect.mockRejectedValueOnce(new Error('page.goto: Target page, context or browser has been closed'));
+      mockGetDaemonHealth.mockResolvedValueOnce({ state: 'ready', status: { runtimeConnected: true, runtimeName: 'Cloak' } });
+
+      const report = await runBrowserDoctor();
+
+      expect(report.binary?.installed).toBe(true);
+      expect(report.issues).toEqual(expect.arrayContaining([
+        expect.stringContaining('Browser connectivity test failed: page.goto: Target page, context or browser has been closed'),
+      ]));
+    });
+
+    it('distinguishes a missing/undownloaded binary from a generic connectivity failure', async () => {
+      mockBinaryInfo.mockReturnValue({
+        version: '146.0.7680.177.5',
+        bundledVersion: '146.0.7680.177.5',
+        tier: 'free',
+        platform: 'linux-x64',
+        binaryPath: '/home/test/.cloakbrowser/chromium-146.0.7680.177.5/chrome',
+        installed: false,
+        cacheDir: '/home/test/.cloakbrowser/chromium-146.0.7680.177.5',
+        downloadUrl: 'https://cloakbrowser.dev/chromium-v146.0.7680.177.5/cloakbrowser-linux-x64.tar.gz',
+      });
+      mockConnect.mockRejectedValueOnce(new Error('fetch failed'));
+      mockGetDaemonHealth.mockResolvedValueOnce({ state: 'ready', status: { runtimeConnected: true, runtimeName: 'Cloak' } });
+
+      const report = await runBrowserDoctor();
+
+      expect(report.binary?.installed).toBe(false);
+      const issueText = report.issues.join('\n');
+      expect(issueText).toContain('CloakBrowser Chromium is not installed and could not be downloaded');
+      expect(issueText).toContain('/home/test/.cloakbrowser/chromium-146.0.7680.177.5/chrome');
+      expect(issueText).toContain('https://cloakbrowser.dev/chromium-v146.0.7680.177.5/cloakbrowser-linux-x64.tar.gz');
+      expect(issueText).toContain('Underlying error: fetch failed');
+      expect(issueText).toContain('CLOAKBROWSER_BINARY_PATH');
+      // The old generic message must not also appear — one clear diagnostic, not two.
+      expect(issueText).not.toContain('Browser connectivity test failed: fetch failed');
+    });
+
+    it('treats CLOAKBROWSER_BINARY_PATH as the effective binary check, not the managed cache', async () => {
+      const fs = await import('node:fs');
+      const os = await import('node:os');
+      const path = await import('node:path');
+      const overridePath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-binary-override-')), 'chrome');
+      fs.writeFileSync(overridePath, '#!/bin/sh\n');
+      vi.stubEnv('CLOAKBROWSER_BINARY_PATH', overridePath);
+      try {
+        // Managed cache would report "not installed" — the override should win.
+        mockBinaryInfo.mockReturnValue({
+          version: '1.0.0', bundledVersion: '1.0.0', tier: 'free', platform: 'linux-x64',
+          binaryPath: '/home/test/.cloakbrowser/chromium-1.0.0/chrome', installed: false,
+          cacheDir: '/home/test/.cloakbrowser/chromium-1.0.0', downloadUrl: 'https://example.test/download',
+        });
+
+        const binary = checkBrowserBinary();
+
+        expect(binary.installed).toBe(true);
+        expect(binary.override).toBe(true);
+        expect(binary.path).toBe(overridePath);
+      } finally {
+        vi.unstubAllEnvs();
+        fs.rmSync(path.dirname(overridePath), { recursive: true, force: true });
+      }
+    });
+
+    it('reports override-specific guidance when CLOAKBROWSER_BINARY_PATH points nowhere', async () => {
+      vi.stubEnv('CLOAKBROWSER_BINARY_PATH', '/does/not/exist/chrome');
+      try {
+        mockConnect.mockRejectedValueOnce(new Error('spawn /does/not/exist/chrome ENOENT'));
+        mockGetDaemonHealth.mockResolvedValueOnce({ state: 'ready', status: { runtimeConnected: true, runtimeName: 'Cloak' } });
+
+        const report = await runBrowserDoctor();
+
+        expect(report.binary?.installed).toBe(false);
+        expect(report.binary?.override).toBe(true);
+        const issueText = report.issues.join('\n');
+        expect(issueText).toContain('CLOAKBROWSER_BINARY_PATH (/does/not/exist/chrome)');
+        expect(issueText).toContain('compatible local Chromium executable');
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
   });
 });
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -5,6 +5,7 @@
  */
 
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { binaryInfo } from 'cloakbrowser';
 import { DEFAULT_DAEMON_PORT } from './constants.js';
 import { BrowserBridge } from './browser/index.js';
@@ -31,9 +32,10 @@ export type ConnectivityResult = {
 };
 
 export type BrowserBinaryStatus = {
-  installed: boolean;
+  installed: boolean | undefined;
   path: string;
   downloadUrl?: string;
+  error?: string;
   /** True when CLOAKBROWSER_BINARY_PATH is set — a different check than the managed cache. */
   override: boolean;
 };
@@ -55,9 +57,20 @@ export type DoctorReport = {
   issues: string[];
 };
 
+function isLaunchableFile(binaryPath: string): boolean {
+  try {
+    if (!fs.statSync(binaryPath).isFile()) return false;
+    if (process.platform === 'win32') return path.extname(binaryPath).toLowerCase() === '.exe';
+    fs.accessSync(binaryPath, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
- * Check whether the CloakBrowser Chromium binary is actually installed, ahead
- * of the live connectivity probe. `runtimeConnected: true` only means the
+ * Check whether the CloakBrowser Chromium binary is actually installed.
+ * `runtimeConnected: true` only means the
  * daemon/Cloak runtime process is healthy — it says nothing about whether the
  * browser binary CloakBrowser needs to launch is present on disk, which is
  * exactly the gap that made a missing-binary failure look like a generic
@@ -66,16 +79,18 @@ export type DoctorReport = {
 export function checkBrowserBinary(): BrowserBinaryStatus {
   const override = process.env.CLOAKBROWSER_BINARY_PATH;
   if (override) {
-    return { installed: fs.existsSync(override), path: override, override: true };
+    return { installed: isLaunchableFile(override), path: override, override: true };
   }
   try {
     const info = binaryInfo();
-    return { installed: info.installed, path: info.binaryPath, downloadUrl: info.downloadUrl, override: false };
+    return {
+      installed: info.installed && isLaunchableFile(info.binaryPath),
+      path: info.binaryPath,
+      downloadUrl: info.downloadUrl,
+      override: false,
+    };
   } catch (err) {
-    // binaryInfo() is a local/synchronous check and shouldn't throw, but a
-    // diagnostic probe must never crash `doctor` — treat "couldn't tell" as
-    // "assume installed" so we don't misreport a binary we failed to check.
-    return { installed: true, path: `unknown (binary check failed: ${getErrorMessage(err)})`, override: false };
+    return { installed: undefined, path: 'unknown', error: getErrorMessage(err), override: false };
   }
 }
 
@@ -120,14 +135,11 @@ export async function checkConnectivity(opts?: { timeout?: number }): Promise<Co
 }
 
 export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<DoctorReport> {
-  // Checked before the live probe so a missing/undownloadable binary can be
-  // distinguished from a real connectivity failure below, instead of both
-  // collapsing into the same generic "fetch failed".
-  const binary = checkBrowserBinary();
-
   // Live connectivity check is the core of doctor — it doubles as auto-start
-  // (bridge.connect spawns daemon) and validates end-to-end browser bridge health.
+  // (bridge.connect spawns daemon and can install Chromium) and validates
+  // end-to-end browser bridge health.
   const connectivity = await checkConnectivity();
+  const binary = checkBrowserBinary();
 
   // Single status read *after* connectivity side-effects settle.
   const health = await getDaemonHealth();
@@ -145,6 +157,18 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
     adapterShadows = findShadowedUserAdapters();
   } catch (err) {
     issues.push(`Could not check adapter overrides: ${getErrorMessage(err)}`);
+  }
+  if (binary.error) {
+    issues.push(`Could not check CloakBrowser Chromium binary: ${binary.error}`);
+  } else if (binary.installed === false) {
+    const source = binary.override ? `CLOAKBROWSER_BINARY_PATH (${binary.path})` : binary.path;
+    issues.push(
+      `CloakBrowser Chromium is ${binary.override ? 'not launchable at' : 'not installed at'} ${source}.\n` +
+      (binary.downloadUrl ? `  Download URL: ${binary.downloadUrl}\n` : '') +
+      (binary.override
+        ? '  Check that CLOAKBROWSER_BINARY_PATH points at a compatible local Chromium executable.'
+        : '  Check network access to the download URL above, or set CLOAKBROWSER_BINARY_PATH to a compatible local Chromium executable.'),
+    );
   }
   if (daemonFlaky) {
     issues.push(
@@ -182,19 +206,7 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
     }
   }
   if (!connectivity.ok) {
-    if (!binary.installed) {
-      const source = binary.override ? `CLOAKBROWSER_BINARY_PATH (${binary.path})` : binary.path;
-      issues.push(
-        `CloakBrowser Chromium is not installed${binary.override ? '' : ' and could not be downloaded'} at ${source}.\n` +
-        (binary.downloadUrl ? `  Download URL: ${binary.downloadUrl}\n` : '') +
-        `  Underlying error: ${connectivity.error ?? 'unknown'}\n` +
-        (binary.override
-          ? '  Check that CLOAKBROWSER_BINARY_PATH points at a compatible local Chromium executable.'
-          : '  Check network access to the download URL above, or set CLOAKBROWSER_BINARY_PATH to a compatible local Chromium executable.'),
-      );
-    } else {
-      issues.push(`Browser connectivity test failed: ${connectivity.error ?? 'unknown'}`);
-    }
+    issues.push(`Browser connectivity test failed: ${connectivity.error ?? 'unknown'}`);
   }
   const profileConfig = loadProfileConfig();
   const staleDefault = profileConfig.defaultContextId;
@@ -269,10 +281,14 @@ export function renderBrowserDoctorReport(report: DoctorReport): string {
   // reflects the daemon/Cloak process and says nothing about whether the
   // Chromium binary Cloak needs to launch is actually installed.
   if (report.binary) {
-    const binaryIcon = report.binary.installed ? '[OK]' : '[MISSING]';
-    const binaryLabel = report.binary.installed
+    const binaryIcon = report.binary.installed === undefined
+      ? '[WARN]'
+      : report.binary.installed ? '[OK]' : '[MISSING]';
+    const binaryLabel = report.binary.installed === undefined
+      ? 'status unknown'
+      : report.binary.installed
       ? `installed at ${report.binary.path}`
-      : `not installed (${report.binary.path})`;
+      : `${report.binary.override ? 'not launchable' : 'not installed'} (${report.binary.path})`;
     lines.push(`${binaryIcon} Browser binary: ${binaryLabel}`);
   }
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -4,6 +4,8 @@
  * Simplified for the daemon-based architecture.
  */
 
+import * as fs from 'node:fs';
+import { binaryInfo } from 'cloakbrowser';
 import { DEFAULT_DAEMON_PORT } from './constants.js';
 import { BrowserBridge } from './browser/index.js';
 import { sendCommand, setDaemonCommandTimeoutSeconds } from './browser/daemon-client.js';
@@ -28,6 +30,13 @@ export type ConnectivityResult = {
   durationMs: number;
 };
 
+export type BrowserBinaryStatus = {
+  installed: boolean;
+  path: string;
+  downloadUrl?: string;
+  /** True when CLOAKBROWSER_BINARY_PATH is set — a different check than the managed cache. */
+  override: boolean;
+};
 
 export type DoctorReport = {
   cliVersion?: string;
@@ -39,11 +48,36 @@ export type DoctorReport = {
   runtimeFlaky?: boolean;
   runtimeName?: string;
   runtimeVersion?: string;
+  binary?: BrowserBinaryStatus;
   connectivity?: ConnectivityResult;
   profiles?: BrowserProfileStatus[];
   adapterShadows?: AdapterShadow[];
   issues: string[];
 };
+
+/**
+ * Check whether the CloakBrowser Chromium binary is actually installed, ahead
+ * of the live connectivity probe. `runtimeConnected: true` only means the
+ * daemon/Cloak runtime process is healthy — it says nothing about whether the
+ * browser binary CloakBrowser needs to launch is present on disk, which is
+ * exactly the gap that made a missing-binary failure look like a generic
+ * connectivity problem (#239).
+ */
+export function checkBrowserBinary(): BrowserBinaryStatus {
+  const override = process.env.CLOAKBROWSER_BINARY_PATH;
+  if (override) {
+    return { installed: fs.existsSync(override), path: override, override: true };
+  }
+  try {
+    const info = binaryInfo();
+    return { installed: info.installed, path: info.binaryPath, downloadUrl: info.downloadUrl, override: false };
+  } catch (err) {
+    // binaryInfo() is a local/synchronous check and shouldn't throw, but a
+    // diagnostic probe must never crash `doctor` — treat "couldn't tell" as
+    // "assume installed" so we don't misreport a binary we failed to check.
+    return { installed: true, path: `unknown (binary check failed: ${getErrorMessage(err)})`, override: false };
+  }
+}
 
 /**
  * Test connectivity by attempting a real browser command.
@@ -86,6 +120,11 @@ export async function checkConnectivity(opts?: { timeout?: number }): Promise<Co
 }
 
 export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<DoctorReport> {
+  // Checked before the live probe so a missing/undownloadable binary can be
+  // distinguished from a real connectivity failure below, instead of both
+  // collapsing into the same generic "fetch failed".
+  const binary = checkBrowserBinary();
+
   // Live connectivity check is the core of doctor — it doubles as auto-start
   // (bridge.connect spawns daemon) and validates end-to-end browser bridge health.
   const connectivity = await checkConnectivity();
@@ -143,7 +182,19 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
     }
   }
   if (!connectivity.ok) {
-    issues.push(`Browser connectivity test failed: ${connectivity.error ?? 'unknown'}`);
+    if (!binary.installed) {
+      const source = binary.override ? `CLOAKBROWSER_BINARY_PATH (${binary.path})` : binary.path;
+      issues.push(
+        `CloakBrowser Chromium is not installed${binary.override ? '' : ' and could not be downloaded'} at ${source}.\n` +
+        (binary.downloadUrl ? `  Download URL: ${binary.downloadUrl}\n` : '') +
+        `  Underlying error: ${connectivity.error ?? 'unknown'}\n` +
+        (binary.override
+          ? '  Check that CLOAKBROWSER_BINARY_PATH points at a compatible local Chromium executable.'
+          : '  Check network access to the download URL above, or set CLOAKBROWSER_BINARY_PATH to a compatible local Chromium executable.'),
+      );
+    } else {
+      issues.push(`Browser connectivity test failed: ${connectivity.error ?? 'unknown'}`);
+    }
   }
   const profileConfig = loadProfileConfig();
   const staleDefault = profileConfig.defaultContextId;
@@ -173,6 +224,7 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
     runtimeFlaky,
     runtimeName,
     runtimeVersion,
+    binary,
     connectivity,
     profiles,
     adapterShadows,
@@ -212,6 +264,17 @@ export function renderBrowserDoctorReport(report: DoctorReport): string {
     ? 'unstable (connected during live check, then disconnected)'
     : report.runtimeConnected ? 'connected' : 'not connected';
   lines.push(`${runtimeIcon} Runtime: ${runtimeName} ${runtimeLabel}${runtimeVersion}`);
+
+  // Browser binary status — distinct from "Runtime connected", which only
+  // reflects the daemon/Cloak process and says nothing about whether the
+  // Chromium binary Cloak needs to launch is actually installed.
+  if (report.binary) {
+    const binaryIcon = report.binary.installed ? '[OK]' : '[MISSING]';
+    const binaryLabel = report.binary.installed
+      ? `installed at ${report.binary.path}`
+      : `not installed (${report.binary.path})`;
+    lines.push(`${binaryIcon} Browser binary: ${binaryLabel}`);
+  }
 
   if (report.profiles && report.profiles.length > 0) {
     const config = loadProfileConfig();


### PR DESCRIPTION
## Summary
- Fixes #239 — `webcmd doctor` reports a generic `fetch failed` when the CloakBrowser Chromium binary is missing and its automatic download can't reach the download servers. The daemon and Cloak runtime report healthy, which makes it look like a browser-profile or daemon problem rather than a missing binary — the reporter's workaround was setting `CLOAKBROWSER_BINARY_PATH` to an existing local Chrome install after a lot of manual diagnosis.
- New `checkBrowserBinary()` in `doctor.ts` checks binary presence ahead of the live connectivity probe, via CloakBrowser's own `binaryInfo()` (already a public export of the `cloakbrowser` package webcmd depends on), or — when `CLOAKBROWSER_BINARY_PATH` is set — that override path directly, so a correctly-configured workaround isn't misreported as "missing."
- `doctor` now renders a distinct `Browser binary:` status line, separate from `Runtime:` — "runtime connected" only reflects the daemon/Cloak process, not whether the Chromium binary it needs to launch is actually installed.
- When connectivity fails specifically because the binary isn't installed, the `Issues:` section now reports the binary path, download URL, and the underlying error, with `CLOAKBROWSER_BINARY_PATH` suggested as an actionable fallback — instead of the old generic `Browser connectivity test failed: fetch failed`.

Scoped to `webcmd doctor` only. I did not touch the general adapter-command error-code path (e.g. `webcmd reddit login`'s `error.code: UNKNOWN`) — that funnels through the daemon IPC/retry-classification system (`session-manager.ts`, `daemon-client.ts`) and is a larger, separate change if wanted.

## Test plan
- [x] `npx vitest run src/doctor.test.ts` — new coverage: binary-installed case leaves the generic message untouched, binary-missing case produces the specific diagnostic (path/URL/underlying error/`CLOAKBROWSER_BINARY_PATH` hint, and confirms the old generic message does *not* also appear), `CLOAKBROWSER_BINARY_PATH` override is treated as authoritative over the managed cache state, override-pointing-nowhere case gets override-specific guidance, plus direct render tests for the new `Browser binary:` line in both states
- [x] `npx tsc --build --force` — clean
- [x] Full `unit` vitest project (147 files / 2356 tests) passes with this change in the tree