### PR TITLE
Show hosted live views before browser runs

### DIFF
--- a/src/hosted/client.test.ts
+++ b/src/hosted/client.test.ts
@@ -187,8 +187,13 @@ describe('HostedClient', () => {
       apiBaseUrl: 'https://api.example.com', apiKey: 'key',
       fetchImpl: async (url, init) => {
         const pathname = new URL(String(url)).pathname;
-        if (pathname === '/v1/sessions') return new Response(JSON.stringify({ ok: true, session }));
-        if (pathname === '/v1/sessions-list') return new Response(JSON.stringify({ ok: true, sessions: [{ ...session, liveViewUrl: 'https://api.example.com/account/live/session_wire' }] }));
+        if (pathname === '/v1/sessions' && init?.method === 'POST') return new Response(JSON.stringify({ ok: true, session }));
+        if (pathname === '/v1/sessions' && (init?.method ?? 'GET') === 'GET') {
+          return new Response(JSON.stringify({
+            ok: true,
+            sessions: [{ ...session, liveViewUrl: 'https://api.example.com/account/live/session_wire' }],
+          }));
+        }
         if (pathname === '/v1/executions') {
           prepareBody = JSON.parse(String(init?.body));
           prepareCapability = new Headers(init?.headers).get('x-webcmd-client-capabilities');
@@ -201,7 +206,7 @@ describe('HostedClient', () => {
             ...(command === 'github/unknown' ? { unexpected: true } : {}),
           }));
         }
-        return new Response(JSON.stringify({ ok: true, sessions: [{ ...session, liveViewUrl: 'https://api.example.com/account/live/session_wire' }] }));
+        return new Response(JSON.stringify({ ok: false, error: { code: 'UNEXPECTED', message: pathname, exitCode: 1 } }));
       },
     });
 

--- a/src/hosted/client.test.ts
+++ b/src/hosted/client.test.ts
@@ -133,7 +133,7 @@ describe('HostedClient', () => {
   });
 
   it('accepts the hosted Session API wire contract', async () => {
-    const requests: Array<{ url: string; method: string; body?: string }> = [];
+    const requests: Array<{ url: string; method: string; body?: string; liveViewCapability: string | null }> = [];
     const session = {
       id: 'session_wire',
       kind: 'explicit',
@@ -144,6 +144,7 @@ describe('HostedClient', () => {
       updatedAt: '2026-08-12T00:01:00.000Z',
       lastUsedAt: '2026-08-12T00:02:00.000Z',
     };
+    const createdSession = { ...session, liveViewUrl: 'https://api.example.com/account/live/session_wire' };
     const client = new HostedClient({
       apiBaseUrl: 'https://api.example.com',
       apiKey: 'key',
@@ -152,14 +153,15 @@ describe('HostedClient', () => {
           url: String(url),
           method: init?.method ?? 'GET',
           ...(init?.body ? { body: String(init.body) } : {}),
+          liveViewCapability: new Headers(init?.headers).get('x-webcmd-client-capabilities'),
         });
-        if (String(url).endsWith('/v1/sessions')) return new Response(JSON.stringify({ ok: true, session }));
+        if (String(url).endsWith('/v1/sessions')) return new Response(JSON.stringify({ ok: true, session: createdSession }));
         if (String(url).endsWith('/v1/sessions?profile=default&limit=20')) return new Response(JSON.stringify({ ok: true, sessions: [session] }));
         return new Response(JSON.stringify({ ok: true, closed: true, alreadyIdle: false, session: 'session_wire' }));
       },
     });
 
-    await expect(client.createBrowserSession()).resolves.toEqual({ ok: true, session });
+    await expect(client.createBrowserSession()).resolves.toEqual({ ok: true, session: createdSession });
     await expect(client.listBrowserSessions('default', 20)).resolves.toEqual({ ok: true, sessions: [session] });
     await expect(client.closeBrowserSession('session_wire')).resolves.toEqual({
       ok: true,
@@ -167,11 +169,54 @@ describe('HostedClient', () => {
       alreadyIdle: false,
       session: 'session_wire',
     });
-    expect(requests.map(({ url, method }) => ({ url, method }))).toEqual([
-      { url: 'https://api.example.com/v1/sessions', method: 'POST' },
-      { url: 'https://api.example.com/v1/sessions?profile=default&limit=20', method: 'GET' },
-      { url: 'https://api.example.com/v1/sessions/session_wire/close', method: 'POST' },
+    expect(requests.map(({ url, method, liveViewCapability }) => ({ url, method, liveViewCapability }))).toEqual([
+      { url: 'https://api.example.com/v1/sessions', method: 'POST', liveViewCapability: 'hosted-live-view-v1' },
+      { url: 'https://api.example.com/v1/sessions?profile=default&limit=20', method: 'GET', liveViewCapability: 'hosted-live-view-v1' },
+      { url: 'https://api.example.com/v1/sessions/session_wire/close', method: 'POST', liveViewCapability: 'hosted-live-view-v1' },
     ]);
+  });
+
+  it('requires a creation live view, keeps session rows exact, and accepts only the prepared live view field', async () => {
+    const session = {
+      id: 'session_wire', kind: 'explicit', profileId: 'profile_default', runtimeState: 'active', handoff: null,
+      createdAt: '2026-08-12T00:00:00.000Z', updatedAt: '2026-08-12T00:01:00.000Z', lastUsedAt: '2026-08-12T00:02:00.000Z',
+    };
+    let prepareBody: unknown;
+    let prepareCapability: string | null = null;
+    const client = new HostedClient({
+      apiBaseUrl: 'https://api.example.com', apiKey: 'key',
+      fetchImpl: async (url, init) => {
+        const pathname = new URL(String(url)).pathname;
+        if (pathname === '/v1/sessions') return new Response(JSON.stringify({ ok: true, session }));
+        if (pathname === '/v1/sessions-list') return new Response(JSON.stringify({ ok: true, sessions: [{ ...session, liveViewUrl: 'https://api.example.com/account/live/session_wire' }] }));
+        if (pathname === '/v1/executions') {
+          prepareBody = JSON.parse(String(init?.body));
+          prepareCapability = new Headers(init?.headers).get('x-webcmd-client-capabilities');
+          const command = (prepareBody as { command: string }).command;
+          return new Response(JSON.stringify({
+            ok: true,
+            execution: { id: 'exec_1', command, status: 'queued' },
+            fileArguments: [],
+            liveViewUrl: 'https://api.example.com/account/live/exec_1',
+            ...(command === 'github/unknown' ? { unexpected: true } : {}),
+          }));
+        }
+        return new Response(JSON.stringify({ ok: true, sessions: [{ ...session, liveViewUrl: 'https://api.example.com/account/live/session_wire' }] }));
+      },
+    });
+
+    await expect(client.createBrowserSession()).rejects.toMatchObject({ code: 'HOSTED_PROTOCOL' });
+    await expect(client.listBrowserSessions()).rejects.toMatchObject({ code: 'HOSTED_PROTOCOL' });
+    await expect(client.prepareExecution({
+      command: 'github/whoami', profile: 'work', session: 'session_work', executionScope: 'profile',
+    })).resolves.toMatchObject({
+      liveViewUrl: 'https://api.example.com/account/live/exec_1',
+    });
+    expect(prepareBody).toEqual({
+      command: 'github/whoami', profile: 'work', session: 'session_work', executionScope: 'profile',
+    });
+    expect(prepareCapability).toBe('hosted-live-view-v1');
+    await expect(client.prepareExecution({ command: 'github/unknown' })).rejects.toMatchObject({ code: 'HOSTED_PROTOCOL' });
   });
 
   it('searches the authenticated marketplace and validates every public plugin field', async () => {

--- a/src/hosted/client.ts
+++ b/src/hosted/client.ts
@@ -269,7 +269,12 @@ export class HostedClient {
     return body;
   }
 
-  async prepareExecution(input: { command: string }): Promise<HostedPrepareExecutionResponse> {
+  async prepareExecution(input: {
+    command: string;
+    profile?: string;
+    session?: string;
+    executionScope?: 'profile' | 'stateless';
+  }): Promise<HostedPrepareExecutionResponse> {
     const body = await this.request('/v1/executions', {
       method: 'POST',
       body: JSON.stringify(input),
@@ -460,6 +465,7 @@ export class HostedClient {
         accept: 'application/json',
         authorization: `Bearer ${this.apiKey}`,
         'x-webcmd-session-protocol-version': String(HOSTED_SESSION_PROTOCOL_VERSION),
+        'x-webcmd-client-capabilities': 'hosted-live-view-v1',
         ...(init.body ? { 'content-type': 'application/json' } : {}),
         ...(this.workspace ? { 'x-webcmd-workspace': this.workspace } : {}),
         ...(init.headers ?? {}),
@@ -585,14 +591,15 @@ function isHostedPrepareExecutionResponse(
   value: unknown,
   requestedCommand: string,
 ): value is HostedPrepareExecutionResponse {
-  return hasExactKeys(value, ['ok', 'execution', 'fileArguments'])
+  return hasOnlyKeys(value, ['ok', 'execution', 'fileArguments', 'liveViewUrl'])
     && value.ok === true
     && hasExactKeys(value.execution, ['id', 'command', 'status'])
     && typeof value.execution.id === 'string'
     && value.execution.command === requestedCommand
     && value.execution.status === 'queued'
     && Array.isArray(value.fileArguments)
-    && value.fileArguments.every(isHostedFileArgument);
+    && value.fileArguments.every(isHostedFileArgument)
+    && (value.liveViewUrl === undefined || typeof value.liveViewUrl === 'string');
 }
 
 function isHostedUploadArtifactResponse(
@@ -620,7 +627,7 @@ function isHostedProfilesResponse(value: unknown): value is HostedProfilesRespon
 function isHostedBrowserSessionResponse(value: unknown): value is HostedBrowserSessionResponse {
   return hasExactKeys(value, ['ok', 'session'])
     && value.ok === true
-    && isHostedBrowserSession(value.session);
+    && isHostedCreatedBrowserSession(value.session);
 }
 
 function isHostedBrowserSessionsResponse(value: unknown): value is HostedBrowserSessionsResponse {
@@ -649,6 +656,12 @@ function isHostedBrowserSession(value: unknown): boolean {
     && typeof value.createdAt === 'string'
     && typeof value.updatedAt === 'string'
     && typeof value.lastUsedAt === 'string';
+}
+
+function isHostedCreatedBrowserSession(value: unknown): boolean {
+  if (!isRecord(value) || typeof value.liveViewUrl !== 'string') return false;
+  const { liveViewUrl: _liveViewUrl, ...session } = value;
+  return isHostedBrowserSession(session);
 }
 
 function isHostedSessionHandoff(value: unknown): boolean {

--- a/src/hosted/files.test.ts
+++ b/src/hosted/files.test.ts
@@ -145,9 +145,14 @@ describe('hosted file transfer helpers', () => {
         text: 'hello',
         images: './one.png,./two.png',
       },
+      profile: 'work',
+      session: 'session_work',
+      executionScope: 'profile',
     });
 
-    expect(client.prepareExecution).toHaveBeenCalledWith({ command: 'twitter/post' });
+    expect(client.prepareExecution).toHaveBeenCalledWith({
+      command: 'twitter/post', profile: 'work', session: 'session_work', executionScope: 'profile',
+    });
     expect(client.uploadExecutionArtifact).toHaveBeenCalledTimes(2);
     expect(client.uploadExecutionArtifact).toHaveBeenNthCalledWith(1, expect.objectContaining({
       executionId: 'exec_prepared',

--- a/src/hosted/files.ts
+++ b/src/hosted/files.ts
@@ -11,6 +11,7 @@ import type {
   HostedCommand,
   HostedCommandArg,
   HostedExecuteResponse,
+  HostedPrepareExecutionResponse,
 } from './types.js';
 
 export interface HostedPreparedFiles {
@@ -36,6 +37,10 @@ export async function prepareHostedFiles(input: {
   command: HostedCommand;
   args: Record<string, unknown>;
   cwd?: string;
+  profile?: string;
+  session?: string;
+  executionScope?: 'profile' | 'stateless';
+  onPrepared?: (prepared: HostedPrepareExecutionResponse) => Promise<void>;
 }): Promise<HostedPreparedFiles> {
   const fileArgs = input.command.args.filter(hasFileMetadata);
   const cwd = input.cwd ?? process.cwd();
@@ -123,7 +128,13 @@ export async function prepareHostedFiles(input: {
     }
   }
 
-  const prepared = await input.client.prepareExecution({ command: input.command.command });
+  const prepared = await input.client.prepareExecution({
+    command: input.command.command,
+    ...(input.profile !== undefined ? { profile: input.profile } : {}),
+    ...(input.session !== undefined ? { session: input.session } : {}),
+    ...(input.executionScope !== undefined ? { executionScope: input.executionScope } : {}),
+  });
+  await input.onPrepared?.(prepared);
   const referencesByArgument = new Map<string, HostedArtifactReference[]>();
   const inputIdByPath = new Map<string, string>();
   for (const upload of inputs) {

--- a/src/hosted/main-lifecycle.test.ts
+++ b/src/hosted/main-lifecycle.test.ts
@@ -41,6 +41,19 @@ const authCommand = {
   defaultFormat: 'plain',
 };
 
+const liveViewCommand = {
+  site: 'live',
+  name: 'view',
+  command: 'live/view',
+  description: 'Exercise the hosted live view lifecycle',
+  access: 'read',
+  strategy: 'UI',
+  browser: true,
+  args: [],
+  columns: ['value'],
+  defaultFormat: 'plain',
+};
+
 afterEach(async () => {
   await Promise.all(servers.splice(0).map(server => new Promise<void>((resolve, reject) => {
     server.close(error => error ? reject(error) : resolve());
@@ -150,6 +163,20 @@ describe('hosted CLI process lifecycle', () => {
     await expect(readFile(fixture.discoverySentinel, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
   }, 20_000);
 
+  it('writes the live view before the prepared browser run completes', async () => {
+    const fixture = await createHostedFixture('browser');
+    const cli = startCli(['live', 'view', '-f', 'plain'], fixture.env);
+
+    await fixture.runStarted;
+    await eventually(() => cli.stderr() === 'Webcmd live view: https://api.example.test/account/live/live_token\n');
+    fixture.releaseRun();
+
+    const result = await cli.done;
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('live result\n');
+    expect(result.stderr).toBe('Webcmd live view: https://api.example.test/account/live/live_token\n');
+  }, 20_000);
+
   it('rejects daemon commands in hosted mode without local discovery', async () => {
     const fixture = await createHostedFixture('success');
 
@@ -191,11 +218,13 @@ describe('hosted CLI process lifecycle', () => {
   }, 20_000);
 });
 
-async function createHostedFixture(outcome: 'success' | 'failure'): Promise<{
+async function createHostedFixture(outcome: 'success' | 'failure' | 'browser'): Promise<{
   root: string;
   env: NodeJS.ProcessEnv;
   discoverySentinel: string;
   requests: string[];
+  runStarted: Promise<void>;
+  releaseRun: () => void;
 }> {
   const root = await mkdtemp(path.join(tmpdir(), 'webcmd-hosted-lifecycle-'));
   tempRoots.push(root);
@@ -203,6 +232,10 @@ async function createHostedFixture(outcome: 'success' | 'failure'): Promise<{
   const userClis = path.join(root, '.webcmd', 'clis', 'lifecycle-sentinel');
   const discoverySentinel = path.join(root, 'local-discovery-ran');
   const requests: string[] = [];
+  let markRunStarted: () => void = () => undefined;
+  const runStarted = new Promise<void>(resolve => { markRunStarted = resolve; });
+  let releaseRun: () => void = () => undefined;
+  const waitForRunRelease = new Promise<void>(resolve => { releaseRun = resolve; });
   await mkdir(configDir, { recursive: true });
   await mkdir(userClis, { recursive: true });
   await writeFile(path.join(userClis, 'sentinel.js'), [
@@ -225,8 +258,28 @@ async function createHostedFixture(outcome: 'success' | 'failure'): Promise<{
             webcmdPackageVersion: PKG_VERSION,
             generatedAt: '2026-07-14T00:00:00.000Z',
           },
-          commands: [command, authCommand],
+          commands: [command, authCommand, liveViewCommand],
         },
+      });
+      return;
+    }
+    if (request.url === '/v1/executions' && request.method === 'POST' && outcome === 'browser') {
+      sendChunkedJson(response, {
+        ok: true,
+        execution: { id: 'exec_live', command: 'live/view', status: 'queued' },
+        fileArguments: [],
+        liveViewUrl: 'https://api.example.test/account/live/live_token',
+      });
+      return;
+    }
+    if (request.url === '/v1/executions/exec_live/run' && request.method === 'POST' && outcome === 'browser') {
+      markRunStarted();
+      await waitForRunRelease;
+      sendChunkedJson(response, {
+        ok: true,
+        result: { value: 'live result' },
+        columns: ['value'],
+        execution: { id: 'exec_live', command: 'live/view', status: 'succeeded' },
       });
       return;
     }
@@ -287,6 +340,8 @@ async function createHostedFixture(outcome: 'success' | 'failure'): Promise<{
     root,
     discoverySentinel,
     requests,
+    runStarted,
+    releaseRun,
     env: {
       ...process.env,
       HOME: root,
@@ -310,17 +365,21 @@ function runCli(args: string[], env: NodeJS.ProcessEnv, imports: string[] = []):
   stdout: string;
   stderr: string;
 }> {
-  return new Promise((resolve, reject) => {
-    const importArgs = imports.flatMap(specifier => ['--import', pathToFileURL(specifier).href]);
-    const child = spawn(process.execPath, [...importArgs, '--import', 'tsx', entrypoint, ...args], {
-      cwd: packageRoot,
-      env,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    const stdout: Buffer[] = [];
-    const stderr: Buffer[] = [];
-    child.stdout.on('data', chunk => stdout.push(Buffer.from(chunk)));
-    child.stderr.on('data', chunk => stderr.push(Buffer.from(chunk)));
+  return startCli(args, env, imports).done;
+}
+
+function startCli(args: string[], env: NodeJS.ProcessEnv, imports: string[] = []) {
+  const importArgs = imports.flatMap(specifier => ['--import', pathToFileURL(specifier).href]);
+  const child = spawn(process.execPath, [...importArgs, '--import', 'tsx', entrypoint, ...args], {
+    cwd: packageRoot,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  child.stdout.on('data', chunk => stdout.push(Buffer.from(chunk)));
+  child.stderr.on('data', chunk => stderr.push(Buffer.from(chunk)));
+  const done = new Promise<{ status: number | null; stdout: string; stderr: string }>((resolve, reject) => {
     child.once('error', reject);
     child.once('close', status => resolve({
       status,
@@ -328,6 +387,18 @@ function runCli(args: string[], env: NodeJS.ProcessEnv, imports: string[] = []):
       stderr: Buffer.concat(stderr).toString('utf8'),
     }));
   });
+  return {
+    done,
+    stderr: () => Buffer.concat(stderr).toString('utf8'),
+  };
+}
+
+async function eventually(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  throw new Error('condition did not become true');
 }
 
 async function createDelayedStdoutPreload(root: string): Promise<string> {

--- a/src/hosted/runner.test.ts
+++ b/src/hosted/runner.test.ts
@@ -45,7 +45,7 @@ const manifest = {
       description: 'Show GitHub identity',
       access: 'read',
       strategy: 'COOKIE',
-      browser: true,
+      browser: false,
       args: [],
       columns: ['username'],
       tags: ['search'],
@@ -80,6 +80,16 @@ function sink(isTTY = false): { stream: Writable; text: () => string } {
 
 function manifestResponse(): Response {
   return new Response(JSON.stringify({ ok: true, manifest }), { status: 200 });
+}
+
+function browserManifestResponse(): Response {
+  return new Response(JSON.stringify({
+    ok: true,
+    manifest: {
+      ...manifest,
+      commands: manifest.commands.map(command => command.command === 'github/whoami' ? { ...command, browser: true } : command),
+    },
+  }), { status: 200 });
 }
 
 function executionResponse(input: {
@@ -140,7 +150,7 @@ function manifestWithFileCommand() {
         description: 'Copy a hosted file',
         access: 'write',
         strategy: 'PUBLIC',
-        browser: false,
+        browser: true,
         args: [
           {
             name: 'source',
@@ -726,6 +736,7 @@ describe('runHostedCli', () => {
       handoff: { site: 'github', expiresAt: '2026-01-01T00:15:00.000Z' },
       createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:01:00.000Z', lastUsedAt: '2026-01-01T00:02:00.000Z',
     };
+    const createdSession = { ...session, liveViewUrl: 'https://api.example.com/account/live/session_abc' };
     const fetchImpl = vi.fn<typeof fetch>(async (url, init) => {
       const request = {
         url: String(url), method: init?.method ?? 'GET',
@@ -733,7 +744,7 @@ describe('runHostedCli', () => {
       };
       requests.push(request);
       if (request.url.endsWith('/v1/manifest')) return manifestResponse();
-      if (request.method === 'POST' && request.url.endsWith('/v1/sessions')) return new Response(JSON.stringify({ ok: true, session }));
+      if (request.method === 'POST' && request.url.endsWith('/v1/sessions')) return new Response(JSON.stringify({ ok: true, session: createdSession }));
       if (request.method === 'POST' && request.url.endsWith(`/v1/sessions/${session.id}/close?profile=work`)) {
         return new Response(JSON.stringify({ ok: true, closed: false, alreadyIdle: true, session: session.id }));
       }
@@ -757,6 +768,7 @@ describe('runHostedCli', () => {
       outputs.push(stdout.text());
     }
     expect(outputs[0]).toContain('"runtimeState": "idle"');
+    expect(outputs[0]).toContain('"liveViewUrl": "https://api.example.com/account/live/session_abc"');
     expect(outputs[1]).toContain('"handoff": "github until 2026-01-01T00:15:00.000Z"');
     expect(outputs[0]).not.toContain('"profileId"');
 
@@ -776,11 +788,12 @@ describe('runHostedCli', () => {
       handoff: null,
       createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:01:00.000Z', lastUsedAt: '2026-01-01T00:02:00.000Z',
     };
+    const createdSession = { ...session, liveViewUrl: 'https://api.example.com/account/live/session_abc' };
     const fetchImpl = vi.fn<typeof fetch>(async (url, init) => {
       const requestUrl = String(url);
       if (requestUrl.endsWith('/v1/manifest')) return manifestResponse();
       if (init?.method === 'POST' && requestUrl.endsWith('/v1/sessions')) {
-        return new Response(JSON.stringify({ ok: true, session }));
+        return new Response(JSON.stringify({ ok: true, session: createdSession }));
       }
       if (requestUrl.includes('/close')) {
         return new Response(JSON.stringify({ ok: true, closed: true, alreadyIdle: false, session: session.id }));
@@ -1516,20 +1529,30 @@ describe('runHostedCli', () => {
     })]);
   });
 
-  it('dispatches hosted commands to /v1/execute', async () => {
+  it('prepares browser-capable hosted commands before running them', async () => {
     const requests: Array<{ url: string; body?: unknown }> = [];
     const stdout = sink();
+    const stderr = sink();
 
     const result = await runHostedCli(['--session', 'session_a', 'github', 'whoami', '-f', 'json'], {
       config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
       stdout: stdout.stream,
+      stderr: stderr.stream,
       fetchImpl: async (url, init) => {
         requests.push({
           url: String(url),
           body: init?.body ? JSON.parse(String(init.body)) as unknown : undefined,
         });
         if (String(url).endsWith('/v1/manifest')) {
-          return manifestResponse();
+          return browserManifestResponse();
+        }
+        if (String(url).endsWith('/v1/executions')) {
+          return new Response(JSON.stringify({
+            ok: true,
+            execution: { id: 'exec_success', command: 'github/whoami', status: 'queued' },
+            fileArguments: [],
+            liveViewUrl: 'https://api.example.com/account/live/exec_success',
+          }));
         }
         return executionResponse({ result: [{ username: 'octocat' }], columns: ['username'] });
       },
@@ -1537,7 +1560,7 @@ describe('runHostedCli', () => {
 
     expect(result).toEqual({ handled: true, exitCode: 0 });
     expect(requests.at(-1)).toEqual({
-      url: 'https://api.example.com/v1/execute',
+      url: 'https://api.example.com/v1/executions/exec_success/run',
       body: {
         command: 'github/whoami',
         args: {},
@@ -1547,6 +1570,70 @@ describe('runHostedCli', () => {
       },
     });
     expect(stdout.text()).toBe('[\n  {\n    "username": "octocat"\n  }\n]\n');
+    expect(stderr.text()).toBe('Webcmd live view: https://api.example.com/account/live/exec_success\n');
+  });
+
+  it.each(['table', 'plain', 'json', 'yaml', 'md', 'csv'])('preserves %s stdout bytes when a browser live view is present', async (format) => {
+    const run = async (withViewer: boolean) => {
+      const stdout = sink(true);
+      const stderr = sink();
+      await runHostedCli(['github', 'whoami', '-f', format], {
+        config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
+        stdout: stdout.stream,
+        stderr: stderr.stream,
+        fetchImpl: async (url) => {
+          const pathname = new URL(String(url)).pathname;
+          if (pathname === '/v1/manifest') return browserManifestResponse();
+          if (pathname === '/v1/executions') return new Response(JSON.stringify({
+            ok: true,
+            execution: { id: 'exec_format', command: 'github/whoami', status: 'queued' },
+            fileArguments: [],
+            ...(withViewer ? { liveViewUrl: 'https://api.example.com/account/live/exec_format' } : {}),
+          }));
+          return executionResponse({ result: [{ username: 'octocat' }], columns: ['username'] });
+        },
+      });
+      return { stdout: stdout.text(), stderr: stderr.text() };
+    };
+
+    const withoutViewer = await run(false);
+    const withViewer = await run(true);
+    expect(withViewer.stdout).toBe(withoutViewer.stdout);
+    expect(withViewer.stderr).toBe('Webcmd live view: https://api.example.com/account/live/exec_format\n');
+  });
+
+  it('prints a stable live view once for each browser command in the same session', async () => {
+    const stderr = sink();
+    let prepared = 0;
+    const fetchImpl: typeof fetch = async (url) => {
+      const pathname = new URL(String(url)).pathname;
+      if (pathname === '/v1/manifest') return browserManifestResponse();
+      if (pathname === '/v1/executions') {
+        prepared += 1;
+        return new Response(JSON.stringify({
+          ok: true,
+          execution: { id: `exec_${prepared}`, command: 'github/whoami', status: 'queued' },
+          fileArguments: [],
+          liveViewUrl: 'https://api.example.com/account/live/session_a',
+        }));
+      }
+      return executionResponse({ result: [], columns: ['username'] });
+    };
+    const options = {
+      config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
+      stdout: sink().stream,
+      stderr: stderr.stream,
+      fetchImpl,
+    };
+
+    await runHostedCli(['--session', 'session_a', 'github', 'whoami'], options);
+    await runHostedCli(['--session', 'session_a', 'github', 'whoami'], options);
+
+    expect(stderr.text()).toBe([
+      'Webcmd live view: https://api.example.com/account/live/session_a',
+      'Webcmd live view: https://api.example.com/account/live/session_a',
+      '',
+    ].join('\n'));
   });
 
   it('uploads local file args, runs a prepared execution, and materializes hosted output artifacts', async () => {
@@ -1557,10 +1644,12 @@ describe('runHostedCli', () => {
       await writeFile(sourcePath, 'input bytes');
       const requests: Array<{ method: string; pathname: string; body?: unknown; filename?: string | null; contentType?: string | null }> = [];
       const stdout = sink();
+      const stderr = sink();
 
       const result = await runHostedCli(['files', 'copy', '--source', sourcePath, '--output', outputDir, '-f', 'json'], {
         config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
         stdout: stdout.stream,
+        stderr: stderr.stream,
         fetchImpl: async (url, init) => {
           const parsedUrl = new URL(String(url));
           const rawBody = init?.body;
@@ -1582,6 +1671,7 @@ describe('runHostedCli', () => {
             return new Response(JSON.stringify({
               ok: true,
               execution: { id: 'exec_files', command: 'files/copy', status: 'queued' },
+              liveViewUrl: 'https://api.example.com/account/live/exec_files',
               fileArguments: [
                 {
                   name: 'source',
@@ -1675,6 +1765,7 @@ describe('runHostedCli', () => {
         file: path.join(outputDir, 'nested', 'result.txt'),
       }]);
       expect(stdout.text()).not.toContain('/private/cloud-root');
+      expect(stderr.text()).toBe('Webcmd live view: https://api.example.com/account/live/exec_files\n');
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }

--- a/src/hosted/runner.ts
+++ b/src/hosted/runner.ts
@@ -675,7 +675,12 @@ function parseHostedSessionListLimit(value: string): number {
 function sessionCreateOutput(data: unknown): unknown {
   if (!data || typeof data !== 'object' || Array.isArray(data)) return data;
   const row = data as Record<string, unknown>;
-  return { id: row.id, kind: row.kind, runtimeState: row.runtimeState, liveViewUrl: row.liveViewUrl };
+  return {
+    id: row.id,
+    kind: row.kind,
+    runtimeState: row.runtimeState,
+    ...(typeof row.liveViewUrl === 'string' ? { liveViewUrl: row.liveViewUrl } : {}),
+  };
 }
 
 function formatHostedSessionHandoff(handoff: unknown): string {

--- a/src/hosted/runner.ts
+++ b/src/hosted/runner.ts
@@ -445,8 +445,8 @@ async function dispatchHosted(
   }
 
   const startTime = now();
-  const response = hasPresentFileArgument(command, parsed.args)
-    ? await executeHostedFileCommand({
+  const response = command.browser || hasPresentFileArgument(command, parsed.args)
+    ? await executeHostedPreparedCommand({
         client,
         command,
         args: parsed.args,
@@ -454,6 +454,7 @@ async function dispatchHosted(
         trace: parsed.trace,
         profile: parsed.profile ?? normalized.profile,
         session: normalized.session,
+        stderr,
       })
     : await client.execute({
         command: command.command,
@@ -674,7 +675,7 @@ function parseHostedSessionListLimit(value: string): number {
 function sessionCreateOutput(data: unknown): unknown {
   if (!data || typeof data !== 'object' || Array.isArray(data)) return data;
   const row = data as Record<string, unknown>;
-  return { id: row.id, kind: row.kind, runtimeState: row.runtimeState };
+  return { id: row.id, kind: row.kind, runtimeState: row.runtimeState, liveViewUrl: row.liveViewUrl };
 }
 
 function formatHostedSessionHandoff(handoff: unknown): string {
@@ -696,7 +697,7 @@ function hasPresentFileArgument(
   });
 }
 
-async function executeHostedFileCommand(input: {
+async function executeHostedPreparedCommand(input: {
   client: HostedClient;
   command: import('./types.js').HostedCommand;
   args: Record<string, unknown>;
@@ -704,11 +705,17 @@ async function executeHostedFileCommand(input: {
   trace: string;
   profile?: string;
   session?: string;
+  stderr: NodeJS.WritableStream;
 }): Promise<import('./types.js').HostedExecuteResponse> {
   const prepared = await prepareHostedFiles({
     client: input.client,
     command: input.command,
     args: input.args,
+    ...(input.profile !== undefined ? { profile: input.profile } : {}),
+    ...(input.session !== undefined ? { session: input.session } : {}),
+    onPrepared: async (prepared) => {
+      if (prepared.liveViewUrl) await writeToStream(input.stderr, `Webcmd live view: ${prepared.liveViewUrl}\n`);
+    },
   });
   const response = await input.client.runPreparedExecution({
     executionId: prepared.executionId,

--- a/src/hosted/types.ts
+++ b/src/hosted/types.ts
@@ -81,9 +81,13 @@ export interface HostedBrowserSession {
   lastUsedAt: string;
 }
 
+export interface HostedCreatedBrowserSession extends HostedBrowserSession {
+  liveViewUrl: string;
+}
+
 export interface HostedBrowserSessionResponse {
   ok: true;
-  session: HostedBrowserSession;
+  session: HostedCreatedBrowserSession;
 }
 
 export interface HostedBrowserSessionsResponse {
@@ -188,6 +192,7 @@ export interface HostedPrepareExecutionResponse {
   ok: true;
   execution: HostedPreparedExecution;
   fileArguments: HostedFileArgument[];
+  liveViewUrl?: string;
 }
 
 export interface HostedArtifactReceipt {


### PR DESCRIPTION
## Summary
- Advertise hosted live-view capability on session creation and prepare requests.
- Validate creation/prepared response liveViewUrl fields while keeping session-list rows exact.
- Route browser-capable hosted commands through prepare/run and print Webcmd live view URLs to stderr before uploads or run.
- Preserve stdout bytes across hosted output formats.
- Review fix: omit `liveViewUrl` from session output when it is absent instead of emitting `undefined`.

## Verification
- npm run build: passed
- npm test -- src/hosted/client.test.ts src/hosted/files.test.ts src/hosted/runner.test.ts src/hosted/main-lifecycle.test.ts: 251 passed
- npm test -- src/hosted/contract.test.ts src/hosted/output-parity.test.ts: 9 passed
- npx vitest run src/hosted/: 473 passed
- git diff --check: passed

## Notes
- PR targets `main` directly.
- The reported 113 hosted failures were reproducible only before generating `hosted-contract.json`; `npm run build` regenerates it and the full `src/hosted` suite is now green.
- `executionScope` is still only forwarded through the existing file-prepare/client layer; there is no CLI/user input source for a new scope flag in this PR.
- No npm publish performed.
- Related cloud PR: https://github.com/agentrhq/webcmd-cloud/pull/35
