### PR TITLE
fix(browser): tolerate pages closing during session cleanup

### DIFF
--- a/src/browser/runtime/local-cloak/session-manager.test.ts
+++ b/src/browser/runtime/local-cloak/session-manager.test.ts
@@ -438,6 +438,28 @@ describe('CloakSessionManager', () => {
     expect(await manager.findPageById(second.pageId, a)).toBeNull();
   });
 
+  it('closes a Session when its page disappears during the ownership check', async () => {
+    const launched = fakeContext();
+    const manager = new CloakSessionManager({
+      baseDir: '/tmp/webcmd-test',
+      launchPersistentContext: vi.fn().mockResolvedValue(launched.context),
+    });
+    const key = { profileId: 'default', session: 'session_a', sessionId: 'session_a', surface: 'browser' as const };
+    const lease = await manager.getPage(key);
+    const send = launched.cdp.send.getMockImplementation()!;
+
+    launched.cdp.send.mockImplementation(async (method: string, params?: { targetId?: string }) => {
+      if (method === 'Browser.getWindowForTarget' && params?.targetId === launched.targetIdFor(lease.page)) {
+        await lease.page.close();
+        throw new Error('Protocol error (Browser.getWindowForTarget): No target with given id');
+      }
+      return send(method, params);
+    });
+
+    await expect(manager.closeSession(key.profileId, key.sessionId)).resolves.toBe(1);
+    expect(await manager.listPages(key)).toEqual([]);
+  });
+
   it('does not let another Session bind an owned page moved to an unowned window', async () => {
     const launched = fakeContext();
     const manager = new CloakSessionManager({

--- a/src/browser/runtime/local-cloak/session-manager.ts
+++ b/src/browser/runtime/local-cloak/session-manager.ts
@@ -645,7 +645,13 @@ export class CloakSessionManager {
     const sessionRuntime = runtime.sessions.get(session);
     if (!sessionRuntime) return 0;
     const entries = this.openEntries(sessionRuntime);
-    await Promise.all(entries.map(([, entry]) => this.assertOwnedWindow(runtime, session, entry)));
+    await Promise.all(entries.map(async ([, entry]) => {
+      try {
+        await this.assertOwnedWindow(runtime, session, entry);
+      } catch (error) {
+        if (!pageIsClosed(entry.page)) throw error;
+      }
+    }));
     for (const [, entry] of entries) await this.removeEntry(runtime, sessionRuntime, entry, true);
     if (entries.length > 0) runtime.lastSeenAt = Date.now();
     return entries.length;


### PR DESCRIPTION
## Description

Prevent Session cleanup from failing when a page disappears during the asynchronous ownership check. Ownership errors still propagate for pages that remain open.

Related issue: reproduced during benchmark Session teardown

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Adapter Notes

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to CliError subclasses instead of raw Error

## Screenshots / Output

- npm test: 442 files passed; 5,646 tests passed; 1 skipped
- npm run typecheck: passed
- npm run build: passed