### PR TITLE
fix: require OpenAI-generated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,14 @@ jobs:
         if: ${{ steps.release.outputs.release_created || inputs.publish_tag != '' }}
         run: npx playwright-core install chromium --with-deps
 
-      - name: Verify existing release tag
-        if: ${{ inputs.publish_tag != '' }}
-        run: test "${{ inputs.publish_tag }}" = "webcmd-v$(node -p "require('./package.json').version")"
+      - name: Verify release metadata
+        if: ${{ steps.release.outputs.release_created || inputs.publish_tag != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          test "${{ steps.release.outputs.tag_name || inputs.publish_tag }}" = "webcmd-v$version"
+          test "$(sed -n 's/^## \[\([^]]*\)\].*/\1/p' CHANGELOG.md | head -n 1)" = "$version"
 
       - name: Type check
         if: ${{ steps.release.outputs.release_created || inputs.publish_tag != '' }}
@@ -105,7 +110,7 @@ jobs:
         run: npm run check:package-bin
 
       - name: Generate enhanced release notes
-        if: ${{ steps.release.outputs.release_created || (inputs.publish_tag != '' && inputs.notes_only) }}
+        if: ${{ steps.release.outputs.release_created || inputs.publish_tag != '' }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -114,24 +119,18 @@ jobs:
         run: |
           set -euo pipefail
           npm --silent run generate-release-notes -- "${{ steps.release.outputs.tag_name || inputs.publish_tag }}" > "$RUNNER_TEMP/release-notes.md"
-          if [ -s "$RUNNER_TEMP/release-notes.md" ]; then
-            release_title="$(sed -n 's/^# //p' "$RUNNER_TEMP/release-notes.md" | head -n 1)"
-            release_body_file="$RUNNER_TEMP/release-notes.md"
-            release_edit_args=()
-            if [ -n "$release_title" ]; then
-              release_body_file="$RUNNER_TEMP/release-body.md"
-              tail -n +2 "$RUNNER_TEMP/release-notes.md" | sed '1{/^$/d;}' > "$release_body_file"
-              release_edit_args+=(--title "$release_title")
-            fi
-            release_edit_args+=(--notes-file "$release_body_file")
-            if gh release edit "${{ steps.release.outputs.tag_name || inputs.publish_tag }}" "${release_edit_args[@]}"; then
-              echo "Enhanced release notes were applied."
-            else
-              echo "::warning::Enhanced release notes could not be applied; keeping release-please notes."
-            fi
-          else
-            echo "Enhanced release notes were not generated; keeping release-please notes."
+          test -s "$RUNNER_TEMP/release-notes.md"
+          release_title="$(sed -n 's/^# //p' "$RUNNER_TEMP/release-notes.md" | head -n 1)"
+          release_body_file="$RUNNER_TEMP/release-notes.md"
+          release_edit_args=()
+          if [ -n "$release_title" ]; then
+            release_body_file="$RUNNER_TEMP/release-body.md"
+            tail -n +2 "$RUNNER_TEMP/release-notes.md" | sed '1{/^$/d;}' > "$release_body_file"
+            release_edit_args+=(--title "$release_title")
           fi
+          release_edit_args+=(--notes-file "$release_body_file")
+          gh release edit "${{ steps.release.outputs.tag_name || inputs.publish_tag }}" "${release_edit_args[@]}"
+          echo "Enhanced release notes were applied."
 
       - name: Publish to npm
         if: ${{ steps.release.outputs.release_created || (inputs.publish_tag != '' && !inputs.notes_only) }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,33 +2,135 @@
 
 ## [0.7.0](https://github.com/agentrhq/webcmd/compare/webcmd-v0.6.2...webcmd-v0.7.0) (2026-08-14)
 
-_webcmd v0.7.0: Browser Session stability and plugin discoverability improvements_
-
-### Bug Fixes
-
-* allow overriding the verify row-shape top-level key cap ([#230](https://github.com/agentrhq/webcmd/issues/230)) ([ab6b7b7](https://github.com/agentrhq/webcmd/commit/ab6b7b7d98faf47171c0014526d08b26c98f10d2)), closes [#218](https://github.com/agentrhq/webcmd/issues/218)
-* **browser:** repair doctor session and first cloak window ([#298](https://github.com/agentrhq/webcmd/issues/298)) ([41a4109](https://github.com/agentrhq/webcmd/commit/41a41099560617a426ed9a52147c88bdf76220c6))
-* run src/browser unit tests in CI and stabilize the vendor digest ([#238](https://github.com/agentrhq/webcmd/issues/238)) ([399d742](https://github.com/agentrhq/webcmd/commit/399d7427b89351eebbc341f20b3ac0d5f6f7eace))
-* support multi-word plugin search ([#285](https://github.com/agentrhq/webcmd/issues/285)) ([46f3ddd](https://github.com/agentrhq/webcmd/commit/46f3ddddfae33d881fe30d6be1f2335d30cd465b))
-
-_webcmd v0.6.2: Browser Sessions, Plugins Everywhere, and Cloud Parity_
+_webcmd v0.7.0: The Multiverse of Agents Is Here._
 
 ### Highlights
-- Added explicit browser Sessions: create, carry, list, and close stable Session IDs for raw browser workflows across local and hosted mode.
-- Added `browser run` code execution for Playwright-style browser automation, including hosted routing and file transfer support.
-- Moved CLI surfaces into plugins, with marketplace search/install paths and command discovery metadata.
-- Added plugin override precedence and reconciliation: `~/.webcmd/clis` wins over installed plugins, update detection is content-based, and overrides report actionable status.
-- Expanded Webcmd Cloud parity for browser commands, hosted manifests, profiles/workspaces, auth handoff, and verify fixture evaluation.
+
+Webcmd 0.7.0 is the multi-agent browser runtime release.
+
+Browser work is no longer organized around one shared window. Agents can create explicit, persistent Sessions inside a profile, work concurrently in isolated Cloak windows, carry authentication state safely, recover stale leases, and close their workspaces deterministically. Authentication handoffs are scoped to the Session that started them, so humans can complete login, MFA, or CAPTCHA challenges without one agent disrupting another.
+
+```bash
+webcmd --profile work session create
+webcmd --session session_abc browser run --stdin
+webcmd --session session_abc browser snapshot --snapshot-mode read
+webcmd session list
+webcmd session close session_abc
+```
+
+The agent multiverse now extends across development environments. Webcmd adds a native Claude Code plugin marketplace alongside Codex, carrying the same seven bundled authoring and browser skills. Onboarding was rewritten across Claude Code, Codex, Cursor, Hermes, OpenCode, OpenClaw, and Pi so agents can install Webcmd, understand which existing tools to keep, and route compatible browser work through one deterministic command surface.
+
+Research workflows also become agent-native. The new OmniSearch plugin searches seven public communities without login, while Smart Search now recognizes site-specific requests and goes directly to an installed adapter instead of wasting time on generic search engines.
 
 ### Improvements
-- Added bundled agent guides and updated Webcmd skills for the plugin-first workflow.
-- Added hosted contract checks, plugin parity checks, and live Cloak session gates.
-- Added release tooling improvements for package, plugin, and manifest consistency.
+
+- Added explicit browser Sessions with `session create`, `session list`, and `session close`, plus the root-level `--session` selector. Agents sharing one profile can now work concurrently in separate browser workspaces. [#291](https://github.com/agentrhq/webcmd/pull/291)
+- Added session isolation across Cloak windows, browser actions, dialogs, adapter execution, authentication handoffs, leases, cancellation, and daemon disconnects.
+- Brought the Session model to hosted browser execution with local/hosted contract and command parity.
+- Made `web fetch` a client-owned core command. It now follows a deterministic HTTP-only ladder before any explicit browser fallback: plain HTTP, Chrome TLS impersonation, then Firefox TLS impersonation.
+- Added a site-named fast path to Smart Search. Requests naming Hacker News, Reddit, or another supported site now try that site's adapter before a generic search engine. [#269](https://github.com/agentrhq/webcmd/pull/269)
+- Improved plugin search so spaced, hyphenated, punctuated, concatenated, and reordered multi-word queries can find the intended plugin while still requiring every search term. [#285](https://github.com/agentrhq/webcmd/pull/285)
+- Added a native Claude Code marketplace and synchronized Claude Code, Codex, and npm package version metadata. [#273](https://github.com/agentrhq/webcmd/pull/273)
+- Streamlined copyable onboarding prompts and restored the manual quick start for users who prefer direct CLI installation. [#272](https://github.com/agentrhq/webcmd/pull/272) [#275](https://github.com/agentrhq/webcmd/pull/275)
+- Reworked tool-routing guidance across seven agent harnesses. Webcmd now distinguishes tools that should be replaced from native search or development tools that should remain available.
+- Made plugin updates ignore only untracked npm-generated artifacts such as `node_modules` and `package-lock.json`, while continuing to protect genuine user changes. [#267](https://github.com/agentrhq/webcmd/pull/267)
+- Added an explicit confirmation boundary before promoting private adapters into the public repository, plus CI protection against unrelated changes in new-plugin pull requests. [#234](https://github.com/agentrhq/webcmd/pull/234) [#304](https://github.com/agentrhq/webcmd/pull/304)
+- **Breaking:** invalid `-f` or `--format` values now fail consistently with exit code 2 instead of silently falling back to a table. Supported formats are `table`, `plain`, `json`, `yaml`, `md`, and `csv`. [#190](https://github.com/agentrhq/webcmd/pull/190)
+
+### Fixes
+
+- Enforced `web fetch --timeout` across the complete request lifecycle, including proxy teardown, DNS resolution, keep-alive tunnels, and late socket errors. A timed-out request now exits at its declared deadline with a structured `TIMEOUT` error. [#265](https://github.com/agentrhq/webcmd/pull/265)
+- Fixed browser-run commands returning JavaScript `undefined`; deterministic output now serializes it as `null`. [#278](https://github.com/agentrhq/webcmd/pull/278)
+- Repaired `webcmd doctor` session cleanup and first-window selection so diagnostic probes do not leak into normal browser work. [#298](https://github.com/agentrhq/webcmd/pull/298)
+- Made the verify row-shape top-level key limit configurable for commands with legitimately wide structured output. [#230](https://github.com/agentrhq/webcmd/pull/230)
+- Restored 44 browser test files containing 596 tests to CI coverage, and made the Playwright vendor digest stable across Windows and POSIX paths. [#238](https://github.com/agentrhq/webcmd/pull/238)
+- Replaced a real 31 MB test write with a sparse file, preserving coverage while avoiding Windows CI timeouts. [#268](https://github.com/agentrhq/webcmd/pull/268)
+- Corrected plugin promotion documentation, repository paths, community-sync guidance, and Hermes formatting.
+
+### Adapters
+
+- Added **OmniSearch**, a no-login research plugin spanning Hacker News, Stack Overflow, GitHub, arXiv, Dev.to, Lobsters, and Bluesky. Its `research` command aggregates evidence, while `verdict` distills community reception for agent workflows. [#270](https://github.com/agentrhq/webcmd/pull/270)
+
+```bash
+webcmd omnisearch research "browser agents" -f json
+webcmd omnisearch verdict "browser agents" -f json
+```
+
+- Added `youtube frames` for capturing timestamped PNG frames at exact timestamps or evenly across a video. [#297](https://github.com/agentrhq/webcmd/pull/297)
+
+```bash
+webcmd youtube frames "<video-url>" --timestamps 30,90,150
+webcmd youtube frames "<video-url>" --count 5
+```
+
+- Added authenticated Amazon India cart inspection and guarded cart additions, including explicit product-variant verification. [#241](https://github.com/agentrhq/webcmd/pull/241)
+
+```bash
+webcmd amazon-in cart
+webcmd amazon-in cart-add
+```
+
+### Contributors
+
+[@adot-7](https://github.com/adot-7) | [@Agnik47](https://github.com/Agnik47) | [@ankitranjan7](https://github.com/ankitranjan7) | [@anshula-100](https://github.com/anshula-100) | [@ayushsingh82](https://github.com/ayushsingh82) | [@beubax](https://github.com/beubax) | [@ngaurav](https://github.com/ngaurav) | [@Rishet11](https://github.com/Rishet11) | [@rishabhraj36](https://github.com/rishabhraj36) | [@Sneh30](https://github.com/Sneh30) | [@yashkhatri012](https://github.com/yashkhatri012)
+
+## [0.6.2](https://github.com/agentrhq/webcmd/compare/webcmd-v0.6.1...webcmd-v0.6.2) (2026-08-12)
+
+### Highlights
+- Added explicit browser Sessions for local and hosted browser workflows.
+- Added the `browser run` code executor path, including hosted routing and file transfer support.
+- Moved CLI surfaces into plugins, with marketplace search/install and command discovery metadata.
+- Added plugin override precedence and reconciliation: local `~/.webcmd/clis` overrides installed plugins, update detection is content-based, and override status is actionable.
+- Expanded Webcmd Cloud parity for browser commands, hosted manifests, profiles/workspaces, auth handoff, and verify fixture evaluation.
 
 ### Fixes
 - Hardened session admission/cancellation, background tab focus, Cloak process matching, and browser run timeout behavior.
 - Fixed plugin discovery/install edge cases, adapter status output, hosted output flushing, and local override reconciliation.
 - Restored and hardened adapter behavior across Amazon, Facebook, Twitter, TikTok, YouTube, and others.
+
+## [0.6.1](https://github.com/agentrhq/webcmd/compare/webcmd-v0.6.0...webcmd-v0.6.1) (2026-08-12)
+
+### Highlights
+- Added explicit raw browser Sessions for parallel agents.
+- Kept adapter commands on an adapter-default Session unless `--session` is supplied.
+- Isolated local Cloak Session windows and pages, and fixed page/admission partitioning by adapter site.
+- Scoped auth handoff and Session close behavior so active work is not interrupted.
+- Updated bundled documentation and skills for Session usage.
+
+## [0.6.0](https://github.com/agentrhq/webcmd/compare/webcmd-v0.5.4...webcmd-v0.6.0) (2026-08-10)
+
+_webcmd v0.6.0: Code Is All You Need._
+
+### Highlights
+Webcmd 0.6.0 is the plugin architecture release. Site CLIs now live as independently installable plugins instead of being bundled into the core package, so the CLI runtime can stay small while adapters evolve on their own cadence. Agents should search the catalog first with `webcmd plugin search <site> -f json`, then install the returned `installSource`.
+
+The new browser-run executor turns browser automation into code. `webcmd browser <session> run` executes sandboxed Playwright-style JavaScript against a real Webcmd browser session, letting agents inspect pages, reuse state, collect artifacts, and verify UI behavior without hand-assembling brittle one-off commands.
+
+Plugin overrides are safer and more deterministic. Local command overrides in `~/.webcmd/clis` take precedence over installed plugin commands, override update detection is content-based, and installing a newly added monorepo sub-plugin refreshes stale local catalog state instead of incorrectly reporting that the plugin does not exist.
+
+### Improvements
+- Added `webcmd update` to upgrade the CLI and refresh linked skills from one command.
+- Added `webcmd adapter override <site>/<command>` for forking an installed plugin command into an editable local override.
+- Moved the core `web` adapter into the new command layout and kept fetch/read workflows available through the same runtime surface.
+- Reworked agent onboarding docs around the new plugin-first flow, including Codex, Claude Code, Cursor, Hermes, OpenCode, Pi, OpenClaw, and custom SDK setup.
+- Migrated enhanced release-note generation to OpenAI-backed tooling and hardened the structured docs-review flow.
+
+### Fixes
+- Fixed stale monorepo plugin installs so a new sub-plugin added to `agentrhq/webcmd` can be found and installed without manually refreshing local cache state.
+- Repaired adapter drift and markdown/console output escaping issues across affected site commands.
+- Hardened docs-review parsing for fenced JSON and switched it to a lighter review model.
+- Hosted browser responses now tolerate additional cloud fields such as `expiresAt`.
+- Cached browser runtime version checks to make status and doctor-style commands faster.
+
+### Adapters
+- All site adapters now install through the plugin catalog instead of shipping inside the npm package.
+- Added postgraduate course export plugins for University of Cincinnati, Concordia University, University of Gottingen, Heidelberg University, HFT Stuttgart, Illinois Institute of Technology, Johns Hopkins University, University of Alberta, and Yale University.
+- Added a `luma` plugin for events, guests, and registration-question workflows.
+- Updated Skyscanner docs with required flags and current examples.
+- Moved and repaired web/social adapter coverage touched by the plugin migration, including Amazon, Facebook, TikTok, Twitter/X, and the built-in web fetch commands.
+
+### Contributors
+[@ankitranjan7](https://github.com/ankitranjan7) | [@anshula-100](https://github.com/anshula-100) | [@askadityapandey](https://github.com/askadityapandey) | [@beubax](https://github.com/beubax) | [@ngaurav](https://github.com/ngaurav) | [@rajarshidattapy](https://github.com/rajarshidattapy) | [@rishabhraj36](https://github.com/rishabhraj36)
 
 ## [0.5.4](https://github.com/agentrhq/webcmd/compare/webcmd-v0.5.3...webcmd-v0.5.4) (2026-08-09)
 
@@ -58,18 +160,6 @@ _webcmd v0.6.2: Browser Sessions, Plugins Everywhere, and Cloud Parity_
 
 ### Contributors
 [@ankitranjan7](https://github.com/ankitranjan7) | [@askadityapandey](https://github.com/askadityapandey) | [@beubax](https://github.com/beubax) | [@rajarshidattapy](https://github.com/rajarshidattapy) | [@rishabhraj36](https://github.com/rishabhraj36)
-
-## [0.5.3](https://github.com/agentrhq/webcmd/compare/webcmd-v0.5.2...webcmd-v0.5.3) (2026-08-07)
-
-### Improvements
-- Adds a new `system-info` command to display version information for webcmd, Node.js, and the operating system. This is useful for debugging and reporting issues.
-
-### Fixes
-- The `whoami` command now handles cases where no user is logged in more gracefully, preventing unexpected errors.
-
-### Adapters
-- **AWS**: Added support for the `eu-south-2` (Spain) region.
-- **GCP**: Added a new `gcp run list` command to list Cloud Run services.
 
 ## [0.5.3](https://github.com/agentrhq/webcmd/compare/webcmd-v0.5.2...webcmd-v0.5.3) (2026-08-03)
 

--- a/scripts/docs-sync-review.ts
+++ b/scripts/docs-sync-review.ts
@@ -218,7 +218,6 @@ async function requestOpenAIReview(
         },
         { role: 'user', content: prompt },
       ],
-      temperature: 0.1,
       ...(useLowReasoning ? { reasoning_effort: 'low' } : {}),
     }),
     signal: AbortSignal.timeout(180_000),
@@ -226,7 +225,10 @@ async function requestOpenAIReview(
   if (response.status === 400 && useLowReasoning) {
     return requestOpenAIReview(prompt, model, apiKey, fetchImpl, false);
   }
-  if (!response.ok) throw new Error(`OpenAI request failed with HTTP ${response.status}.`);
+  if (!response.ok) {
+    const detail = (await response.text()).slice(0, 600);
+    throw new Error(`OpenAI request failed with HTTP ${response.status}: ${detail}`);
+  }
   return response;
 }
 

--- a/scripts/generate-release-notes.ts
+++ b/scripts/generate-release-notes.ts
@@ -57,6 +57,8 @@ interface RunDependencies {
   generateText?: (prompt: string, model: string, apiKey: string) => Promise<string>;
 }
 
+type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
 type GhRunner = (args: readonly string[]) => string;
 
 interface LoadReleaseContextOptions {
@@ -178,8 +180,13 @@ export async function loadReleaseContext(tag: string, env: NodeJS.ProcessEnv, op
   };
 }
 
-async function generateText(prompt: string, model: string, apiKey: string): Promise<string> {
-  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+export async function generateOpenAIReleaseNotes(
+  prompt: string,
+  model: string,
+  apiKey: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<string> {
+  const response = await fetchImpl('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
       authorization: `Bearer ${apiKey}`,
@@ -188,11 +195,11 @@ async function generateText(prompt: string, model: string, apiKey: string): Prom
     body: JSON.stringify({
       model,
       messages: [{ role: 'user', content: prompt }],
-      temperature: 0.1,
     }),
   });
   if (!response.ok) {
-    throw new Error(`OpenAI request failed with HTTP ${response.status}`);
+    const detail = (await response.text()).slice(0, 600);
+    throw new Error(`OpenAI request failed with HTTP ${response.status}: ${detail}`);
   }
   const data = await response.json() as {
     choices?: Array<{ message?: { content?: string | null } }>;
@@ -248,24 +255,23 @@ export async function runGenerateReleaseNotes(
 
   const apiKey = env.OPENAI_API_KEY?.trim();
   if (!apiKey) {
-    io.writeStderr('OPENAI_API_KEY is not set; leaving release-please notes unchanged.\n');
-    return 0;
+    io.writeStderr('OPENAI_API_KEY is required to generate release notes.\n');
+    return 1;
   }
 
   try {
     const context = await (deps.loadContext ?? loadReleaseContext)(tag, env);
     const model = env.OPENAI_RELEASE_NOTES_MODEL || DEFAULT_MODEL;
     const prompt = buildReleaseNotesPrompt(context);
-    const raw = await (deps.generateText ?? generateText)(prompt, model, apiKey);
+    const raw = await (deps.generateText ?? generateOpenAIReleaseNotes)(prompt, model, apiKey);
     const normalized = normalizeReleaseNotes(raw, { context });
-    if (normalized) {
-      io.writeStdout(`${normalized}\n`);
-    }
+    if (!normalized) throw new Error('OpenAI returned no usable release notes.');
+    io.writeStdout(`${normalized}\n`);
     return 0;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     io.writeStderr(`OpenAI release notes failed: ${message}\n`);
-    return 0;
+    return 1;
   }
 }
 

--- a/src/docs-sync-review-cli.test.ts
+++ b/src/docs-sync-review-cli.test.ts
@@ -356,6 +356,7 @@ describe('OpenAI and documentation boundaries', () => {
         body: expect.stringContaining('"reasoning_effort":"low"'),
       }),
     );
+    expect((fetchImpl.mock.calls[0]?.[1] as RequestInit).body).not.toContain('temperature');
     expect(result).toEqual({ verdict: 'no_update_needed', summary: 'Covered.', findings: [] });
   });
 
@@ -381,6 +382,18 @@ describe('OpenAI and documentation boundaries', () => {
       .toContain('"reasoning_effort":"low"');
     expect((fetchImpl.mock.calls as unknown as Array<[unknown, { body?: string }]>)[1]?.[1]?.body)
       .not.toContain('reasoning_effort');
+  });
+
+  it('reports bounded OpenAI API details', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({
+      error: { message: `unsupported parameter: temperature ${'x'.repeat(800)}` },
+    }, 400));
+
+    const error = await generateOpenAIReview('prompt', 'model', 'key', fetchImpl)
+      .catch((value: unknown) => value) as Error;
+
+    expect(error.message).toContain('unsupported parameter: temperature');
+    expect(error.message.length).toBeLessThan(750);
   });
 
   it('defaults the docs review model to gpt-5.4-mini', async () => {

--- a/src/docs-sync-review-cli.test.ts
+++ b/src/docs-sync-review-cli.test.ts
@@ -356,7 +356,8 @@ describe('OpenAI and documentation boundaries', () => {
         body: expect.stringContaining('"reasoning_effort":"low"'),
       }),
     );
-    expect((fetchImpl.mock.calls[0]?.[1] as RequestInit).body).not.toContain('temperature');
+    const calls = fetchImpl.mock.calls as unknown as Array<[unknown, RequestInit]>;
+    expect(calls[0]?.[1].body).not.toContain('temperature');
     expect(result).toEqual({ verdict: 'no_update_needed', summary: 'Covered.', findings: [] });
   });
 

--- a/src/generate-release-notes-cli.test.ts
+++ b/src/generate-release-notes-cli.test.ts
@@ -170,7 +170,8 @@ describe('runGenerateReleaseNotes', () => {
     const error = await generateOpenAIReleaseNotes('prompt', 'gpt-test', 'key', fetchImpl)
       .catch((value: unknown) => value) as Error;
 
-    const body = (fetchImpl.mock.calls[0]?.[1] as RequestInit).body as string;
+    const calls = fetchImpl.mock.calls as unknown as Array<[unknown, RequestInit]>;
+    const body = calls[0]?.[1].body as string;
     expect(body).not.toContain('temperature');
     expect(error.message).toContain('unsupported parameter: temperature');
     expect(error.message.length).toBeLessThan(750);

--- a/src/generate-release-notes-cli.test.ts
+++ b/src/generate-release-notes-cli.test.ts
@@ -4,7 +4,11 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
 import type { ReleaseContext } from './release-notes.js';
-import { loadReleaseContext, runGenerateReleaseNotes } from '../scripts/generate-release-notes.js';
+import {
+  generateOpenAIReleaseNotes,
+  loadReleaseContext,
+  runGenerateReleaseNotes,
+} from '../scripts/generate-release-notes.js';
 
 function createIo() {
   let stdout = '';
@@ -38,15 +42,15 @@ describe('runGenerateReleaseNotes', () => {
     });
   });
 
-  it('exits 0 and leaves stdout empty when OPENAI_API_KEY is missing', async () => {
+  it('fails when OPENAI_API_KEY is missing', async () => {
     const { io, read } = createIo();
 
     const exitCode = await runGenerateReleaseNotes(['node', 'script', 'v0.0.0'], {}, {}, io);
 
-    expect(exitCode).toBe(0);
+    expect(exitCode).toBe(1);
     expect(read()).toEqual({
       stdout: '',
-      stderr: 'OPENAI_API_KEY is not set; leaving release-please notes unchanged.\n',
+      stderr: 'OPENAI_API_KEY is required to generate release notes.\n',
     });
   });
 
@@ -131,14 +135,14 @@ describe('runGenerateReleaseNotes', () => {
       io,
     );
 
-    expect(exitCode).toBe(0);
+    expect(exitCode).toBe(1);
     expect(read()).toEqual({
       stdout: '',
-      stderr: '',
+      stderr: 'OpenAI release notes failed: OpenAI returned no usable release notes.\n',
     });
   });
 
-  it('swallows generator errors and keeps release-please notes intact', async () => {
+  it('fails when release-note generation fails', async () => {
     const { io, read } = createIo();
     const loadContext = vi.fn(async () => {
       throw new Error('gh timed out');
@@ -151,11 +155,25 @@ describe('runGenerateReleaseNotes', () => {
       io,
     );
 
-    expect(exitCode).toBe(0);
+    expect(exitCode).toBe(1);
     expect(read()).toEqual({
       stdout: '',
       stderr: 'OpenAI release notes failed: gh timed out\n',
     });
+  });
+
+  it('uses a reasoning-compatible OpenAI request and reports bounded API details', async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      error: { message: `unsupported parameter: temperature ${'x'.repeat(800)}` },
+    }), { status: 400, headers: { 'content-type': 'application/json' } }));
+
+    const error = await generateOpenAIReleaseNotes('prompt', 'gpt-test', 'key', fetchImpl)
+      .catch((value: unknown) => value) as Error;
+
+    const body = (fetchImpl.mock.calls[0]?.[1] as RequestInit).body as string;
+    expect(body).not.toContain('temperature');
+    expect(error.message).toContain('unsupported parameter: temperature');
+    expect(error.message.length).toBeLessThan(750);
   });
 
   it('updates the matching changelog entry from an existing notes file', async () => {
@@ -257,11 +275,11 @@ describe('runGenerateReleaseNotes', () => {
     expect(gh).toHaveBeenCalledWith(['pr', 'diff', '42', '--repo', 'acme/webcmd']);
   });
 
-  it('keeps npm publish unblocked when enhanced release-note editing fails', () => {
+  it('requires enhanced release notes before publishing', () => {
     const workflowPath = fileURLToPath(new URL('../.github/workflows/release.yml', import.meta.url));
     const workflow = readFileSync(workflowPath, 'utf8');
 
-    expect(workflow.indexOf('- name: Publish to npm')).toBeLessThan(workflow.indexOf('- name: Update changelog with enhanced release notes'));
+    expect(workflow.indexOf('- name: Generate enhanced release notes')).toBeLessThan(workflow.indexOf('- name: Publish to npm'));
     expect(workflow).toContain('npm --silent run generate-release-notes -- --update-changelog');
     expect(workflow).toContain('git push origin "HEAD:${{ github.ref_name }}"');
     expect(workflow).toContain('release_title="$(sed -n');
@@ -269,7 +287,20 @@ describe('runGenerateReleaseNotes', () => {
     expect(workflow).toContain('release_body_file="$RUNNER_TEMP/release-body.md"');
     expect(workflow).toContain('release_edit_args+=(--title "$release_title")');
     expect(workflow).toContain('release_edit_args+=(--notes-file "$release_body_file")');
-    expect(workflow).toContain('if gh release edit "${{ steps.release.outputs.tag_name || inputs.publish_tag }}" "${release_edit_args[@]}"; then');
-    expect(workflow).toMatch(/Enhanced release notes could not be applied; keeping release-please notes\./);
+    expect(workflow).toContain('gh release edit "${{ steps.release.outputs.tag_name || inputs.publish_tag }}" "${release_edit_args[@]}"');
+    expect(workflow).not.toMatch(/keeping release-please notes/i);
+  });
+
+  it('keeps changelog versions unique and contiguous', () => {
+    const changelogPath = fileURLToPath(new URL('../CHANGELOG.md', import.meta.url));
+    const packagePath = fileURLToPath(new URL('../package.json', import.meta.url));
+    const changelog = readFileSync(changelogPath, 'utf8');
+    const packageVersion = JSON.parse(readFileSync(packagePath, 'utf8')).version as string;
+    const versions = [...changelog.matchAll(/^## \[?(\d+\.\d+\.\d+)\]?/gm)].map((match) => match[1]!);
+    const links = [...changelog.matchAll(/^## \[(\d+\.\d+\.\d+)\]\([^\n]*compare\/webcmd-v(\d+\.\d+\.\d+)\.\.\.webcmd-v\1\)/gm)];
+
+    expect(versions[0]).toBe(packageVersion);
+    expect(new Set(versions).size).toBe(versions.length);
+    links.forEach((match) => expect(versions[versions.indexOf(match[1]!)+1]).toBe(match[2]));
   });
 });


### PR DESCRIPTION
## Summary
- make OpenAI release-note generation fail closed before npm publishing
- remove unsupported reasoning-model temperature parameters and surface bounded API errors
- repair the 0.6.0-0.7.0 changelog history and add continuity coverage
- preserve docs-sync review as advisory while fixing its OpenAI request

## Test plan
- `npx vitest run --project unit src/generate-release-notes-cli.test.ts src/docs-sync-review-cli.test.ts`