### PR TITLE
Fix 0.7.2 release metadata

### DIFF
--- a/plugins/linkedin/package.json
+++ b/plugins/linkedin/package.json
@@ -4,6 +4,6 @@
   "type": "module",
   "description": "LinkedIn profile, network, messaging, job, and Sales Navigator commands for WebCMD",
   "peerDependencies": {
-    "@agentrhq/webcmd": ">=0.7.1"
+    "@agentrhq/webcmd": ">=0.7.2"
   }
 }

--- a/plugins/linkedin/webcmd-plugin.json
+++ b/plugins/linkedin/webcmd-plugin.json
@@ -2,7 +2,7 @@
   "name": "linkedin",
   "version": "0.1.0",
   "description": "LinkedIn profile, network, messaging, job, and Sales Navigator commands for WebCMD",
-  "webcmd": ">=0.7.1",
+  "webcmd": ">=0.7.2",
   "author": {
     "name": "WebCMD Agent",
     "handle": "agentrhq"

--- a/webcmd-plugin.json
+++ b/webcmd-plugin.json
@@ -638,7 +638,7 @@
       "path": "plugins/linkedin",
       "version": "0.1.0",
       "description": "LinkedIn profile, network, messaging, job, and Sales Navigator commands for WebCMD",
-      "webcmd": ">=0.7.1",
+      "webcmd": ">=0.7.2",
       "author": {
         "name": "WebCMD Agent",
         "handle": "agentrhq"


### PR DESCRIPTION
## Summary\n- Align LinkedIn plugin runtime floor with the 0.7.2 release.\n\n## Verification\n- npm run typecheck\n- npm run build\n- npm run build-plugin-manifest\n- npm run check:plugin-parity\n- npm run check-community-plugins\n- npm run check:hosted-contract\n- git diff --exit-code -- cli-manifest.json hosted-contract.json webcmd-plugin.json README.md\n- npm run check:codex-plugin\n- npm test\n- npm run check:package-bin\n- npm publish --dry-run --access public --ignore-scripts