### PR TITLE
feat(cli): add --format to profile list and report disconnected profiles

### DIFF
--- a/src/browser/profile.test.ts
+++ b/src/browser/profile.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { ENV_PREFIX } from '../brand.js';
-import { profileRouteParams, resolveProfileSelection } from './profile.js';
+import { profileListRows, profileRouteParams, resolveProfileSelection } from './profile.js';
 
 describe('profile selection', () => {
   let configDir: string;
@@ -49,5 +49,51 @@ describe('profile selection', () => {
     expect(profileRouteParams({ contextId: 'a', source: 'explicit' })).toEqual({ contextId: 'a' });
     expect(profileRouteParams({ contextId: 'b', source: 'preferred' })).toEqual({ preferredContextId: 'b' });
     expect(profileRouteParams(undefined)).toEqual({});
+  });
+});
+
+describe('profileListRows', () => {
+  const config = {
+    aliases: { work: 'ctx-work', sales: 'ctx-sales' },
+    defaultContextId: 'ctx-default',
+  } as never;
+
+  it('marks connected profiles and carries their alias, default flag, and version', () => {
+    const rows = profileListRows(config, [
+      { contextId: 'ctx-work', runtimeVersion: '1.2.3' },
+      { contextId: 'ctx-default' },
+    ]);
+    expect(rows).toEqual([
+      { contextId: 'ctx-work', alias: 'work', default: false, connected: true, runtimeVersion: '1.2.3' },
+      { contextId: 'ctx-default', alias: '', default: true, connected: true, runtimeVersion: '' },
+      { contextId: 'ctx-sales', alias: 'sales', default: false, connected: false, runtimeVersion: '' },
+    ]);
+  });
+
+  it('includes saved profiles that are not currently connected', () => {
+    const rows = profileListRows(config, [{ contextId: 'ctx-work' }]);
+    expect(rows.map((row) => [row.contextId, row.connected])).toEqual([
+      ['ctx-work', true],
+      ['ctx-sales', false],
+      ['ctx-default', false],
+    ]);
+  });
+
+  it('reports every saved profile when the runtime shows none', () => {
+    // Regression guard: structured output that hides disconnected profiles reads as
+    // "only the default exists", which sends callers hunting through internal state.
+    const rows = profileListRows(config, []);
+    expect(rows.map((row) => row.contextId).sort()).toEqual(['ctx-default', 'ctx-sales', 'ctx-work']);
+    expect(rows.every((row) => row.connected === false)).toBe(true);
+  });
+
+  it('does not duplicate a default that is also a saved alias', () => {
+    const rows = profileListRows(
+      { aliases: { work: 'ctx-work' }, defaultContextId: 'ctx-work' } as never,
+      [],
+    );
+    expect(rows).toEqual([
+      { contextId: 'ctx-work', alias: 'work', default: true, connected: false, runtimeVersion: '' },
+    ]);
   });
 });

--- a/src/browser/profile.ts
+++ b/src/browser/profile.ts
@@ -113,3 +113,57 @@ export function setDefaultProfile(profile: string): ProfileConfig {
   saveProfileConfig(config);
   return config;
 }
+
+export interface ProfileListRow {
+  contextId: string;
+  alias: string;
+  default: boolean;
+  connected: boolean;
+  runtimeVersion: string;
+}
+
+/**
+ * Structured view of `profile list`, including saved-but-disconnected profiles.
+ *
+ * The prose output already surfaces disconnected aliases; structured output must too.
+ * A caller that sees only connected profiles concludes the others do not exist and goes
+ * looking for profile state elsewhere, which is exactly the wrong place to look.
+ */
+export function profileListRows(
+  config: ProfileConfig,
+  connected: Array<{ contextId: string; runtimeVersion?: string }>,
+): ProfileListRow[] {
+  const seen = new Set<string>();
+  const rows: ProfileListRow[] = [];
+  for (const profile of connected) {
+    seen.add(profile.contextId);
+    rows.push({
+      contextId: profile.contextId,
+      alias: aliasForContextId(config, profile.contextId) ?? '',
+      default: config.defaultContextId === profile.contextId,
+      connected: true,
+      runtimeVersion: profile.runtimeVersion ?? '',
+    });
+  }
+  for (const [alias, contextId] of Object.entries(config.aliases)) {
+    if (seen.has(contextId)) continue;
+    seen.add(contextId);
+    rows.push({
+      contextId,
+      alias,
+      default: config.defaultContextId === contextId,
+      connected: false,
+      runtimeVersion: '',
+    });
+  }
+  if (config.defaultContextId && !seen.has(config.defaultContextId)) {
+    rows.push({
+      contextId: config.defaultContextId,
+      alias: '',
+      default: true,
+      connected: false,
+      runtimeVersion: '',
+    });
+  }
+  return rows;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,7 +44,7 @@ import { daemonRestart, daemonStatus, daemonStop } from './commands/daemon.js';
 import { isVerbose, log } from './logger.js';
 import { BrowserCommandError, listExistingBrowserTabs, releaseSiteSessionLease, sendCommand } from './browser/daemon-client.js';
 import { fetchDaemonStatus } from './browser/daemon-transport.js';
-import { aliasForContextId, loadProfileConfig, profileRouteParams, renameProfile, resolveProfileSelection, setDefaultProfile, type ProfileSelection } from './browser/profile.js';
+import { aliasForContextId, loadProfileConfig, profileListRows, profileRouteParams, renameProfile, resolveProfileSelection, setDefaultProfile, type ProfileSelection } from './browser/profile.js';
 import { formatDaemonVersion, isDaemonStale } from './browser/daemon-version.js';
 import { DEFAULT_BROWSER_CONNECT_TIMEOUT } from './browser/config.js';
 import { CLI_COMMAND, PACKAGE_NAME } from './brand.js';
@@ -1778,10 +1778,41 @@ cli({
   profileCmd
     .command('list')
     .description('List Chrome and Chromium profiles available through the Cloak runtime')
-    .action(async () => {
+    .option('-f, --format <fmt>', OUTPUT_FORMAT_HELP, 'table')
+    .action(async (opts: { format?: string }, command: Command) => {
+      const fmt = resolveOutputFormat(opts.format);
+      if (fmt === null) return;
       const status = await fetchDaemonStatus();
       const config = loadProfileConfig();
       const profiles = status?.profiles ?? [];
+      const daemonUsable = Boolean(status)
+        && !isDaemonStale(status!, PKG_VERSION)
+        && Array.isArray(status!.profiles);
+      if (fmt !== 'table') {
+        // An empty list and an unreadable runtime are different facts. Emitting `[]` for a
+        // stale or absent daemon reads as "no profiles exist" and sends callers looking for
+        // profile state elsewhere, so structured mode fails loudly instead.
+        if (!daemonUsable) {
+          const error = new CliError(
+            'DAEMON_UNAVAILABLE',
+            status
+              ? `Daemon ${formatDaemonVersion(status)} is stale for CLI v${PKG_VERSION}; profile list is incomplete.`
+              : 'Daemon is not running; profile list is incomplete.',
+            status ? 'Run: webcmd daemon restart' : 'Run webcmd doctor after opening Chrome.',
+          );
+          console.error(`Error: ${error.message}`);
+          console.error(`Hint: ${error.hint}`);
+          process.exitCode = error.exitCode;
+          return;
+        }
+        // Saved-but-disconnected profiles are included: they exist, they are just not live.
+        await renderOutput(profileListRows(config, profiles), {
+          fmt,
+          fmtExplicit: command.getOptionValueSource('format') === 'cli',
+          columns: ['contextId', 'alias', 'default', 'connected', 'runtimeVersion'],
+        });
+        return;
+      }
       if (!status) {
         console.log('Daemon is not running. Run webcmd doctor after opening Chrome.');
         return;


### PR DESCRIPTION
Closes #338.

## What

`profile list` gains `-f, --format`, and its structured output tells the truth about two things the prose output already knew.

## Why this one command

An agent ran `webcmd profile list -f json`, got `unknown option '-f'`, concluded it had typed something wrong, and went looking for profile state directly in `~/.webcmd`. It read `browser-sessions.json` — a global file holding session records for unrelated profiles — and used what it found there. The task it was running had an explicit "do not read unrelated state" boundary, so that read was the violation.

The flag is not a wild guess on the agent's part. It works on `list`, `session list`, `session create`, `session close`, `skills list`, `plugin list`, `plugin search`, `plugin catalog list`, `adapter status`, `external list`, and `auth status` — and the top-level help epilogue tips `webcmd <site> --help -f yaml`. `profile list` was the odd one out.

## Two behaviours, not one

**Disconnected profiles are included.** The prose output already prints a "Disconnected saved profiles" section. Structured output that omitted them would let a caller conclude a saved profile does not exist.

**An unreadable daemon is an error, not `[]`.** This is the part that actually fixes the failure above. An empty array and "I cannot see the runtime" are different facts, and only one of them justifies looking elsewhere. Structured mode now exits 1 with `DAEMON_UNAVAILABLE` and the existing restart hint.

```
$ webcmd profile list -f json
Error: Daemon v0.7.1 is stale for CLI v0.7.2; profile list is incomplete.
Hint: Run: webcmd daemon restart
$ echo $?
1
```

Default table output is byte-identical — the new path is reachable only through an explicit non-table `--format`.


## Cloud

No `webcmd-cloud` change. This is local CLI presentation; hosted profiles are served by `/v1/profiles` and do not route through this code path.

## Tests

Four cases on the new `profileListRows` builder covering connected rows, disconnected saved aliases, the all-disconnected case, and default/alias de-duplication. Full unit suite: 2461 passed, 0 failed (baseline 2457 + 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

