### PR TITLE
fix(browser): default every daemon command to a background window

### DIFF
--- a/src/browser/runtime/local-cloak/provider.test.ts
+++ b/src/browser/runtime/local-cloak/provider.test.ts
@@ -142,6 +142,9 @@ function makeProviderWithFakePage(initialViewport: { width: number; height: numb
   const provider = new LocalCloakRuntimeProvider({
     baseDir: '/tmp/webcmd-test',
     launchPersistentContext: vi.fn().mockResolvedValue(context),
+    // Commands now default to background, which routes a darwin launch through
+    // the background launcher; the fake context stands in for both.
+    launchBackgroundPersistentContext: vi.fn().mockResolvedValue(context),
   });
   return { provider, browser, page: pages[0], pages, context, cdpSession, pageCdpSessions };
 }
@@ -226,6 +229,30 @@ describe('LocalCloakRuntimeProvider', () => {
     });
     expect(result).toMatchObject({ id: 'cmd-1', ok: true, page: expect.any(String) });
     expect(page.goto).toHaveBeenCalledWith('https://example.com/', expect.objectContaining({ waitUntil: 'load' }));
+  });
+
+  it.each([
+    { label: 'omits windowMode', windowMode: undefined, background: true, focus: false },
+    { label: 'asks for foreground', windowMode: 'foreground' as const, background: false, focus: true },
+  ])('opens a window tab per the command that $label', async ({ windowMode, background, focus }) => {
+    const { provider, cdpSession } = makeProviderWithFakePage();
+    for (const session of ['first', 'second']) {
+      await provider.dispatch({
+        id: `nav-${session}`,
+        action: 'navigate',
+        session,
+        surface: 'browser',
+        url: `https://${session}.example/`,
+        profileId: 'default',
+        ...(windowMode ? { windowMode } : {}),
+      });
+    }
+
+    const windowTargets = cdpSession.send.mock.calls
+      .filter(([command, params]) => command === 'Target.createTarget' && !(params as { hidden?: boolean })?.hidden)
+      .map(([, params]) => params as { background?: boolean; focus?: boolean });
+    expect(windowTargets.length).toBeGreaterThan(0);
+    for (const params of windowTargets) expect(params).toMatchObject({ background, focus });
   });
 
   it("maps waitUntil 'none' to a commit-only navigation wait", async () => {
@@ -855,7 +882,7 @@ describe('LocalCloakRuntimeProvider', () => {
 
     await expect(provider.dispatch({ id: 'select', action: 'tabs', op: 'select', session: 'work', surface: 'browser', page: created.page, profileId: 'default' }))
       .resolves.toMatchObject({ id: 'select', ok: true, page: created.page, data: { selected: true } });
-    expect(pages[0].bringToFront).toHaveBeenCalled();
+    expect(pages[0].bringToFront).not.toHaveBeenCalled();
 
     await expect(provider.dispatch({ id: 'close', action: 'tabs', op: 'close', session: 'work', surface: 'browser', page: created.page, profileId: 'default' }))
       .resolves.toMatchObject({ id: 'close', ok: true, data: { closed: created.page } });
@@ -896,7 +923,7 @@ describe('LocalCloakRuntimeProvider', () => {
     expect(pages[0].bringToFront).not.toHaveBeenCalled();
   });
 
-  it('brings bound tabs to front by default', async () => {
+  it('does not bring bound tabs to front by default', async () => {
     const { provider, pages } = makeProviderWithFakePage();
     const created = await provider.dispatch({ id: 'new', action: 'tabs', op: 'new', session: 'source', surface: 'browser', url: 'https://second.example/', profileId: 'default' });
 

--- a/src/browser/runtime/local-cloak/provider.ts
+++ b/src/browser/runtime/local-cloak/provider.ts
@@ -11,6 +11,7 @@ import {
 export interface LocalCloakRuntimeProviderOptions {
   baseDir?: string;
   launchPersistentContext?: LaunchPersistentContext;
+  launchBackgroundPersistentContext?: LaunchPersistentContext;
 }
 
 export class LocalCloakRuntimeProvider implements BrowserRuntimeProvider {
@@ -91,7 +92,13 @@ export class LocalCloakRuntimeProvider implements BrowserRuntimeProvider {
     return { closed: closedCount > 0, alreadyIdle: closedCount === 0, session: record.id };
   }
 
-  async dispatch(command: BrowserRuntimeCommand, signal?: AbortSignal): Promise<BrowserRuntimeResult> {
+  async dispatch(rawCommand: BrowserRuntimeCommand, signal?: AbortSignal): Promise<BrowserRuntimeResult> {
+    // Every dispatched command runs in the background unless the caller asked
+    // for a window explicitly, so no command steals focus by default. Session
+    // handoff bypasses dispatch and still foregrounds through foregroundSession.
+    const command: BrowserRuntimeCommand = rawCommand.windowMode
+      ? rawCommand
+      : { ...rawCommand, windowMode: 'background' };
     const key = this.commandQueueKey(command);
     const previous = this.sessionQueues.get(key) ?? Promise.resolve();
     let release!: () => void;

--- a/src/cli-argv-preprocess.test.ts
+++ b/src/cli-argv-preprocess.test.ts
@@ -14,9 +14,9 @@ describe('rejectPositionalBrowserSessionArgv', () => {
 });
 
 describe('rejectPositionalBrowserSessionArgv details', () => {
-  it('keeps browser subcommands and hoists trailing --window', () => {
-    expect(rejectPositionalBrowserSessionArgv(['--session', 'session_a', 'browser', 'state', '--window', 'background'])).toEqual([
-      '--session', 'session_a', 'browser', '--window', 'background', 'state',
+  it('leaves a recognised browser subcommand and its options in place', () => {
+    expect(rejectPositionalBrowserSessionArgv(['--session', 'session_a', 'browser', 'snapshot', '--snapshot-mode', 'act'])).toEqual([
+      '--session', 'session_a', 'browser', 'snapshot', '--snapshot-mode', 'act',
     ]);
   });
 

--- a/src/cli-argv-preprocess.ts
+++ b/src/cli-argv-preprocess.ts
@@ -75,10 +75,7 @@ export function rejectPositionalBrowserSessionArgv(argv: readonly string[]): str
   const commandIndex = findRootCommandIndex(result);
   if (result[commandIndex] !== 'browser') return result;
   const candidate = result[commandIndex + 1];
-  if (!candidate || candidate.startsWith('-') || BROWSER_SUBCOMMAND_NAMES.has(candidate)) {
-    hoistBrowserWindowOption(result, commandIndex + 1);
-    return result;
-  }
+  if (!candidate || candidate.startsWith('-') || BROWSER_SUBCOMMAND_NAMES.has(candidate)) return result;
   const replacement = [
     ...result.slice(0, commandIndex),
     '--session', candidate,
@@ -120,33 +117,6 @@ function findRootCommandIndex(argv: readonly string[]): number {
     index += token.includes('=') || !ROOT_VALUE_FLAGS.has(token) ? 1 : 2;
   }
   return index;
-}
-
-/**
- * Move one trailing `--window <mode>` / `--window=<mode>` from after the browser
- * subcommand to just before it. Stops at `--` so literal browser arguments are
- * untouched. Mutates `argv` in place.
- */
-function hoistBrowserWindowOption(argv: string[], fromIndex: number): void {
-  const subcommandIdx = argv.findIndex((tok, idx) => idx >= fromIndex && BROWSER_SUBCOMMAND_NAMES.has(tok));
-  if (subcommandIdx === -1) return;
-
-  for (let i = subcommandIdx + 1; i < argv.length; i += 1) {
-    const tok = argv[i];
-    if (tok === '--') return;
-    if (tok.startsWith('--window=')) {
-      const removed = argv.splice(i, 1);
-      argv.splice(subcommandIdx, 0, ...removed);
-      return;
-    }
-    if (tok === '--window') {
-      const value = argv[i + 1];
-      if (value === undefined || value === '--') return;
-      const removed = argv.splice(i, 2);
-      argv.splice(subcommandIdx, 0, ...removed);
-      return;
-    }
-  }
 }
 
 /**

--- a/src/pipeline/steps/transform.ts
+++ b/src/pipeline/steps/transform.ts
@@ -53,14 +53,38 @@ export async function stepFilter(_page: IPage | null, params: unknown, data: unk
   return data.filter((item, i) => evalExpr(String(params), { args, item, index: i }));
 }
 
+/** Parse a sort key as a number, or null when it is not one. */
+function sortableNumber(value: unknown): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value !== 'string' || value.trim() === '') return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Compare two sort keys.
+ *
+ * Numbers are compared numerically rather than through the collator. ICU's
+ * `numeric` collation only understands runs of digits, so it splits a decimal
+ * at the separator and its ordering of values like "9.5" against "10" varies by
+ * platform and locale — Windows CI disagreed with macOS/Linux on exactly that
+ * pair. Everything else falls back to a locale-pinned natural compare.
+ */
+function compareSortKeys(left: unknown, right: unknown): number {
+  const leftNumber = sortableNumber(left);
+  const rightNumber = sortableNumber(right);
+  if (leftNumber !== null && rightNumber !== null) {
+    return leftNumber === rightNumber ? 0 : leftNumber < rightNumber ? -1 : 1;
+  }
+  return String(left ?? '').localeCompare(String(right ?? ''), 'en', { numeric: true });
+}
+
 export async function stepSort(_page: IPage | null, params: unknown, data: unknown, _args: Record<string, unknown>): Promise<unknown> {
   if (!Array.isArray(data)) return data;
   const key = isRecord(params) ? String(params.by ?? '') : String(params);
   const reverse = isRecord(params) ? params.order === 'desc' : false;
   return [...data].sort((a, b) => {
-    const left = isRecord(a) ? a[key] : undefined;
-    const right = isRecord(b) ? b[key] : undefined;
-    const cmp = String(left ?? '').localeCompare(String(right ?? ''), undefined, { numeric: true });
+    const cmp = compareSortKeys(isRecord(a) ? a[key] : undefined, isRecord(b) ? b[key] : undefined);
     return reverse ? -cmp : cmp;
   });
 }

--- a/src/pipeline/steps/transform.ts
+++ b/src/pipeline/steps/transform.ts
@@ -64,16 +64,19 @@ function sortableNumber(value: unknown): number | null {
 /**
  * Compare two sort keys.
  *
- * Numbers are compared numerically rather than through the collator. ICU's
- * `numeric` collation only understands runs of digits, so it splits a decimal
+ * Columns whose non-empty values are all numbers are compared numerically.
+ * ICU's `numeric` collation only understands runs of digits, so it splits a decimal
  * at the separator and its ordering of values like "9.5" against "10" varies by
  * platform and locale — Windows CI disagreed with macOS/Linux on exactly that
  * pair. Everything else falls back to a locale-pinned natural compare.
  */
-function compareSortKeys(left: unknown, right: unknown): number {
-  const leftNumber = sortableNumber(left);
-  const rightNumber = sortableNumber(right);
-  if (leftNumber !== null && rightNumber !== null) {
+function compareSortKeys(left: unknown, right: unknown, numericColumn: boolean): number {
+  if (numericColumn) {
+    const leftNumber = sortableNumber(left);
+    const rightNumber = sortableNumber(right);
+    if (leftNumber === null || rightNumber === null) {
+      return leftNumber === rightNumber ? 0 : leftNumber === null ? -1 : 1;
+    }
     return leftNumber === rightNumber ? 0 : leftNumber < rightNumber ? -1 : 1;
   }
   return String(left ?? '').localeCompare(String(right ?? ''), 'en', { numeric: true });
@@ -83,8 +86,11 @@ export async function stepSort(_page: IPage | null, params: unknown, data: unkno
   if (!Array.isArray(data)) return data;
   const key = isRecord(params) ? String(params.by ?? '') : String(params);
   const reverse = isRecord(params) ? params.order === 'desc' : false;
+  const keys = data.map((item) => isRecord(item) ? item[key] : undefined);
+  const numericColumn = keys.some((value) => sortableNumber(value) !== null)
+    && keys.every((value) => value == null || (typeof value === 'string' && value.trim() === '') || sortableNumber(value) !== null);
   return [...data].sort((a, b) => {
-    const cmp = compareSortKeys(isRecord(a) ? a[key] : undefined, isRecord(b) ? b[key] : undefined);
+    const cmp = compareSortKeys(isRecord(a) ? a[key] : undefined, isRecord(b) ? b[key] : undefined, numericColumn);
     return reverse ? -cmp : cmp;
   });
 }

--- a/src/pipeline/transform.test.ts
+++ b/src/pipeline/transform.test.ts
@@ -128,6 +128,18 @@ describe('stepSort', () => {
     expect((result as typeof data).map((r) => r.name)).toEqual(['B', 'C', 'A']);
   });
 
+  it('orders decimals by value, not by collation', async () => {
+    // ICU numeric collation splits "9.5" at the separator, so the ordering of
+    // this trio against "10" used to differ between Windows and macOS/Linux.
+    const data = [
+      { name: 'TEN', change: '10.0' },
+      { name: 'NINE', change: '9.5' },
+      { name: 'HUNDRED', change: '100.0' },
+    ];
+    const result = await stepSort(null, { by: 'change', order: 'desc' }, data, {});
+    expect((result as typeof data).map((r) => r.name)).toEqual(['HUNDRED', 'TEN', 'NINE']);
+  });
+
   it('handles missing fields gracefully', async () => {
     const data = [
       { name: 'A', value: '10' },

--- a/src/pipeline/transform.test.ts
+++ b/src/pipeline/transform.test.ts
@@ -140,6 +140,18 @@ describe('stepSort', () => {
     expect((result as typeof data).map((r) => r.name)).toEqual(['HUNDRED', 'TEN', 'NINE']);
   });
 
+  it('uses one comparison mode for a mixed column', async () => {
+    const expected = ['0x10', '1a', '2'];
+    for (const values of [
+      ['2', '0x10', '1a'],
+      ['2', '1a', '0x10'],
+      ['0x10', '2', '1a'],
+    ]) {
+      const result = await stepSort(null, 'value', values.map((value) => ({ value })), {});
+      expect((result as Array<{ value: string }>).map(({ value }) => value)).toEqual(expected);
+    }
+  });
+
   it('handles missing fields gracefully', async () => {
     const data = [
       { name: 'A', value: '10' },

--- a/tests/e2e/browser-run.test.ts
+++ b/tests/e2e/browser-run.test.ts
@@ -93,7 +93,7 @@ describe('browser run local lifecycle', () => {
     servers.push(fixture.server);
     const cacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'webcmd-browser-run-'));
     tempDirs.push(cacheDir);
-    const env = { WEBCMD_CACHE_DIR: cacheDir };
+    const env = { WEBCMD_CACHE_DIR: cacheDir, WEBCMD_CONFIG_DIR: cacheDir };
 
     const created = await runCliWithStdin(['session', 'create', '-f', 'json'], '', env);
     expect(created.code).toBe(0);

--- a/tests/e2e/browser-run.test.ts
+++ b/tests/e2e/browser-run.test.ts
@@ -94,9 +94,12 @@ describe('browser run local lifecycle', () => {
     const cacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'webcmd-browser-run-'));
     tempDirs.push(cacheDir);
     const env = { WEBCMD_CACHE_DIR: cacheDir };
-    const session = 'browser-run-lifecycle';
 
-    const first = await runCliWithStdin(['browser', session, 'run', '--stdin'], `
+    const created = await runCliWithStdin(['session', 'create', '-f', 'json'], '', env);
+    expect(created.code).toBe(0);
+    const session = parseJsonOutput(created.stdout).id as string;
+
+    const first = await runCliWithStdin(['--session', session, 'browser', 'run', '--stdin'], `
       globalThis.onlyThisRun = 'gone';
       await page.goto(${JSON.stringify(fixture.url)});
       await page.locator('#name').fill('Ada');
@@ -128,11 +131,11 @@ describe('browser run local lifecycle', () => {
     });
     expect(firstData.snapshotDiff).toContain('Ada');
 
-    const snapshot = await runCliWithStdin(['browser', session, 'snapshot', '--snapshot-mode', 'act'], '', env);
+    const snapshot = await runCliWithStdin(['--session', session, 'browser', 'snapshot', '--snapshot-mode', 'act'], '', env);
     expect(snapshot.code).toBe(0);
     expect(snapshot.stdout).toContain('Ada');
 
-    const second = await runCliWithStdin(['browser', session, 'run', '--stdin', '--no-snapshot-diff'], `
+    const second = await runCliWithStdin(['--session', session, 'browser', 'run', '--stdin', '--no-snapshot-diff'], `
       return {
         saved: await page.locator('#status').innerText(),
         variable: typeof globalThis.onlyThisRun,
@@ -145,20 +148,20 @@ describe('browser run local lifecycle', () => {
     });
     expect(secondData).not.toHaveProperty('snapshotDiff');
 
-    const tabs = await runCliWithStdin(['browser', session, 'tabs'], '', env);
+    const tabs = await runCliWithStdin(['--session', session, 'browser', 'tabs'], '', env);
     expect(tabs.code).toBe(0);
     const popup = parseJsonOutput(tabs.stdout).find((tab: { title: string }) => tab.title === 'Popup receipt');
     expect(popup).toMatchObject({ id: expect.any(String) });
 
-    const bound = await runCliWithStdin(['browser', session, 'bind', '--page', popup.id], '', env);
+    const bound = await runCliWithStdin(['--session', session, 'browser', 'bind', '--page', popup.id], '', env);
     expect(bound.code).toBe(0);
     expect(parseJsonOutput(bound.stdout)).toMatchObject({ page: popup.id, title: 'Popup receipt' });
 
-    const closed = await runCliWithStdin(['browser', session, 'close'], '', env);
+    const closed = await runCliWithStdin(['--session', session, 'browser', 'close'], '', env);
     expect(closed.code).toBe(0);
     expect(parseJsonOutput(closed.stdout)).toMatchObject({ closed: true });
 
-    const tabsAfterClose = await runCliWithStdin(['browser', session, 'tabs'], '', env);
+    const tabsAfterClose = await runCliWithStdin(['--session', session, 'browser', 'tabs'], '', env);
     expect(tabsAfterClose.code).toBe(0);
     expect(parseJsonOutput(tabsAfterClose.stdout)).toEqual([]);
   }, 120_000);


### PR DESCRIPTION
## Description

**No command steals your focus anymore.** Run `webcmd browser ...` and Chromium stays behind whatever you're doing.

Four commits, independent, reviewable in order:

1. `provider.ts` — the fix (~9 lines)
2. `transform.ts` — unblocks Windows CI (unrelated, splittable)
3. `browser-run.test.ts` — repairs a dead e2e test (unrelated, splittable)
4. `cli-argv-preprocess.ts` — deletes dead code (root cause #196)

Related issue:

---

### 1. The fix — background by default

Focus behaviour was inconsistent across the three things webcmd does:

| Surface | Browser? | Before |
|---|---|---|
| Plugin/adapter commands | sometimes | background ✅ |
| `web fetch` | no | n/a — plain HTTP ✅ |
| `webcmd browser ...` | yes | **foreground** ❌ |

Raw browser commands never set `windowMode`. The Cloak runtime reads *unset* as foreground in three places:

- `createWindowPage` → `focus: windowMode !== 'background'`
- the `bringToFront()` guards in `selectPage` / `bindPage`
- the launch router — macOS `open -g` only engaged on an explicit `'background'`

**Fix:** default `windowMode` to `background` in `LocalCloakRuntimeProvider.dispatch`, the one entry point every browser action passes through.

```ts
const command: BrowserRuntimeCommand = rawCommand.windowMode
  ? rawCommand
  : { ...rawCommand, windowMode: 'background' };
```

**Why not in `session-manager.ts`, where the mechanism lives?** Tried it. Breaks 86 unit tests that construct the manager with only `launchPersistentContext` mocked — they'd all need a second mock injected, which mutes the darwin launch-routing signal those tests exist to catch. `dispatch` is the policy layer; the manager stays the mechanism.

**Auth handoff still foregrounds.** `startSessionHandoff` bypasses `dispatch` and calls `manager.foregroundSession` directly. That's the one path that must keep raising the window.

**Two intentional changes:** `browser tabs select` and `browser bind` no longer raise the window. Test names and assertions updated.

### How to force foreground

| | `--window foreground` | `WEBCMD_WINDOW=foreground` |
|---|---|---|
| Plugin/adapter commands | ✅ | ✅ |
| Raw `webcmd browser ...` | ❌ never existed | ✅ |

No new flag on raw browser commands: it would ripple through `command-catalog` → the generated `hosted-contract.json` → cloud contract → the in-flight cloud parity PR. The env var covers it. Worth its own PR later, after parity lands.

### 2. Windows CI — `stepSort` compared numbers as strings

`Plugin tests (windows-latest)` failed on `binance gainers`: expected `[HUNDRED, TEN, NINE]`, got `[HUNDRED, NINE, TEN]`.

Cause: `stepSort` ran every key through `localeCompare(..., { numeric: true })` with **no locale pinned**. ICU numeric collation only understands runs of digits — it splits `"9.5"` at the decimal point and compares the `9`. Ordering `"9.5"` against `"10"` therefore depends on the ICU build *and* the system locale. Windows disagreed with macOS/Linux on exactly that pair.

Fix: compare numerically when both sides parse as finite numbers; pin the fallback collator to `'en'`. Regression test pins the `10.0 / 9.5 / 100.0` trio.

### 3. Dead e2e test

`browser-run.test.ts` still used the retired `browser <session> run` grammar — the argv preprocessor rejects it with **exit 2 before anything runs** — and a hand-written session id the daemon has no record of.

It survived because **it runs in no CI workflow**: `ci.yml` has no e2e job, and `e2e-headed.yml` runs only `browser-tabs` and `cloak-runtime`.

Fix: create a real Session via `session create`, address it with the root `--session` selector, matching the sibling e2e files.

### 4. Dead argv hoister

`hoistBrowserWindowOption` relocated a trailing `--window <mode>` to just before the browser subcommand, so Commander would attach it to `browser`.

**`browser` stopped declaring `--window` in #196**, when the browser surface was collapsed. The hoister stayed. It still moves the flag; Commander still rejects it as unknown. The path cannot succeed.

Its test only inspected the returned array and never handed it to Commander — which is why it stayed green for six weeks while guarding nothing. It also asserted on `browser state`, a subcommand that no longer exists.

Same root event as commit 1: #196 dropped the option and left the fallout behind — dead plumbing here, and no `windowMode` on the wire there. Behaviour is unchanged by this commit; `--window` on a raw browser command errored before and errors after.

---

## Type of Change

- [x] 🐛 Bug fix

## Reviewer: start here

1. Read `src/browser/runtime/local-cloak/provider.ts` — the whole fix is one ternary
2. Confirm `startSessionHandoff` still bypasses `dispatch` (it does; that's the only intentional focus-steal)
3. Decide whether commits 2 and 3 should be split into their own PRs

## webcmd-cloud: nothing to do

Hosted browsers are remote Browser Use instances — no local window, no focus to steal. `router.ts` already accepts `windowMode` as optional passthrough with no foreground default. The hosted contract is untouched, so the open cloud parity PR needs nothing added.

## Deploy note

The default lives daemon-side, so a running daemon keeps the old behaviour until its version changes. `ensureBrowserBridgeReady` auto-restarts a version-mismatched daemon, so this lands automatically on a release bump. Testing locally on the same version? Run `webcmd daemon restart` once.

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

`npm run build && npm run test:all` — everything, including e2e:

```
Test Files  451 passed | 2 skipped (453)
     Tests  5660 passed | 61 skipped (5721)
```

`npx tsc --noEmit` — clean.

New coverage:

- `provider.test.ts` — parameterised: no `windowMode` → `background: true, focus: false`; explicit `foreground` → `background: false, focus: true`
- `transform.test.ts` — decimal ordering pinned against collation drift
- `cli-argv-preprocess.test.ts` — replaced the hoist test with one asserting a recognised subcommand and its options pass through untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
