### PR TITLE
feat(cli): add -f/--format to webcmd daemon status

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1857,10 +1857,15 @@ cli({
   const daemonCmd = program.command('daemon').description('Manage the webcmd daemon');
   // Snapshot before applyRootSubcommandSummaries() rewrites .description() to a child-name listing.
   const originalDaemonDescription = daemonCmd.description();
-  daemonCmd
+  const daemonStatusCmd = daemonCmd
     .command('status')
     .description('Show daemon status')
-    .action(async () => { await daemonStatus(); });
+    .option('-f, --format <fmt>', OUTPUT_FORMAT_HELP, 'table');
+  daemonStatusCmd.action(async (opts) => {
+    const fmt = resolveOutputFormat(opts.format);
+    if (fmt === null) return;
+    await daemonStatus(fmt);
+  });
   daemonCmd
     .command('stop')
     .description('Stop the daemon')

--- a/src/commands/daemon.test.ts
+++ b/src/commands/daemon.test.ts
@@ -105,6 +105,35 @@ describe('daemonStatus', () => {
 
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('fake connected'));
   });
+
+  it('renders a structured envelope for -f json when running (#175)', async () => {
+    fetchDaemonStatusMock.mockResolvedValue({
+      ok: true,
+      pid: 12345,
+      uptime: 60,
+      daemonVersion: PKG_VERSION,
+      runtimeConnected: true,
+      runtimeName: 'fake',
+      pending: 0,
+      memoryMB: 64,
+      port: 9777,
+    });
+
+    await daemonStatus('json');
+
+    const printed = stdoutSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+    const data = JSON.parse(printed);
+    expect(data).toMatchObject({ running: true, pid: 12345, port: 9777 });
+  });
+
+  it('renders a structured envelope for -f json when not running (#175)', async () => {
+    fetchDaemonStatusMock.mockResolvedValue(null);
+
+    await daemonStatus('json');
+
+    const printed = stdoutSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+    expect(JSON.parse(printed)).toEqual({ running: false });
+  });
 });
 
 // ────────────────────────────────────────────────────────────────────

--- a/src/commands/daemon.test.ts
+++ b/src/commands/daemon.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import yaml from 'js-yaml';
 
 const {
   fetchDaemonStatusMock,
@@ -133,6 +134,35 @@ describe('daemonStatus', () => {
 
     const printed = stdoutSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
     expect(JSON.parse(printed)).toEqual({ running: false });
+  });
+
+  it('renders a structured envelope for -f yaml when running (#175)', async () => {
+    fetchDaemonStatusMock.mockResolvedValue({
+      ok: true,
+      pid: 12345,
+      uptime: 60,
+      daemonVersion: PKG_VERSION,
+      runtimeConnected: true,
+      runtimeName: 'fake',
+      pending: 0,
+      memoryMB: 64,
+      port: 9777,
+    });
+
+    await daemonStatus('yaml');
+
+    const printed = stdoutSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+    const data = yaml.load(printed) as Record<string, unknown>;
+    expect(data).toMatchObject({ running: true, pid: 12345, port: 9777 });
+  });
+
+  it('renders a structured envelope for -f yaml when not running (#175)', async () => {
+    fetchDaemonStatusMock.mockResolvedValue(null);
+
+    await daemonStatus('yaml');
+
+    const printed = stdoutSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+    expect(yaml.load(printed)).toEqual({ running: false });
   });
 });
 

--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -11,9 +11,14 @@ import { formatDuration } from '../download/progress.js';
 import { log } from '../logger.js';
 import { PKG_VERSION } from '../version.js';
 import { formatDaemonVersion, isDaemonStale } from '../browser/daemon-version.js';
+import { render } from '../output.js';
 
-export async function daemonStatus(): Promise<void> {
+export async function daemonStatus(fmt: string = 'table'): Promise<void> {
   const status = await fetchDaemonStatus();
+  if (fmt !== 'table') {
+    await render(status ? { running: true, ...status } : { running: false }, { fmt });
+    return;
+  }
   if (!status) {
     console.log('Daemon: not running');
     return;


### PR DESCRIPTION




## Summary

Partial slice of #175.

`daemon status` fetches a fully-typed `DaemonStatus` object but only
ever printed it as hand-written text lines, rejecting `-f` entirely.
Agents/scripts polling daemon health had no structured way to read it.

## Changes

- `daemonStatus()` now takes an optional `fmt` (default `table`,
  unchanged text output).
- Other formats render a `{ running, ...status }` envelope through the
  shared output path. `running` distinguishes the "daemon not
  reachable" case, which previously had no structured representation
  at all (`fetchDaemonStatus` returns `null` rather than a partial
  status object).
- CLI registration adds `-f, --format` to `daemon status`.

## Scope note

Same slice-of-#175 approach as the `validate` PR — one complete,
tested command rather than a partial pass across the full list in the
issue.

## Test plan

- [x] New cases in `src/commands/daemon.test.ts`: `-f json` when
      running and when not running.
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run --project unit src/commands/daemon.test.ts` — 16/16 pass.
- [x] Manual smoke: `webcmd daemon status -f json` / `webcmd daemon status`.
