### PR TITLE
fix(browser): isolate persistent session pages

### DIFF
--- a/src/browser/run/playwright-transport.ts
+++ b/src/browser/run/playwright-transport.ts
@@ -291,6 +291,7 @@ function scopedBrowser(browser: object, context: object): object {
   let proxy: object;
   proxy = new Proxy(browser, {
     get(target, property) {
+      if (property === '_defaultContext') return Reflect.get(target, property, target) ? context : undefined;
       if (property === 'contexts') return () => (
         Reflect.get(target, '_defaultContext', target) ? [] : [context]
       );

--- a/src/browser/run/runner.test.ts
+++ b/src/browser/run/runner.test.ts
@@ -453,6 +453,37 @@ afterAll(async () => {
     }
   });
 
+  it('hides sibling Session pages in a persistent context', async () => {
+    const userDataDir = fs.mkdtempSync('/tmp/webcmd-persistent-browser-run-');
+    const persistent = await chromium.launchPersistentContext(userDataDir, { headless: true });
+    try {
+      const owned = persistent.pages()[0] ?? await persistent.newPage();
+      const sibling = await persistent.newPage();
+      await owned.goto('data:text/plain,owned');
+      await sibling.goto('data:text/plain,sibling');
+      const persistentBrowser = persistent.browser();
+      if (!persistentBrowser) throw new Error('persistent browser missing');
+
+      const output = await runBrowserProgram({
+        browser: persistentBrowser,
+        context: persistent,
+        page: owned,
+        pageId: 'persistent-page',
+        pages: () => [owned],
+        createPage: () => persistent.newPage(),
+        onPage(listener) {
+          persistent.on('page', listener);
+          return () => persistent.off('page', listener);
+        },
+      }, 'return context.pages().map(page => page.url());');
+
+      expect(output.result).toEqual([owned.url()]);
+    } finally {
+      await persistent.close();
+      fs.rmSync(userDataDir, { recursive: true, force: true });
+    }
+  });
+
   it('waits for requests and responses', async () => {
     const output = await run(`
       const requestPromise = page.waitForRequest('**/data');


### PR DESCRIPTION
## Summary

- route Playwright dispatcher access to a persistent browser default context through the Session-scoped context proxy
- prevent browser run from exposing pages owned by sibling Sessions
- add a focused persistent-context regression test

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed

## Verification

- npm test — 5,590 passed, 1 skipped
- npm run typecheck
- npm run build
- browser-run unit suite — 56 passed