### PR TITLE
ci: guard new plugin PR scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  plugin-pr-scope:
+    name: Plugin PR scope
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Check plugin PR scope
+        run: npm run check:plugin-pr-scope -- "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}"
+
   build:
     name: Build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "build-plugin-manifest": "tsx src/build-plugin-command-manifest.ts",
     "check:codex-plugin": "node scripts/check-codex-plugin.mjs",
     "check:hosted-contract": "node scripts/check-hosted-contract.mjs",
+    "check:plugin-pr-scope": "node scripts/check-plugin-pr-scope.mjs",
     "clean-dist": "node scripts/clean-dist.cjs",
     "copy-yaml": "node scripts/copy-yaml.cjs",
     "sync-community-plugins": "tsx scripts/sync-community-plugins.ts",

--- a/scripts/check-plugin-pr-scope.mjs
+++ b/scripts/check-plugin-pr-scope.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+
+const [baseArg, headArg, ...extraArgs] = process.argv.slice(2);
+
+if (!baseArg || !headArg || extraArgs.length) {
+  console.error('Usage: check-plugin-pr-scope <base-sha> <head-sha>');
+  process.exit(1);
+}
+
+function git(args) {
+  const result = spawnSync('git', args, { encoding: 'utf8' });
+  if (result.error) {
+    console.error(`Failed to run git: ${result.error.message}`);
+    process.exit(1);
+  }
+  return result;
+}
+
+function resolveSha(label, value) {
+  const result = git(['rev-parse', '--verify', `${value}^{commit}`]);
+  if (result.status !== 0) {
+    console.error(`Invalid ${label} SHA: ${value}`);
+    process.exit(1);
+  }
+  return result.stdout.trim();
+}
+
+const base = resolveSha('base', baseArg);
+const head = resolveSha('head', headArg);
+const mergeBaseResult = git(['merge-base', base, head]);
+if (mergeBaseResult.status !== 0) {
+  console.error(`Could not find a merge base for ${baseArg} and ${headArg}.`);
+  process.exit(1);
+}
+
+const mergeBase = mergeBaseResult.stdout.trim();
+const diffResult = git(['diff', '--name-status', '-z', '--no-renames', mergeBase, head, '--']);
+if (diffResult.status !== 0) {
+  console.error('Could not read the pull request diff.');
+  process.exit(1);
+}
+
+const fields = diffResult.stdout.split('\0');
+if (fields.at(-1) === '') fields.pop();
+if (fields.length % 2 !== 0) {
+  console.error('Could not parse the pull request diff.');
+  process.exit(1);
+}
+
+const changes = [];
+for (let index = 0; index < fields.length; index += 2) {
+  changes.push({ status: fields[index], path: fields[index + 1] });
+}
+
+const pluginDirectories = new Set();
+for (const change of changes) {
+  const manifest = change.status === 'A'
+    ? change.path.match(/^(plugins\/[^/]+)\/webcmd-plugin\.json$/)
+    : null;
+  if (manifest) pluginDirectories.add(manifest[1]);
+}
+
+if (pluginDirectories.size === 0) process.exit(0);
+
+const outsideChanges = changes.filter(
+  (change) => ![...pluginDirectories].some((directory) => change.path.startsWith(`${directory}/`)),
+);
+
+if (outsideChanges.length > 0) {
+  console.error('Plugin-only PR scope violation: adding a plugin manifest requires every changed path to stay inside the newly added plugin directories.');
+  for (const change of outsideChanges) console.error(`  ${change.status} ${change.path}`);
+  process.exit(1);
+}

--- a/src/plugin-pr-scope.test.ts
+++ b/src/plugin-pr-scope.test.ts
@@ -63,6 +63,15 @@ describe('plugin-only PR scope guard', () => {
     expect(runGuard(root, base, head).status).toBe(0);
   });
 
+  it('ignores unrelated changes added to the base after the feature branch diverges', () => {
+    const { root, base, head } = fixture((repo) => addPlugin(repo, 'foo'));
+    git(root, 'checkout', '--quiet', base);
+    write(root, 'README.md', 'base advanced\n');
+    const newBase = commit(root, 'advance base');
+
+    expect(runGuard(root, newBase, head).status).toBe(0);
+  });
+
   it.each([
     ['README.md', (root: string) => write(root, 'README.md', 'after\n')],
     ['webcmd-plugin.json', (root: string) => write(root, 'webcmd-plugin.json', '{"changed":true}\n')],

--- a/src/plugin-pr-scope.test.ts
+++ b/src/plugin-pr-scope.test.ts
@@ -1,0 +1,143 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const checkerPath = path.join(packageRoot, 'scripts/check-plugin-pr-scope.mjs');
+const fixtureRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of fixtureRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function git(root: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim();
+}
+
+function write(root: string, relativePath: string, contents = relativePath): void {
+  const destination = path.join(root, ...relativePath.split('/'));
+  mkdirSync(path.dirname(destination), { recursive: true });
+  writeFileSync(destination, contents);
+}
+
+function commit(root: string, message: string): string {
+  git(root, 'add', '-A');
+  git(root, 'commit', '--quiet', '-m', message);
+  return git(root, 'rev-parse', 'HEAD');
+}
+
+function fixture(change: (root: string) => void) {
+  const root = mkdtempSync(path.join(tmpdir(), 'webcmd-plugin-pr-scope-'));
+  fixtureRoots.push(root);
+  git(root, 'init', '--quiet');
+  git(root, 'config', 'user.email', 'test@example.com');
+  git(root, 'config', 'user.name', 'Test');
+  write(root, 'README.md', 'before\n');
+  write(root, 'webcmd-plugin.json', '{}\n');
+  write(root, 'package.json', '{}\n');
+  write(root, '.github/workflows/ci.yml', 'name: CI\n');
+  write(root, 'plugins/existing/webcmd-plugin.json', '{}\n');
+  write(root, 'plugins/existing/index.js', 'export {};\n');
+  const base = commit(root, 'base');
+  change(root);
+  const head = commit(root, 'head');
+  return { root, base, head };
+}
+
+function addPlugin(root: string, name: string): void {
+  write(root, `plugins/${name}/webcmd-plugin.json`, '{}\n');
+  write(root, `plugins/${name}/index.js`, 'export {};\n');
+}
+
+function runGuard(root: string, ...args: string[]) {
+  return spawnSync(process.execPath, [checkerPath, ...args], { cwd: root, encoding: 'utf8' });
+}
+
+describe('plugin-only PR scope guard', () => {
+  it('accepts changes contained in one newly added plugin', () => {
+    const { root, base, head } = fixture((repo) => addPlugin(repo, 'foo'));
+
+    expect(runGuard(root, base, head).status).toBe(0);
+  });
+
+  it.each([
+    ['README.md', (root: string) => write(root, 'README.md', 'after\n')],
+    ['webcmd-plugin.json', (root: string) => write(root, 'webcmd-plugin.json', '{"changed":true}\n')],
+    ['package.json', (root: string) => write(root, 'package.json', '{"changed":true}\n')],
+    ['.github/workflows/ci.yml', (root: string) => write(root, '.github/workflows/ci.yml', 'name: changed\n')],
+    ['docs/note.md', (root: string) => write(root, 'docs/note.md')],
+  ])('rejects a new plugin plus %s', (outsidePath, addOutsideChange) => {
+    const { root, base, head } = fixture((repo) => {
+      addPlugin(repo, 'foo');
+      addOutsideChange(repo);
+    });
+
+    const result = runGuard(root, base, head);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(outsidePath);
+  });
+
+  it('accepts changes contained in two newly added plugins', () => {
+    const { root, base, head } = fixture((repo) => {
+      addPlugin(repo, 'foo');
+      addPlugin(repo, 'bar');
+    });
+
+    expect(runGuard(root, base, head).status).toBe(0);
+  });
+
+  it('rejects a new plugin plus an existing-plugin edit', () => {
+    const { root, base, head } = fixture((repo) => {
+      addPlugin(repo, 'foo');
+      write(repo, 'plugins/existing/index.js', 'export const changed = true;\n');
+    });
+
+    const result = runGuard(root, base, head);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('plugins/existing/index.js');
+  });
+
+  it.each([
+    ['existing-plugin maintenance', (root: string) => write(root, 'plugins/existing/index.js', 'export const changed = true;\n')],
+    ['a non-plugin change', (root: string) => write(root, 'README.md', 'after\n')],
+  ])('does not activate for %s', (_label, change) => {
+    const { root, base, head } = fixture(change);
+
+    expect(runGuard(root, base, head).status).toBe(0);
+  });
+
+  it('rejects the deleted paths of a renamed existing plugin', () => {
+    const { root, base, head } = fixture((repo) => {
+      renameSync(path.join(repo, 'plugins/existing'), path.join(repo, 'plugins/renamed'));
+    });
+
+    const result = runGuard(root, base, head);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('plugins/existing/webcmd-plugin.json');
+  });
+
+  it('does not treat a plugin name as a path prefix', () => {
+    const { root, base, head } = fixture((repo) => {
+      addPlugin(repo, 'foo');
+      write(repo, 'plugins/foo-bar/index.js', 'export {};\n');
+    });
+
+    const result = runGuard(root, base, head);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('plugins/foo-bar/index.js');
+  });
+
+  it('fails clearly when SHAs are missing or invalid', () => {
+    const missing = runGuard(packageRoot);
+    expect(missing.status).toBe(1);
+    expect(missing.stderr).toContain('Usage:');
+
+    const { root, head } = fixture((repo) => write(repo, 'README.md', 'after\n'));
+    const invalid = runGuard(root, 'not-a-sha', head);
+    expect(invalid.status).toBe(1);
+    expect(invalid.stderr).toContain('Invalid base SHA');
+  });
+});


### PR DESCRIPTION
## Description

Add a PR-only CI guard for new community plugins.

When a PR adds `plugins/<name>/webcmd-plugin.json`, every changed path must stay inside the newly added plugin directory or directories. This prevents plugin PRs from committing generated `README.md` and root `webcmd-plugin.json` updates, or unrelated repository changes. Existing-plugin maintenance and non-plugin PRs are unaffected.

The guard compares the pull request head against its true merge base, parses a NUL-delimited no-renames diff, and runs in one dedicated Ubuntu job with no persisted credentials.

Related issue: none

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [x] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Adapter Notes

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Verification

- TDD red: 13 focused tests failed before the guard script existed
- Mutation check: diverged-history test failed when the implementation used `base..head` instead of `merge-base..head`
- `npx vitest run --project unit src/plugin-pr-scope.test.ts` — 14 passed
- `npm run typecheck`
- `npm run build`
- `npm test` — 5,528 passed, 56 skipped
- `npm run check-community-plugins` — checked 123 plugins
- `git diff --check`

## Screenshots / Output

Not applicable.