### PR TITLE
fix(browser): keep background Chromium profile alive

### DIFF
--- a/src/browser/runtime/local-cloak/darwin-background-launch.test.ts
+++ b/src/browser/runtime/local-cloak/darwin-background-launch.test.ts
@@ -47,6 +47,7 @@ describe('launchDarwinBackgroundPersistentContext', () => {
       '--password-store=basic',
       '--use-mock-keychain',
       '--disable-popup-blocking',
+      '--disable-features=DestroyProfileOnBrowserClose',
       '--user-data-dir=/tmp/cloak profile',
       '--remote-debugging-address=127.0.0.1',
       '--remote-debugging-port=0',

--- a/src/browser/runtime/local-cloak/darwin-background-launch.ts
+++ b/src/browser/runtime/local-cloak/darwin-background-launch.ts
@@ -137,6 +137,7 @@ export async function launchDarwinBackgroundPersistentContext(
       '--password-store=basic',
       '--use-mock-keychain',
       '--disable-popup-blocking',
+      '--disable-features=DestroyProfileOnBrowserClose',
       `--user-data-dir=${options.userDataDir}`,
       '--remote-debugging-address=127.0.0.1',
       '--remote-debugging-port=0',


### PR DESCRIPTION
## Description

Prevent macOS background Cloak Chromium from crashing with `EXC_BREAKPOINT / SIGTRAP` after `webcmd doctor` closes its probe window.

The background launcher bypasses Playwright defaults, so `DestroyProfileOnBrowserClose` remained enabled while Webcmd kept a hidden CDP target alive. This disables that feature in the macOS background launch arguments and tests the emitted `/usr/bin/open` argument.

Related issue: None

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Maintenance / refactor

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Adapter Notes

- [ ] I updated an existing adapter command
- [ ] I added a new adapter command
- [ ] I updated the adapter manifest/examples
- [ ] I ran adapter verification

## Screenshots / Output

- Focused regression: 6 passed
- Full suite: 5,550 passed, 56 skipped
- `npm run build`: passed
- Live macOS `webcmd doctor`: green; Chromium remained alive for 8 seconds after completion; no crash report generated