### PR TITLE
feat(browser): expose writeArtifact under a public name and document it

### DIFF
--- a/skills/webcmd-browser/references/browser-run-playwright.md
+++ b/skills/webcmd-browser/references/browser-run-playwright.md
@@ -6,9 +6,63 @@
 
 `context.newPage()` is not available inside `run`; create or bind Session tabs through Webcmd commands so page ownership stays deterministic.
 
-## Artifact paths
+## Artifacts: getting bytes out of the sandbox
 
-Artifacts written by Playwright must use a relative logical filename. Webcmd returns an artifact receipt with its locator; it does not grant host-path write access.
+There is no host filesystem. The only way to get a file out of a run is to write it as an
+artifact, using a **relative logical filename** — absolute paths and `..` are rejected with
+`BROWSER_RUN_INVALID_INPUT`.
+
+### Writing one
+
+```js
+const receipt = await writeArtifact('report.csv', new TextEncoder().encode(csv), 'text/csv');
+return receipt;
+```
+
+`writeArtifact(filename, bytes, contentType?)` takes a `Uint8Array` and resolves to the
+receipt. `contentType` is optional and defaults to `application/octet-stream` for anything
+that is not `.png`/`.jpg` — pass it explicitly when it matters. `__webcmdWriteArtifact` is a
+legacy alias for the same function.
+
+Two other calls write artifacts for you: `page.screenshot({ path: 'shot.png' })` and
+`download.saveAs('out.csv')`. Both take the same relative logical filename.
+
+### Capturing a download
+
+`download.createReadStream()` throws — Readable streams do not exist in the sandbox. Use
+`saveAs` with a relative name instead; it routes through the artifact sink:
+
+```js
+const [download] = await Promise.all([
+  page.waitForEvent('download'),
+  page.getByRole('button', { name: 'Convert' }).click(),
+]);
+await download.saveAs(download.suggestedFilename());
+return { saved: download.suggestedFilename() };
+```
+
+Do not scrape an on-page preview as a substitute for the downloaded bytes — it will not match.
+
+### Redeeming a receipt
+
+Every artifact written during a run appears in the run result's `artifacts` array, whether it
+came from `writeArtifact`, `saveAs`, or `screenshot`:
+
+```json
+{
+  "artifactId": "artifact_9d1f6368490aa37a22a18426",
+  "filename": "downloads/out.csv",
+  "contentType": "application/octet-stream",
+  "byteSize": 12,
+  "locator": "browser-run://artifact_9d1f6368490aa37a22a18426/downloads%2Fout.csv"
+}
+```
+
+Locally the bytes land at `~/.webcmd/cache/browser-run/<artifactId>/<filename>` (under
+`$WEBCMD_CACHE_DIR/browser-run` when that is set), readable once `run` has returned. Hosted
+runs use the same receipt shape with a `cloud-artifact://` locator backed by the execution's
+trace artifact store. The receipt never carries the bytes themselves, so return the receipt —
+or just read it off `artifacts` — rather than trying to return file contents through `result`.
 
 ## Errors
 

--- a/src/browser/run/runner.test.ts
+++ b/src/browser/run/runner.test.ts
@@ -1,4 +1,6 @@
 import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { createRequire } from 'node:module';
 import {
   afterAll,
@@ -16,6 +18,7 @@ import {
   type BrowserContext,
   type Page,
 } from 'playwright-core';
+import { LocalBrowserRunArtifactSink } from './artifacts.js';
 import { QuickJSHost } from './quickjs-host.js';
 import { runBrowserProgram } from './runner.js';
 
@@ -42,10 +45,11 @@ function sessionScope(pages: () => readonly Page[] = () => context.pages()) {
   };
 }
 
-function run(source: string, options = {}) {
+function run(source: string, options = {}, input = {}) {
   return runBrowserProgram({
     ...sessionScope(),
     pageId: 'page-1',
+    ...input,
   }, source, options);
 }
 
@@ -642,6 +646,36 @@ afterAll(async () => {
 
     expect(output.result).toEqual({ length: 3, returned: [255, 0, 128] });
   });
+
+  it.each(['writeArtifact', '__webcmdWriteArtifact'])(
+    'returns a redeemable receipt from %s',
+    async (fn) => {
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-artifact-'));
+      try {
+        const output = await run(`
+          const receipt = await ${fn}(
+            'nested/report.csv',
+            new TextEncoder().encode('id,name\\n1,caf\\u00e9\\n'),
+          );
+          return receipt;
+        `, {}, { artifactSink: new LocalBrowserRunArtifactSink({ baseDir }) });
+
+        const receipt = output.result as { artifactId: string; locator: string };
+        expect(receipt).toMatchObject({
+          filename: 'nested/report.csv',
+          contentType: 'application/octet-stream',
+          byteSize: 16,
+          locator: expect.stringContaining('browser-run://'),
+        });
+        expect(output.artifacts).toEqual([receipt]);
+        expect(
+          fs.readFileSync(path.join(baseDir, receipt.artifactId, 'nested/report.csv'), 'utf8'),
+        ).toBe('id,name\n1,caf\u00e9\n');
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it('rejects absolute artifact paths instead of touching host paths', async () => {
     const target = '/tmp/webcmd-browser-run-owned.txt';

--- a/src/browser/run/runner.ts
+++ b/src/browser/run/runner.ts
@@ -264,7 +264,7 @@ export async function runBrowserProgram(
           name !== 'writeArtifact'
           || typeof args[0] !== 'string'
           || typeof args[1] !== 'string'
-          || (args[2] !== undefined && typeof args[2] !== 'string')
+          || (args[2] != null && typeof args[2] !== 'string')
         ) {
           throw new BrowserRunError(
             'BROWSER_RUN_INVALID_INPUT',
@@ -440,12 +440,18 @@ export async function runBrowserProgram(
         globalThis.__webcmdTransportReceive = message => {
           connection.dispatch(JSON.parse(message));
         };
-        globalThis.__webcmdWriteArtifact = async (filename, bytes, contentType) => {
-          await __webcmdHostCall(
+        globalThis.writeArtifact = async (filename, bytes, contentType) => (
+          __webcmdHostCall(
             'writeArtifact',
-            JSON.stringify([filename, __webcmdEncodeBase64(bytes), contentType]),
-          );
-        };
+            JSON.stringify([
+              filename,
+              __webcmdEncodeBase64(bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)),
+              contentType,
+            ]),
+          )
+        );
+        // Legacy alias; writeArtifact is the documented name.
+        globalThis.__webcmdWriteArtifact = globalThis.writeArtifact;
         __WebcmdPlaywrightClient.quickjsPlatform.fs().promises.readFile = () => (
           unsupported('Host filesystem reads')
         );

--- a/src/skills.test.ts
+++ b/src/skills.test.ts
@@ -216,7 +216,8 @@ describe('webcmd skills content', () => {
     expect(browser).not.toContain('page.snapshotForAI()');
     expect(browser).not.toContain('--snapshot-diff');
     expect(browserRunReference).toMatch(/sandbox boundaries/i);
-    expect(browserRunReference).toMatch(/artifact paths/i);
+    expect(browserRunReference).toMatch(/artifacts/i);
+    expect(browserRunReference).toContain("writeArtifact(");
     expect(browserRunReference).toMatch(/errors/i);
     expect(browserRunReference).toMatch(/snapshot behavior/i);
     expect(browserRunReference).toContain('--snapshot-mode act|tree');


### PR DESCRIPTION
Closes #339.

> **Stacked on #344** (`fix/browser-run-globals`). Base is that branch, not `main` — the docs example uses `TextEncoder`, which #344 adds, and both PRs edit the same shim block. Review/merge #344 first.

## What

`__webcmdWriteArtifact` was the only way to get bytes out of the QuickJS sandbox, and its dunder prefix reads as "private implementation detail" to anything that finds it. An internal agent-behaviour eval showed an agent capture a download correctly, fail to find any way to persist it, then fall back to scraping the on-page preview and hand-writing a mismatched file.

- **`globalThis.writeArtifact(filename, bytes, contentType?)`** is now the public name. Bare global, matching the flat `page`/`context`/`browser` precedent — a `webcmd.*` namespace would be a second discovery hop for one function, and the sandbox has no other namespaced surface to hang it off.
- `__webcmdWriteArtifact` stays as a direct alias to the same function, so in-flight programs and the internal `page.screenshot({ path })` wrapper are unaffected.
- It now **returns the receipt**. The old implementation did `await __webcmdHostCall(...)` with no `return`, so the receipt the host already produced was discarded. #339's check requires the receipt back, and the screenshot wrapper never needed it, which is why nothing caught this.
- It accepts `Uint8Array` or anything `new Uint8Array(...)` accepts.

## Bug found while testing the two-argument call

Calling `writeArtifact(name, bytes)` without a `contentType` failed with `BROWSER_RUN_INVALID_INPUT`. `JSON.stringify([f, b, undefined])` yields `[f, b, null]`, and the host guard tested `args[2] !== undefined && typeof args[2] !== 'string'`, so `null` fell through to the rejection. Loosened to `args[2] != null`; the downstream default was already `args[2] ?? artifactContentType(...)`, which handles `null` correctly. Only the screenshot wrapper called this before, and it always passes a content type, so the two-argument path had never run.

## Docs

`skills/webcmd-browser/references/browser-run-playwright.md` gains an "Artifacts: getting bytes out of the sandbox" section covering the signature, the download path, and receipt redemption.

That file is being rewritten in #342. This PR branches off `main`'s version rather than #342's, so it does not carry that rewrite — but the section is written in #342's structure and tone (short prose, fenced examples, worked cases) so it slots straight into its "Files and binary data" area on merge.

Two things I verified in the sandbox before writing the example, rather than assuming:

- **`download.createReadStream()` throws** `Readable streams are not available in the QuickJS sandbox`. This is the obvious thing to reach for after catching a download event, and it is a dead end.
- **`download.saveAs('relative/name.csv')` already works** and routes through the artifact sink, producing a receipt in `output.artifacts` with no `writeArtifact` call at all. That is the correct answer for the download case and was documented nowhere. The docs now lead with it.

`src/skills.test.ts` asserted the old `/artifact paths/i` heading; retargeted to `/artifacts/i` plus a literal `writeArtifact(` check, which is a stronger assertion than the heading text.

## Tests

`returns a redeemable receipt from %s`, parameterized over `writeArtifact` and `__webcmdWriteArtifact`, in `src/browser/run/runner.test.ts`. Each writes through a `LocalBrowserRunArtifactSink` pointed at a temp dir, asserts the returned receipt's shape, asserts it equals the entry in `output.artifacts`, and reads the bytes back off disk at `<baseDir>/<artifactId>/<filename>` after `run` returns. Uses a nested logical path and a multi-byte character so the byte count is a real check.

### Counts

`npm run build` clean.

`npx vitest run --project unit`:

| | passed | skipped | failed |
|---|---|---|---|
| `main`, no Chromium installed (stated baseline) | 2457 | 57 | 0 |
| `main`, Chromium installed | 2513 | 1 | 0 |
| #344 (this PR's base) | 2518 | 1 | 0 |
| this branch | 2520 | 1 | 0 |

`runner.test.ts` is gated on a local Chromium binary, which is why the stated 2457 baseline shows 57 skips. I installed Chromium via `node_modules/playwright-core/cli.js install chromium` so these tests actually execute. The +2 over #344 is exactly the two parameterized cases above.

## Cloud

No change needed. `webcmd-cloud` imports `runBrowserProgram` from `@agentrhq/webcmd/browser/run` at `src/browser/hosted-browser.ts:17`, so hosted runs get `writeArtifact` when the cloud bumps its pinned `@agentrhq/webcmd` (currently 0.7.2 on its `main`) — not bumped here.

This PR adds a sandbox global and loosens a host-side argument guard; it does not change the `BrowserRunArtifactSink` interface. `webcmd-cloud/src/browser/run-artifact-sink.ts` implements exactly that interface — `write({ filename, contentType, bytes }) => BrowserRunArtifactReceipt` — and is unaffected. Its receipts already flow back through the same `output.artifacts` array, with a `cloud-artifact://` locator instead of `browser-run://`, which the new docs note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
