### PR TITLE
feat(cli): add -f/--format to webcmd profile list

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -17,6 +17,7 @@ import {
 } from './command-presentation.js';
 import { parseOutputFormat } from './command-surface.js';
 import { render as renderOutput } from './output.js';
+import { saveProfileConfig } from './browser/profile.js';
 import * as pluginModule from './plugin.js';
 import * as discoveryModule from './discovery.js';
 
@@ -1721,6 +1722,62 @@ describe('profile list', () => {
     expect(output).not.toContain(`Browser ${'Bridge'}`);
     expect(output).not.toContain(`Webcmd ${'extension'}`);
     expect(output).not.toContain('webcmd daemon restart');
+  });
+
+  it('-f json renders an empty array instead of prose when no profiles are active (#175)', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        pid: 123,
+        uptime: 1,
+        daemonVersion: PKG_VERSION,
+        runtimeConnected: false,
+        runtimeName: 'Cloak',
+        profiles: [],
+        pending: 0,
+        memoryMB: 20,
+        port: 9777,
+      }),
+    } as Response);
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'webcmd', 'profile', 'list', '-f', 'json']);
+
+    const output = stdoutSpy.mock.calls.flat().join('\n');
+    expect(JSON.parse(output)).toEqual([]);
+  });
+
+  it('-f json renders connected and disconnected-saved profiles as structured rows (#175)', async () => {
+    saveProfileConfig({
+      version: 1,
+      defaultContextId: 'work',
+      aliases: { work: 'work', archived: 'gone' },
+    });
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        pid: 123,
+        uptime: 1,
+        daemonVersion: PKG_VERSION,
+        runtimeConnected: true,
+        runtimeName: 'Cloak',
+        profiles: [{ contextId: 'work', runtimeConnected: true, runtimeVersion: '1.2.3', pending: 0 }],
+        pending: 0,
+        memoryMB: 20,
+        port: 9777,
+      }),
+    } as Response);
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'webcmd', 'profile', 'list', '-f', 'json']);
+
+    const output = stdoutSpy.mock.calls.flat().join('\n');
+    expect(JSON.parse(output)).toEqual([
+      { contextId: 'work', alias: 'work', default: true, connected: true, runtimeVersion: '1.2.3' },
+      { contextId: 'gone', alias: 'archived', default: false, connected: false, runtimeVersion: null },
+    ]);
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1775,54 +1775,90 @@ cli({
   // Snapshot before applyRootSubcommandSummaries() rewrites .description() to a child-name listing.
   const originalProfileDescription = profileCmd.description();
 
-  profileCmd
+  const profileListCmd = profileCmd
     .command('list')
     .description('List Chrome and Chromium profiles available through the Cloak runtime')
-    .action(async () => {
-      const status = await fetchDaemonStatus();
-      const config = loadProfileConfig();
-      const profiles = status?.profiles ?? [];
-      if (!status) {
-        console.log('Daemon is not running. Run webcmd doctor after opening Chrome.');
-        return;
-      }
-      if (isDaemonStale(status, PKG_VERSION) || !Array.isArray(status.profiles)) {
-        console.log(`Daemon ${formatDaemonVersion(status)} is stale for CLI v${PKG_VERSION}.`);
-        console.log('Run: webcmd daemon restart');
-        return;
-      }
-      if (profiles.length === 0) {
-        console.log('No Cloak runtime profiles are active.');
-        console.log('Run a browser-backed command or webcmd <site> login to create one.');
-        return;
-      }
+    .option('-f, --format <fmt>', OUTPUT_FORMAT_HELP, 'table');
+  profileListCmd.action(async (opts) => {
+    const fmt = resolveOutputFormat(opts.format);
+    if (fmt === null) return;
+    const status = await fetchDaemonStatus();
+    const config = loadProfileConfig();
+    const profiles = status?.profiles ?? [];
+    if (!status) {
+      if (fmt !== 'table') { renderOutput([], { fmt }); return; }
+      console.log('Daemon is not running. Run webcmd doctor after opening Chrome.');
+      return;
+    }
+    if (isDaemonStale(status, PKG_VERSION) || !Array.isArray(status.profiles)) {
+      if (fmt !== 'table') { renderOutput([], { fmt }); return; }
+      console.log(`Daemon ${formatDaemonVersion(status)} is stale for CLI v${PKG_VERSION}.`);
+      console.log('Run: webcmd daemon restart');
+      return;
+    }
+    if (profiles.length === 0) {
+      if (fmt !== 'table') { renderOutput([], { fmt }); return; }
+      console.log('No Cloak runtime profiles are active.');
+      console.log('Run a browser-backed command or webcmd <site> login to create one.');
+      return;
+    }
 
-      const knownContextIds = new Set(profiles.map((profile) => profile.contextId));
-      console.log('Available Cloak profiles');
+    const knownContextIds = new Set(profiles.map((profile) => profile.contextId));
+    const disconnectedAliases = Object.entries(config.aliases)
+      .filter(([, contextId]) => !knownContextIds.has(contextId));
+
+    if (fmt !== 'table') {
+      // Aligns with the hosted `profile list` row shape (`default`); local rows also
+      // carry `connected`/`runtimeVersion` since Cloak profiles are live runtime
+      // connections, not persisted Cloud records.
+      const rows = profiles.map((profile) => ({
+        contextId: profile.contextId,
+        alias: aliasForContextId(config, profile.contextId) ?? null,
+        default: config.defaultContextId === profile.contextId,
+        connected: true,
+        runtimeVersion: profile.runtimeVersion ?? null,
+      }));
+      const shown = new Set<string>();
+      for (const [alias, contextId] of disconnectedAliases) {
+        shown.add(contextId);
+        rows.push({
+          contextId,
+          alias,
+          default: config.defaultContextId === contextId,
+          connected: false,
+          runtimeVersion: null,
+        });
+      }
+      if (config.defaultContextId && !shown.has(config.defaultContextId) && !knownContextIds.has(config.defaultContextId)) {
+        rows.push({ contextId: config.defaultContextId, alias: null, default: true, connected: false, runtimeVersion: null });
+      }
+      renderOutput(rows, { fmt });
+      return;
+    }
+
+    console.log('Available Cloak profiles');
+    console.log();
+    for (const profile of profiles) {
+      const alias = aliasForContextId(config, profile.contextId);
+      const defaultMark = config.defaultContextId === profile.contextId ? ' default' : '';
+      const aliasText = alias ? ` ${alias}` : '';
+      const version = profile.runtimeVersion ? ` v${profile.runtimeVersion}` : ' version unknown';
+      console.log(`  ${profile.contextId}${aliasText}${defaultMark} — connected${version}`);
+    }
+
+    if (disconnectedAliases.length > 0 || (config.defaultContextId && !knownContextIds.has(config.defaultContextId))) {
       console.log();
-      for (const profile of profiles) {
-        const alias = aliasForContextId(config, profile.contextId);
-        const defaultMark = config.defaultContextId === profile.contextId ? ' default' : '';
-        const aliasText = alias ? ` ${alias}` : '';
-        const version = profile.runtimeVersion ? ` v${profile.runtimeVersion}` : ' version unknown';
-        console.log(`  ${profile.contextId}${aliasText}${defaultMark} — connected${version}`);
+      console.log('Disconnected saved profiles:');
+      const shown = new Set<string>();
+      for (const [alias, contextId] of disconnectedAliases) {
+        shown.add(contextId);
+        console.log(`  ${contextId} ${alias} — not connected`);
       }
-
-      const disconnectedAliases = Object.entries(config.aliases)
-        .filter(([, contextId]) => !knownContextIds.has(contextId));
-      if (disconnectedAliases.length > 0 || (config.defaultContextId && !knownContextIds.has(config.defaultContextId))) {
-        console.log();
-        console.log('Disconnected saved profiles:');
-        const shown = new Set<string>();
-        for (const [alias, contextId] of disconnectedAliases) {
-          shown.add(contextId);
-          console.log(`  ${contextId} ${alias} — not connected`);
-        }
-        if (config.defaultContextId && !shown.has(config.defaultContextId) && !knownContextIds.has(config.defaultContextId)) {
-          console.log(`  ${config.defaultContextId} — default, not connected`);
-        }
+      if (config.defaultContextId && !shown.has(config.defaultContextId) && !knownContextIds.has(config.defaultContextId)) {
+        console.log(`  ${config.defaultContextId} — default, not connected`);
       }
-    });
+    }
+  });
 
   profileCmd
     .command('rename')


### PR DESCRIPTION

## Summary

Partial slice of #175.

Local `profile list` rejected `-f` entirely and only printed prose,
while hosted `profile list` already supports `-f json|yaml|csv|md`
(`src/hosted/runner.ts`) — the same command name behaving differently
between modes with no indication why. #175 explicitly calls out
"align local profile list with hosted profile-list formatting."

## Changes

- Add `-f, --format` (default `table`, prose output unchanged).
- Other formats render one row per profile through the shared output
  path. Row shape aligns with hosted's where the concept overlaps
  (`default`), plus locally-meaningful fields hosted doesn't have
  (`connected`, `runtimeVersion`) since Cloak profiles are live
  runtime connections, not persisted Cloud records.
- Disconnected saved aliases (already shown in the prose output) are
  included as `connected: false` rows so the structured view doesn't
  silently drop information the text view shows.
- The daemon-not-running/stale/no-profiles branches render `[]` for
  non-table formats rather than swallowing output, mirroring the
  existing `adapter status` empty-list convention.

## Scope note

Same slice-of-#175 approach as the `validate` and `daemon status` PRs.

## Test plan

- [x] New cases in `src/cli.test.ts`: `-f json` with no profiles
      (→ `[]`), and with a connected profile + a disconnected saved
      alias + a disconnected default (→ structured rows).
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run --project unit src/cli.test.ts` — 104/104 pass.
- [x] Manual smoke: `webcmd profile list -f json` / `webcmd profile list`.
