### PR TITLE
fix(browser): name the supported alternative in unsupported-API errors

### DIFF
--- a/src/browser/run/playwright-transport.ts
+++ b/src/browser/run/playwright-transport.ts
@@ -67,6 +67,28 @@ const DENIED_METHODS = new Map<string, Set<string>>([
   ['Playwright', new Set(['newRequest'])],
 ]);
 
+const CLOSE_SESSION = 'end the session with `webcmd session close <session-id>`';
+const NO_RAW_CDP = 'raw CDP is not exposed inside browser run; drive the page with the Playwright APIs on `page`';
+const ONE_CONTEXT = 'a run is scoped to one context; start another with `webcmd session create`';
+
+const API_REMEDIATIONS: Record<string, string> = {
+  'Browser.close': CLOSE_SESSION,
+  'Browser.newBrowserCDPSession': NO_RAW_CDP,
+  'Browser.newContext': ONE_CONTEXT,
+  'Browser.newContextForReuse': ONE_CONTEXT,
+  'BrowserContext.close': CLOSE_SESSION,
+  'BrowserContext.newCDPSession': NO_RAW_CDP,
+  'Page.close': `the session owns its tabs; leave the tab open, or ${CLOSE_SESSION}`,
+  'Playwright.newRequest': 'use `page.request` to make HTTP calls in the page\'s context',
+};
+
+export function unsupportedApiMessage(api: string): string {
+  const remediation = API_REMEDIATIONS[api];
+  return remediation
+    ? `${api} is unavailable in browser run; ${remediation}.`
+    : `${api} is unavailable in browser run.`;
+}
+
 function implementation<T>(object: T): unknown {
   const client = object as T & PlaywrightClientObject;
   const value = client._connection?.toImpl?.(object);
@@ -436,7 +458,7 @@ export class PlaywrightTransport {
         error: {
           error: {
             name: 'BrowserRunError',
-            message: `BROWSER_RUN_API_UNSUPPORTED: ${api} is unavailable in browser run.`,
+            message: `BROWSER_RUN_API_UNSUPPORTED: ${unsupportedApiMessage(api)}`,
             stack: '',
           },
         },

--- a/src/browser/run/runner.test.ts
+++ b/src/browser/run/runner.test.ts
@@ -16,6 +16,7 @@ import {
   type BrowserContext,
   type Page,
 } from 'playwright-core';
+import { unsupportedApiMessage } from './playwright-transport.js';
 import { QuickJSHost } from './quickjs-host.js';
 import { runBrowserProgram } from './runner.js';
 
@@ -530,26 +531,28 @@ afterAll(async () => {
   });
 
   it.each([
-    ['browser.close()', 'await browser.close();'],
-    ['browser.newContext()', 'await browser.newContext();'],
-    ['context.close()', 'await context.close();'],
-    ['page.close()', 'await page.close();'],
-    ['browserType.launch()', 'await browser.browserType().launch();'],
-    ['browserType.connect()', 'await browser.browserType().connect("ws://localhost");'],
-    ['browserType.connectOverCDP()', 'await browser.browserType().connectOverCDP("http://localhost");'],
-  ])('rejects ownership-changing API %s', async (_name, source) => {
+    ['browser.close()', 'await browser.close();', 'Browser.close'],
+    ['browser.newContext()', 'await browser.newContext();', 'Browser.newContext'],
+    ['context.close()', 'await context.close();', 'BrowserContext.close'],
+    ['page.close()', 'await page.close();', 'Page.close'],
+    ['browserType.launch()', 'await browser.browserType().launch();', undefined],
+    ['browserType.connect()', 'await browser.browserType().connect("ws://localhost");', undefined],
+    ['browserType.connectOverCDP()', 'await browser.browserType().connectOverCDP("http://localhost");', undefined],
+  ])('rejects ownership-changing API %s', async (_name, source, api) => {
     await expect(run(source)).rejects.toMatchObject({
       code: 'BROWSER_RUN_API_UNSUPPORTED',
+      ...(api ? { message: unsupportedApiMessage(api) } : {}),
     });
     expect(browser.isConnected()).toBe(true);
   });
 
   it.each([
-    ['browser.newBrowserCDPSession()', 'await browser.newBrowserCDPSession();'],
-    ['context.newCDPSession()', 'await context.newCDPSession(page);'],
-  ])('rejects CDP escape route %s', async (_name, source) => {
+    ['browser.newBrowserCDPSession()', 'await browser.newBrowserCDPSession();', 'Browser.newBrowserCDPSession'],
+    ['context.newCDPSession()', 'await context.newCDPSession(page);', 'BrowserContext.newCDPSession'],
+  ])('rejects CDP escape route %s', async (_name, source, api) => {
     await expect(run(source)).rejects.toMatchObject({
       code: 'BROWSER_RUN_API_UNSUPPORTED',
+      message: unsupportedApiMessage(api),
     });
     expect(browser.isConnected()).toBe(true);
     expect(page.isClosed()).toBe(false);
@@ -781,5 +784,28 @@ afterAll(async () => {
     `)).rejects.toMatchObject({
       message: expect.not.stringContaining('secret'),
     });
+  });
+});
+
+describe('unsupportedApiMessage', () => {
+  it.each([
+    ['Browser.close', 'webcmd session close <session-id>'],
+    ['Browser.newBrowserCDPSession', 'raw CDP is not exposed inside browser run'],
+    ['Browser.newContext', 'webcmd session create'],
+    ['Browser.newContextForReuse', 'webcmd session create'],
+    ['BrowserContext.close', 'webcmd session close <session-id>'],
+    ['BrowserContext.newCDPSession', 'raw CDP is not exposed inside browser run'],
+    ['Page.close', 'leave the tab open'],
+    ['Playwright.newRequest', 'use `page.request`'],
+  ])('points %s at a supported alternative', (api, remediation) => {
+    const message = unsupportedApiMessage(api);
+    expect(message).toContain(`${api} is unavailable in browser run;`);
+    expect(message).toContain(remediation);
+  });
+
+  it('keeps the generic text for an unmapped API', () => {
+    expect(unsupportedApiMessage('Browser.killForTests')).toBe(
+      'Browser.killForTests is unavailable in browser run.',
+    );
   });
 });


### PR DESCRIPTION
Closes #336.

`BROWSER_RUN_API_UNSUPPORTED` named the blocked API and stopped there. The entire usable content was a negation, so a caller could only guess the next API — and every guess is a round trip against a live browser. An internal agent-behaviour eval showed the guessing clustering rather than terminating.

Webcmd already ships one message that gets this right, and it is the precedent this follows:

```
BROWSER_RUN_API_UNSUPPORTED: File paths are unavailable in the QuickJS sandbox; use in-memory file payloads.
```

## Change

`src/browser/run/playwright-transport.ts` — a static `API_REMEDIATIONS` map keyed by `Type.method` sits next to `DENIED_METHODS` (the ground truth of what is blocked), and `unsupportedApiMessage(api)` joins the remediation with the same `; ` shape as the precedent. APIs not in the map get today's byte-identical text, so nothing regresses.

| API | Now says |
|---|---|
| `Page.close` | the session owns its tabs; leave the tab open, or end the session with `webcmd session close <session-id>` |
| `Browser.close`, `BrowserContext.close` | end the session with `webcmd session close <session-id>` |
| `Browser.newContext`, `Browser.newContextForReuse` | a run is scoped to one context; start another with `webcmd session create` |
| `Browser.newBrowserCDPSession`, `BrowserContext.newCDPSession` | raw CDP is not exposed inside browser run; drive the page with the Playwright APIs on `page` |
| `Playwright.newRequest` | use `page.request` to make HTTP calls in the page's context |

`Browser.killForTests`, `startServer`, `stopServer` and every `BrowserType`/`Android`/`Electron` method stay on the generic text — no obvious stable alternative to name.


## Scope

- The issue names `runner.ts:392` as root cause. That second thrower is left unchanged on purpose: it serves exactly two literal APIs (`Host filesystem reads`, `BrowserType.connect`), neither of them mapped, so routing it through the map changes no message today — and it lives inside the QuickJS shim script that #335 is rewriting. Not worth the conflict for zero behaviour change.
- Undefined-global rejections (`Buffer`, `TextEncoder`, `DataTransfer`) are explicitly out of scope here; #335 owns that boundary.

## Tests

- `unsupportedApiMessage` unit cases: one per mapped API asserting the message carries its remediation, plus `Browser.killForTests` asserting the exact generic text. `Playwright.newRequest` and `Browser.newContextForReuse` are not reachable from the sandbox globals (`page`/`context`/`browser`), so the helper test is the only way to cover the whole map.
- The existing `rejects ownership-changing API` and `rejects CDP escape route` integration cases now assert the full message, proving the remediation survives the QuickJS round trip and the redaction pass.

Verified with `npm install && npm run build` then the full `npx vitest run --project unit`:

- before: **2514 tests (2457 passed, 57 skipped), 0 failed**
- after: **2523 tests (2522 passed, 1 skipped), 0 failed** — +9 new cases

The skipped-count shift is unrelated to this PR: `runner.test.ts` is gated on a local Chromium being present, which was not yet detected during the baseline run and was on the later ones. `npx tsc --noEmit` is clean.

## Cloud

No change needed. `webcmd-cloud` imports `runBrowserProgram` from `@agentrhq/webcmd/browser/run` (`src/browser/hosted-browser.ts:17`), so hosted runs execute this exact code path and pick the better messages up when the cloud bumps its pinned `@agentrhq/webcmd` (currently 0.7.2 on its `main`). That pin is deliberately not bumped here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

