### PR TITLE
feat(session): address browser Sessions by name

### DIFF
--- a/skills/webcmd-browser/SKILL.md
+++ b/skills/webcmd-browser/SKILL.md
@@ -31,9 +31,11 @@ Until `doctor` is green, browser commands may fail. Registry and plugin discover
 ## Session lifecycle
 
 - Create an opaque browser session before raw browser work: `webcmd --profile <profile> session create`.
-- Raw browser commands require that ID at the root: `webcmd --session <session-id> browser ...`; the old positional session form is retired.
+- Name a session you intend to reuse: `webcmd session create --name research`. Then `--session research` works anywhere `--session <session-id>` does, and `webcmd session rename <session-id> <name>` names one after the fact. Names are unique per profile.
+- When told to work in a named session, address it by name. If it does not exist the command fails with `SESSION_NOT_FOUND` and lists the sessions that do — never create a replacement session instead.
+- Raw browser commands accept that ID or name at the root: `webcmd --session <session-id|name> browser ...`; the old positional session form is retired.
 - Profiles are cookie jars and auth scope; sessions are browser workspaces/windows within a profile. Parallel agents use separate sessions.
-- `webcmd session list` shows sessions and their handoff/runtime state; close finished work with `webcmd session close <session-id>`. Close is blocked while that Session has a live handoff.
+- `webcmd session list` shows each session's name, handoff, and runtime state; close finished work with `webcmd session close <session-id>`. Close is blocked while that Session has a live handoff.
 - Browser state in the bound page persists between calls, but each `run` gets a fresh JavaScript scope.
 - `webcmd --session <session-id> browser tabs` lists existing pages without creating a new one.
 - `webcmd --session <session-id> browser bind --page <page-id>` explicitly attaches the session to an existing page.

--- a/src/browser/protocol.ts
+++ b/src/browser/protocol.ts
@@ -71,6 +71,8 @@ export interface BrowserRuntimeCommand {
   discard?: boolean;
   /** Maximum Session rows returned by session-list. */
   limit?: number;
+  /** Optional user-supplied Session alias for session-create. */
+  sessionName?: string;
   cdpMethod?: string;
   cdpParams?: Record<string, unknown>;
   windowMode?: BrowserWindowMode;

--- a/src/browser/runtime/local-cloak/provider.ts
+++ b/src/browser/runtime/local-cloak/provider.ts
@@ -50,7 +50,7 @@ export class LocalCloakRuntimeProvider implements BrowserRuntimeProvider {
   }
 
   async createSession(command: BrowserRuntimeCommand): Promise<BrowserSessionRecord> {
-    return this.sessions.create(this.resolveProfileId(command));
+    return this.sessions.create(this.resolveProfileId(command), command.sessionName);
   }
 
   async requireSession(command: BrowserRuntimeCommand): Promise<BrowserSessionRecord> {

--- a/src/browser/sessions.test.ts
+++ b/src/browser/sessions.test.ts
@@ -149,6 +149,63 @@ describe('LocalBrowserSessionStore', () => {
       isActive: session => session.id === 'session_active',
     }).find('work', 'session_active')).toBeDefined();
   });
+  it('addresses a named session by alias and survives a reload', () => {
+    const baseDir = tempDir();
+    let next = 0;
+    const store = new LocalBrowserSessionStore({ baseDir, idFactory: () => `session_${++next}` });
+
+    const created = store.create('profile_work', 'research');
+
+    expect(created.name).toBe('research');
+    // Round trip through the file so a daemon rewrite cannot silently drop the alias.
+    expect(new LocalBrowserSessionStore({ baseDir }).resolveSelector('profile_work', 'research')).toBe(created.id);
+    expect(new LocalBrowserSessionStore({ baseDir }).list('profile_work').map((row) => row.name)).toEqual(['research']);
+  });
+
+  it('fails loudly on an unknown alias and names the sessions that do exist', () => {
+    const store = new LocalBrowserSessionStore({ baseDir: tempDir(), idFactory: () => 'session_known' });
+    store.create('profile_work', 'research');
+
+    expect(() => store.resolveSelector('profile_work', 'missing')).toThrowError(expect.objectContaining({
+      code: 'SESSION_NOT_FOUND',
+      hint: expect.stringContaining('session_known (research)'),
+    }));
+    expect(() => store.resolveSelector('profile_work', 'not an alias')).toThrowError(
+      expect.objectContaining({ code: 'INVALID_SESSION_SELECTOR' }),
+    );
+    // Opaque IDs pass through untouched so a stale local file cannot mask a live Session.
+    expect(store.resolveSelector('profile_work', 'session_elsewhere')).toBe('session_elsewhere');
+  });
+
+  it('keeps aliases unique per profile and reusable across profiles', () => {
+    let next = 0;
+    const store = new LocalBrowserSessionStore({ baseDir: tempDir(), idFactory: () => `session_${++next}` });
+    const first = store.create('profile_work', 'research');
+
+    expect(() => store.create('profile_work', 'research')).toThrowError(expect.objectContaining({
+      code: 'SESSION_NAME_TAKEN',
+    }));
+    const other = store.create('profile_personal', 'research');
+    expect(other.id).not.toBe(first.id);
+    expect(store.resolveSelector('profile_work', 'research')).toBe(first.id);
+    expect(store.resolveSelector('profile_personal', 'research')).toBe(other.id);
+  });
+
+  it('renames an existing session and rejects ID-shaped or malformed aliases', () => {
+    let next = 0;
+    const store = new LocalBrowserSessionStore({ baseDir: tempDir(), idFactory: () => `session_${++next}` });
+    const created = store.create('profile_work');
+
+    expect(store.rename('profile_work', created.id, 'research').name).toBe('research');
+    expect(store.rename('profile_work', created.id, 'research').name).toBe('research');
+    expect(store.resolveSelector('profile_work', 'research')).toBe(created.id);
+    expect(() => store.rename('profile_work', created.id, 'session_fake')).toThrowError(
+      expect.objectContaining({ code: 'INVALID_SESSION_NAME' }),
+    );
+    expect(() => store.rename('profile_work', 'session_missing', 'other')).toThrowError(
+      expect.objectContaining({ code: 'SESSION_NOT_FOUND' }),
+    );
+  });
 });
 
 function sessionRecord(

--- a/src/browser/sessions.ts
+++ b/src/browser/sessions.ts
@@ -8,6 +8,8 @@ import { CliError, ConfigError, EXIT_CODES } from '../errors.js';
 export interface BrowserSessionRecord {
   id: string;
   profileId: string;
+  /** Optional user-supplied alias, unique per Profile. */
+  name?: string;
   kind: 'explicit' | 'adapter-default';
   createdAt: string;
   updatedAt: string;
@@ -30,12 +32,49 @@ type StateFile = { version: 1; sessions: BrowserSessionRecord[] };
 const SESSION_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 
 export class SessionNotFoundError extends CliError {
-  constructor(sessionId: string, profileId: string) {
+  constructor(sessionId: string, profileId: string, candidates: BrowserSessionRecord[] = []) {
     super(
       'SESSION_NOT_FOUND',
       `Session not found: ${sessionId}`,
-      `Run \`webcmd --profile ${profileId} session list\` to choose an existing Session.`,
+      formatSessionCandidates(profileId, candidates),
       EXIT_CODES.EMPTY_RESULT,
+    );
+  }
+}
+
+/**
+ * Agents that cannot resolve a Session selector otherwise create a fresh Session
+ * and silently lose the isolation the caller asked for, so the miss must name the
+ * Sessions that do exist.
+ */
+function formatSessionCandidates(profileId: string, candidates: BrowserSessionRecord[]): string {
+  const listCommand = `Run \`webcmd --profile ${profileId} session list\` to choose an existing Session.`;
+  if (candidates.length === 0) return listCommand;
+  const known = candidates
+    .slice(0, 10)
+    .map((row) => (row.name ? `${row.id} (${row.name})` : row.id))
+    .join(', ');
+  return `Known Sessions for Profile ${profileId}: ${known}. ${listCommand}`;
+}
+
+export class SessionNameTakenError extends CliError {
+  constructor(name: string, sessionId: string, profileId: string) {
+    super(
+      'SESSION_NAME_TAKEN',
+      `Session name "${name}" is already used by ${sessionId} in Profile ${profileId}.`,
+      'Pick another name, or rename the existing Session first.',
+      EXIT_CODES.USAGE_ERROR,
+    );
+  }
+}
+
+export class InvalidSessionNameError extends CliError {
+  constructor(name: string, reason: string) {
+    super(
+      'INVALID_SESSION_NAME',
+      `Invalid Session name "${name}": ${reason}`,
+      'Use 1-64 characters: letters, digits, dash, underscore, or dot; it must not start with `session_`.',
+      EXIT_CODES.USAGE_ERROR,
     );
   }
 }
@@ -64,12 +103,46 @@ export class LocalBrowserSessionStore {
     this.isActive = opts.isActive ?? (() => false);
   }
 
-  create(profileId: string): BrowserSessionRecord {
+  create(profileId: string, name?: string): BrowserSessionRecord {
     const state = this.load();
+    const alias = name === undefined ? undefined : normalizeSessionName(name);
+    if (alias) this.requireNameFree(state, profileId, alias);
     const record = this.newRecord(profileId, 'explicit', state.sessions);
+    if (alias) record.name = alias;
     state.sessions.push(record);
     this.save(state);
     return { ...record };
+  }
+
+  rename(profileId: string, sessionId: string, name: string): BrowserSessionRecord {
+    const alias = normalizeSessionName(name);
+    const state = this.load();
+    const record = this.requireMutable(state, profileId, sessionId);
+    this.requireNameFree(state, profileId, alias, record.id);
+    record.name = alias;
+    this.touchRecord(state, record);
+    return { ...record };
+  }
+
+  /**
+   * Resolve a `--session` selector to a Session ID. Opaque IDs pass through so a
+   * stale local file cannot mask a Session the runtime knows about; anything else
+   * is looked up as an alias and a miss is a loud SESSION_NOT_FOUND.
+   */
+  resolveSelector(profileId: string, selector: string): string {
+    const value = selector.trim();
+    if (isSessionIdShape(value)) return value;
+    if (!isSessionNameShape(value)) throw new InvalidSessionSelectorError(value);
+    const state = this.load();
+    const scoped = state.sessions.filter((row) => row.profileId === profileId);
+    const match = scoped.find((row) => row.name === value);
+    if (match) return match.id;
+    throw new SessionNotFoundError(value, profileId, scoped);
+  }
+
+  private requireNameFree(state: StateFile, profileId: string, name: string, exceptId?: string): void {
+    const clash = state.sessions.find((row) => row.profileId === profileId && row.name === name && row.id !== exceptId);
+    if (clash) throw new SessionNameTakenError(name, clash.id, profileId);
   }
 
   find(profileId: string, sessionId: string): BrowserSessionRecord | undefined {
@@ -84,7 +157,7 @@ export class LocalBrowserSessionStore {
     requireSessionIdShape(id);
     const state = this.load();
     const record = state.sessions.find((row) => row.id === id && row.profileId === profileId);
-    if (!record) throw new SessionNotFoundError(id, profileId);
+    if (!record) throw new SessionNotFoundError(id, profileId, state.sessions.filter((row) => row.profileId === profileId));
     this.touchRecord(state, record);
     return { ...record };
   }
@@ -176,7 +249,7 @@ export class LocalBrowserSessionStore {
   private requireMutable(state: StateFile, profileId: string, sessionId: string): BrowserSessionRecord {
     requireSessionIdShape(sessionId);
     const record = state.sessions.find((row) => row.id === sessionId && row.profileId === profileId);
-    if (!record) throw new SessionNotFoundError(sessionId, profileId);
+    if (!record) throw new SessionNotFoundError(sessionId, profileId, state.sessions.filter((row) => row.profileId === profileId));
     return record;
   }
 
@@ -232,11 +305,12 @@ function validateState(value: unknown): StateFile {
     throw new ConfigError('browser-sessions.json has an unsupported schema.');
   }
   const adapterDefaults = new Set<string>();
-  const sessions = state.sessions.map((row) => validateRecord(row, adapterDefaults));
+  const names = new Set<string>();
+  const sessions = state.sessions.map((row) => validateRecord(row, adapterDefaults, names));
   return { version: 1, sessions };
 }
 
-function validateRecord(value: unknown, adapterDefaults: Set<string>): BrowserSessionRecord {
+function validateRecord(value: unknown, adapterDefaults: Set<string>, names: Set<string>): BrowserSessionRecord {
   if (!value || typeof value !== 'object') throw new ConfigError('browser-sessions.json contains an invalid Session record.');
   const row = value as Partial<BrowserSessionRecord>;
   if (typeof row.id !== 'string') throw new ConfigError('browser-sessions.json contains a Session without an id.');
@@ -260,6 +334,14 @@ function validateRecord(value: unknown, adapterDefaults: Set<string>): BrowserSe
     if (adapterDefaults.has(key)) throw new ConfigError(`browser-sessions.json contains multiple adapter-default Sessions for ${key}.`);
     adapterDefaults.add(key);
   }
+  let name: string | undefined;
+  if (row.name !== undefined) {
+    if (typeof row.name !== 'string') throw new ConfigError('browser-sessions.json contains an invalid Session name.');
+    name = normalizeSessionName(row.name);
+    const key = `${row.profileId} ${name}`;
+    if (names.has(key)) throw new ConfigError(`browser-sessions.json contains a duplicate Session name for ${row.profileId}.`);
+    names.add(key);
+  }
   const handoff = row.handoff;
   if (handoff && (
     typeof handoff.site !== 'string'
@@ -272,6 +354,7 @@ function validateRecord(value: unknown, adapterDefaults: Set<string>): BrowserSe
   return {
     id: row.id,
     profileId: row.profileId,
+    ...(name ? { name } : {}),
     kind: row.kind,
     createdAt,
     updatedAt,
@@ -280,8 +363,29 @@ function validateRecord(value: unknown, adapterDefaults: Set<string>): BrowserSe
   };
 }
 
+export function isSessionIdShape(sessionId: string): boolean {
+  return /^session_[A-Za-z0-9_-]+$/u.test(sessionId);
+}
+
 export function requireSessionIdShape(sessionId: string): void {
-  if (!/^session_[A-Za-z0-9_-]+$/u.test(sessionId)) throw new InvalidSessionSelectorError(sessionId);
+  if (!isSessionIdShape(sessionId)) throw new InvalidSessionSelectorError(sessionId);
+}
+
+/**
+ * A name that looks like an ID would make selector resolution ambiguous, so
+ * `session_`-prefixed aliases are rejected outright.
+ */
+export function isSessionNameShape(name: string): boolean {
+  return name.length <= 64 && !name.startsWith('session_') && /^[A-Za-z0-9][A-Za-z0-9_.-]*$/u.test(name);
+}
+
+export function normalizeSessionName(name: string): string {
+  const value = name.trim();
+  if (!value) throw new InvalidSessionNameError(name, 'a name is required');
+  if (value.length > 64) throw new InvalidSessionNameError(name, 'names are limited to 64 characters');
+  if (value.startsWith('session_')) throw new InvalidSessionNameError(name, 'names must not look like a Session ID');
+  if (!isSessionNameShape(value)) throw new InvalidSessionNameError(name, 'names allow letters, digits, dash, underscore, and dot');
+  return value;
 }
 
 function getWebcmdConfigDir(): string {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import yaml from 'js-yaml';
 import { cli, getRegistry, runWithDiscoverySource, Strategy } from './registry.js';
+import { LocalBrowserSessionStore } from './browser/sessions.js';
 import { BrowserCommandError } from './browser/daemon-client.js';
 import { getDaemonRunContext } from './session-lease.js';
 import type { IPage } from './types.js';
@@ -1740,7 +1741,7 @@ describe('browser raw session commands', () => {
 
   it.each([
     { argv: ['browser', 'tabs'], code: 'SESSION_REQUIRED' },
-    { argv: ['--session', 'work', 'browser', 'tabs'], code: 'INVALID_SESSION_SELECTOR' },
+    { argv: ['--session', 'not a session', 'browser', 'tabs'], code: 'INVALID_SESSION_SELECTOR' },
   ])('rejects an unusable raw selector with exit 2 before daemon dispatch: $code', async ({ argv, code }) => {
     const program = createProgram('', '');
 
@@ -1750,6 +1751,28 @@ describe('browser raw session commands', () => {
     expect(mockListExistingBrowserTabs).not.toHaveBeenCalled();
     expect(mockSendCommand).not.toHaveBeenCalled();
     expect(stderrSpy.mock.calls.flat().join('')).toContain(code);
+  });
+
+  it('addresses a named Session by alias and refuses to fall through on a miss', async () => {
+    const store = new LocalBrowserSessionStore();
+    const named = store.create('default', 'research');
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'webcmd', '--session', 'research', 'browser', 'tabs']);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(mockListExistingBrowserTabs).toHaveBeenCalledWith(named.id, expect.anything());
+
+    mockListExistingBrowserTabs.mockClear();
+    await createProgram('', '').parseAsync(['node', 'webcmd', '--session', 'ghost', 'browser', 'tabs']);
+
+    // The point of the feature: an unresolved name must not quietly become a new Session.
+    expect(process.exitCode).toBe(66);
+    expect(mockListExistingBrowserTabs).not.toHaveBeenCalled();
+    expect(mockSendCommand).not.toHaveBeenCalled();
+    const stderr = stderrSpy.mock.calls.flat().join('');
+    expect(stderr).toContain('SESSION_NOT_FOUND');
+    expect(stderr).toContain(`${named.id} (research)`);
   });
 
   it('lists tabs without allocating a local browser runtime', async () => {
@@ -1884,6 +1907,47 @@ describe('browser Session lifecycle commands', () => {
     expect(output).toContain('session_abc');
     expect(output).toContain('runtimeState');
     expect(output).not.toContain('profileId');
+  });
+
+  it('sends --name to the daemon and surfaces the alias in create and list output', async () => {
+    mockSendCommand.mockResolvedValue({
+      id: 'session_named', name: 'research', kind: 'explicit', profileId: 'default', runtimeState: 'idle',
+    });
+
+    await createProgram('', '').parseAsync(['node', 'webcmd', 'session', 'create', '--name', 'research', '-f', 'json']);
+
+    expect(mockSendCommand).toHaveBeenCalledWith('session-create', { contextId: 'default', sessionName: 'research' });
+    expect(JSON.parse(consoleLogSpy.mock.calls.flat().join('\n'))).toMatchObject({ id: 'session_named', name: 'research' });
+  });
+
+  it('fails loudly when a daemon creates the Session without the requested name', async () => {
+    mockSendCommand.mockResolvedValue({ id: 'session_unnamed', kind: 'explicit', profileId: 'default', runtimeState: 'idle' });
+
+    await expect(createProgram('', '').parseAsync(['node', 'webcmd', 'session', 'create', '--name', 'research']))
+      .rejects.toMatchObject({ code: 'SESSION_NAME_UNSUPPORTED' });
+  });
+
+  it('renames a persisted Session and lists it under its name', async () => {
+    const baseDir = path.join(isolatedCliTestHome, '.webcmd');
+    fs.mkdirSync(baseDir, { recursive: true });
+    fs.writeFileSync(path.join(baseDir, 'browser-sessions.json'), JSON.stringify({
+      version: 1,
+      sessions: [{
+        id: 'session_renamable',
+        profileId: 'default',
+        kind: 'explicit',
+        createdAt: '2026-08-11T00:00:00.000Z',
+        updatedAt: '2026-08-11T00:00:00.000Z',
+        lastUsedAt: '2026-08-11T00:00:00.000Z',
+      }],
+    }), { mode: 0o600 });
+
+    await createProgram('', '').parseAsync(['node', 'webcmd', 'session', 'rename', 'session_renamable', 'research', '-f', 'json']);
+    consoleLogSpy.mockClear();
+    await createProgram('', '').parseAsync(['node', 'webcmd', 'session', 'list', '-f', 'json']);
+
+    expect(JSON.parse(consoleLogSpy.mock.calls.flat().join('\n')))
+      .toEqual([expect.objectContaining({ id: 'session_renamable', name: 'research' })]);
   });
 
   it('lists persisted Sessions without creating the adapter default when daemon is absent', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,7 +52,7 @@ import type { BrowserDownloadWaitResult, IPage, ScreenshotOptions } from './type
 import type { BrowserWindowMode } from './runtime.js';
 import { configureRootCommandSurface } from './root-command-surface.js';
 import { validateRawBrowserSession } from './hosted/browser-args.js';
-import { LocalBrowserSessionStore, requireSessionIdShape, type BrowserSessionListRow } from './browser/sessions.js';
+import { LocalBrowserSessionStore, isSessionIdShape, normalizeSessionName, requireSessionIdShape, type BrowserSessionListRow } from './browser/sessions.js';
 import { missingPluginGuidance, PLUGINS_DIR } from './discovery.js';
 import { loadBrowserRunSource } from './browser/run/input.js';
 import { BrowserRunError } from './browser/run/types.js';
@@ -556,7 +556,15 @@ function getCommandOption(command: Command | undefined, option: string): unknown
 }
 
 function getBrowserSession(command?: Command): string {
-  return validateRawBrowserSession(getCommandOption(command, 'session'), getCommandOption(command, 'profile') as string | undefined);
+  const raw = getCommandOption(command, 'session');
+  const profile = getCommandOption(command, 'profile') as string | undefined;
+  // Resolve aliases before shape validation so a named Session is addressable
+  // everywhere an ID is, and an unknown selector fails loudly instead of
+  // falling through to a fresh Session.
+  const selector = typeof raw === 'string' && raw.trim() && !isSessionIdShape(raw.trim())
+    ? new LocalBrowserSessionStore().resolveSelector(getSelectedProfileId(command), raw)
+    : raw;
+  return validateRawBrowserSession(selector, profile);
 }
 
 function getBrowserProfileSelection(command?: Command): ProfileSelection | undefined {
@@ -575,7 +583,7 @@ function formatHandoff(row: BrowserSessionListRow): string {
 function sessionCreateOutput(data: unknown): unknown {
   if (!data || typeof data !== 'object' || Array.isArray(data)) return data;
   const row = data as Record<string, unknown>;
-  return { id: row.id, kind: row.kind, runtimeState: row.runtimeState };
+  return { id: row.id, ...(typeof row.name === 'string' ? { name: row.name } : {}), kind: row.kind, runtimeState: row.runtimeState };
 }
 
 function applyVerbose(opts: { verbose?: boolean }): void {
@@ -821,13 +829,39 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string, pluginsDi
   sessionCmd
     .command('create')
     .description('Create a new opaque browser Session ID for the selected Profile')
+    .option('--name <alias>', 'Reusable Session alias, unique per Profile (e.g. research)')
     .option('-f, --format <fmt>', OUTPUT_FORMAT_HELP, 'yaml')
     .action(async (opts, command) => {
       const fmt = resolveOutputFormat(opts.format);
       if (fmt === null) return;
       const profileId = getSelectedProfileId(command);
-      const data = await sendCommand('session-create', { contextId: profileId });
-      await renderOutput(sessionCreateOutput(data), { fmt, fmtExplicit: command.getOptionValueSource('format') === 'cli', columns: ['id', 'kind', 'runtimeState'] });
+      const name = opts.name === undefined ? undefined : normalizeSessionName(opts.name);
+      const data = await sendCommand('session-create', { contextId: profileId, ...(name ? { sessionName: name } : {}) });
+      // An older daemon silently drops the alias, which is the failure this feature exists to remove.
+      if (name && (data as { name?: unknown } | null)?.name !== name) {
+        throw new CliError(
+          'SESSION_NAME_UNSUPPORTED',
+          `The running daemon created the Session without the name "${name}".`,
+          'Run `webcmd daemon restart` to pick up this Webcmd version, then retry.',
+          EXIT_CODES.GENERIC_ERROR,
+        );
+      }
+      await renderOutput(sessionCreateOutput(data), { fmt, fmtExplicit: command.getOptionValueSource('format') === 'cli', columns: ['id', 'name', 'kind', 'runtimeState'] });
+    });
+
+  sessionCmd
+    .command('rename')
+    .description('Assign a reusable alias to an existing browser Session')
+    .argument('<session-id>', 'Existing opaque Session ID from `webcmd session create`')
+    .argument('<alias>', 'Session alias, e.g. research or checkout-qa')
+    .option('-f, --format <fmt>', OUTPUT_FORMAT_HELP, 'yaml')
+    .action(async (sessionId: string, alias: string, opts: { format?: string }, command) => {
+      const fmt = resolveOutputFormat(opts.format);
+      if (fmt === null) return;
+      const profileId = getSelectedProfileId(command);
+      requireSessionIdShape(sessionId);
+      const record = new LocalBrowserSessionStore().rename(profileId, sessionId, alias);
+      await renderOutput(record, { fmt, fmtExplicit: command.getOptionValueSource('format') === 'cli', columns: ['id', 'name', 'kind'] });
     });
 
   sessionCmd
@@ -851,7 +885,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string, pluginsDi
         console.log(`No browser Sessions found for Profile ${profileId}.`);
         return;
       }
-      await renderOutput(output, { fmt, fmtExplicit: command.getOptionValueSource('format') === 'cli', columns: ['id', 'kind', 'runtimeState', 'handoff'] });
+      await renderOutput(output, { fmt, fmtExplicit: command.getOptionValueSource('format') === 'cli', columns: ['id', 'name', 'kind', 'runtimeState', 'handoff'] });
     });
 
   sessionCmd
@@ -864,6 +898,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string, pluginsDi
       const fmt = resolveOutputFormat(opts.format);
       if (fmt === null) return;
       const profileId = getSelectedProfileId(command);
+      sessionId = new LocalBrowserSessionStore().resolveSelector(profileId, sessionId);
       requireSessionIdShape(sessionId);
       const status = await fetchDaemonStatus({ contextId: profileId });
       if (!status || (status.runtimeConnected && !isDaemonStale(status, PKG_VERSION))) {

--- a/src/hosted/browser-args.test.ts
+++ b/src/hosted/browser-args.test.ts
@@ -12,9 +12,11 @@ describe('hosted browser argument surface', () => {
     expect(() => validateRawBrowserSession(undefined)).toThrowError(
       expect.objectContaining({ code: 'SESSION_REQUIRED', exitCode: 2 }),
     );
-    expect(() => validateRawBrowserSession('work')).toThrowError(
+    expect(() => validateRawBrowserSession('not a session')).toThrowError(
       expect.objectContaining({ code: 'INVALID_SESSION_SELECTOR', exitCode: 2 }),
     );
+    // A Session alias is a valid selector; the server resolves it.
+    expect(validateRawBrowserSession('research')).toBe('research');
   });
 
   it('includes the selected profile in raw-session recovery commands', () => {

--- a/src/hosted/browser-args.ts
+++ b/src/hosted/browser-args.ts
@@ -6,6 +6,7 @@ import {
 } from '../browser/command-catalog.js';
 import { CommanderStructuralError } from '../command-surface.js';
 import { CliError, EXIT_CODES } from '../errors.js';
+import { isSessionIdShape, isSessionNameShape } from '../browser/sessions.js';
 import { configureRootCommandSurface } from '../root-command-surface.js';
 
 export class HostedBrowserHelp extends Error {
@@ -29,8 +30,9 @@ export function validateRawBrowserSession(value: unknown, profile?: string): str
   const profileFlag = profile?.trim() ? ` --profile ${profile.trim()}` : '';
   const help = `Create one: webcmd${profileFlag} session create\nList sessions: webcmd${profileFlag} session list`;
   if (!session) throw new CliError('SESSION_REQUIRED', 'A Session selector is required for browser commands.', help, EXIT_CODES.USAGE_ERROR);
-  if (!/^session_[A-Za-z0-9_-]+$/u.test(session)) {
-    throw new CliError('INVALID_SESSION_SELECTOR', 'Session selector must be an opaque Session ID.', help, EXIT_CODES.USAGE_ERROR);
+  // A Session alias is a valid selector; whoever owns the Session records resolves it.
+  if (!isSessionIdShape(session) && !isSessionNameShape(session)) {
+    throw new CliError('INVALID_SESSION_SELECTOR', 'Session selector must be an opaque Session ID or a Session name.', help, EXIT_CODES.USAGE_ERROR);
   }
   return session;
 }

--- a/src/hosted/client.test.ts
+++ b/src/hosted/client.test.ts
@@ -170,9 +170,9 @@ describe('HostedClient', () => {
       session: 'session_wire',
     });
     expect(requests.map(({ url, method, liveViewCapability }) => ({ url, method, liveViewCapability }))).toEqual([
-      { url: 'https://api.example.com/v1/sessions', method: 'POST', liveViewCapability: 'hosted-live-view-v1' },
-      { url: 'https://api.example.com/v1/sessions?profile=default&limit=20', method: 'GET', liveViewCapability: 'hosted-live-view-v1' },
-      { url: 'https://api.example.com/v1/sessions/session_wire/close', method: 'POST', liveViewCapability: 'hosted-live-view-v1' },
+      { url: 'https://api.example.com/v1/sessions', method: 'POST', liveViewCapability: 'hosted-live-view-v1,hosted-session-alias-v1' },
+      { url: 'https://api.example.com/v1/sessions?profile=default&limit=20', method: 'GET', liveViewCapability: 'hosted-live-view-v1,hosted-session-alias-v1' },
+      { url: 'https://api.example.com/v1/sessions/session_wire/close', method: 'POST', liveViewCapability: 'hosted-live-view-v1,hosted-session-alias-v1' },
     ]);
   });
 
@@ -220,7 +220,7 @@ describe('HostedClient', () => {
     expect(prepareBody).toEqual({
       command: 'github/whoami', profile: 'work', session: 'session_work', executionScope: 'profile',
     });
-    expect(prepareCapability).toBe('hosted-live-view-v1');
+    expect(prepareCapability).toBe('hosted-live-view-v1,hosted-session-alias-v1');
     await expect(client.prepareExecution({ command: 'github/unknown' })).rejects.toMatchObject({ code: 'HOSTED_PROTOCOL' });
   });
 

--- a/src/hosted/client.ts
+++ b/src/hosted/client.ts
@@ -135,10 +135,27 @@ export class HostedClient {
     return { ok: true, deleted: true };
   }
 
-  async createBrowserSession(profile?: string): Promise<HostedBrowserSessionResponse> {
+  async createBrowserSession(profile?: string, name?: string): Promise<HostedBrowserSessionResponse> {
     const body = await this.request('/v1/sessions', {
       method: 'POST',
-      body: JSON.stringify(profile !== undefined ? { profile } : {}),
+      body: JSON.stringify({
+        ...(profile !== undefined ? { profile } : {}),
+        ...(name !== undefined ? { name } : {}),
+      }),
+    });
+    if (!isHostedBrowserSessionResponse(body)) {
+      throw protocolError('Webcmd Cloud returned an invalid browser session response.');
+    }
+    if (name !== undefined && body.session.name !== name) {
+      throw protocolError('Webcmd Cloud created the Session without the requested name.');
+    }
+    return body;
+  }
+
+  async renameBrowserSession(session: string, name: string, profile?: string): Promise<HostedBrowserSessionResponse> {
+    const body = await this.request(`/v1/sessions/${encodeURIComponent(session)}/name${profileQuery(profile)}`, {
+      method: 'POST',
+      body: JSON.stringify({ name }),
     });
     if (!isHostedBrowserSessionResponse(body)) {
       throw protocolError('Webcmd Cloud returned an invalid browser session response.');
@@ -465,7 +482,7 @@ export class HostedClient {
         accept: 'application/json',
         authorization: `Bearer ${this.apiKey}`,
         'x-webcmd-session-protocol-version': String(HOSTED_SESSION_PROTOCOL_VERSION),
-        'x-webcmd-client-capabilities': 'hosted-live-view-v1',
+        'x-webcmd-client-capabilities': 'hosted-live-view-v1,hosted-session-alias-v1',
         ...(init.body ? { 'content-type': 'application/json' } : {}),
         ...(this.workspace ? { 'x-webcmd-workspace': this.workspace } : {}),
         ...(init.headers ?? {}),
@@ -647,7 +664,10 @@ function isHostedBrowserSessionCloseResponse(value: unknown): value is HostedBro
 }
 
 function isHostedBrowserSession(value: unknown): boolean {
-  return hasExactKeys(value, ['id', 'kind', 'profileId', 'runtimeState', 'handoff', 'createdAt', 'updatedAt', 'lastUsedAt'])
+  // `name` stays optional so this CLI keeps working against a cloud that predates Session aliases.
+  return hasOnlyKeys(value, ['id', 'name', 'kind', 'profileId', 'runtimeState', 'handoff', 'createdAt', 'updatedAt', 'lastUsedAt'])
+    && ['id', 'kind', 'profileId', 'runtimeState', 'handoff', 'createdAt', 'updatedAt', 'lastUsedAt'].every((key) => key in value)
+    && (value.name === undefined || typeof value.name === 'string')
     && typeof value.id === 'string'
     && (value.kind === 'explicit' || value.kind === 'adapter-default')
     && typeof value.profileId === 'string'

--- a/src/hosted/client.ts
+++ b/src/hosted/client.ts
@@ -7,6 +7,7 @@ import type {
   HostedBrowserFinishResponse,
   HostedBrowserSessionCloseResponse,
   HostedBrowserSessionResponse,
+  HostedRenamedBrowserSessionResponse,
   HostedBrowserSessionsResponse,
   HostedBrowserRunActionInput,
   HostedBrowserRunActionResponse,
@@ -152,15 +153,19 @@ export class HostedClient {
     return body;
   }
 
-  async renameBrowserSession(session: string, name: string, profile?: string): Promise<HostedBrowserSessionResponse> {
+  async renameBrowserSession(session: string, name: string, profile?: string): Promise<HostedRenamedBrowserSessionResponse> {
     const body = await this.request(`/v1/sessions/${encodeURIComponent(session)}/name${profileQuery(profile)}`, {
       method: 'POST',
       body: JSON.stringify({ name }),
     });
-    if (!isHostedBrowserSessionResponse(body)) {
+    // A rename carries no live view, so this row is a plain Session row.
+    if (!hasExactKeys(body, ['ok', 'session']) || body.ok !== true || !isHostedBrowserSession(body.session)) {
       throw protocolError('Webcmd Cloud returned an invalid browser session response.');
     }
-    return body;
+    if ((body.session as { name?: unknown }).name !== name) {
+      throw protocolError('Webcmd Cloud did not apply the requested Session name.');
+    }
+    return body as unknown as HostedRenamedBrowserSessionResponse;
   }
 
   async listBrowserSessions(profile?: string, limit?: number): Promise<HostedBrowserSessionsResponse> {

--- a/src/hosted/runner.test.ts
+++ b/src/hosted/runner.test.ts
@@ -782,6 +782,54 @@ describe('runHostedCli', () => {
     ]);
   });
 
+  it('sends hosted Session names on create/rename and passes an alias selector through to the server', async () => {
+    const named = {
+      id: 'session_named', name: 'research', kind: 'explicit', profileId: 'profile_default', runtimeState: 'idle',
+      handoff: null,
+      createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:01:00.000Z', lastUsedAt: '2026-01-01T00:02:00.000Z',
+    };
+    const requests: Array<{ url: string; method: string; body?: unknown }> = [];
+    const fetchImpl = vi.fn<typeof fetch>(async (url, init) => {
+      const request = {
+        url: String(url), method: init?.method ?? 'GET',
+        ...(init?.body ? { body: JSON.parse(String(init.body)) } : {}),
+      };
+      if (request.url.endsWith('/v1/manifest')) return manifestResponse();
+      requests.push(request);
+      if (request.url.includes('/v1/browser/')) return new Response(JSON.stringify({ ok: true, result: { tabs: [] } }));
+      return new Response(JSON.stringify({
+        ok: true,
+        session: { ...named, liveViewUrl: 'https://api.example.com/account/live/session_named' },
+      }));
+    });
+
+    const create = sink();
+    expect(await runHostedCli(['session', 'create', '--name', 'research', '-f', 'json'], {
+      config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
+      stdout: create.stream,
+      fetchImpl,
+    })).toEqual({ handled: true, exitCode: 0 });
+    expect(create.text()).toContain('"name": "research"');
+
+    await runHostedCli(['session', 'rename', 'session_named', 'research', '-f', 'json'], {
+      config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
+      stdout: sink().stream,
+      fetchImpl,
+    });
+    // The hosted client never resolves aliases itself; the tenant-scoped server owns that.
+    await runHostedCli(['--session', 'research', 'browser', 'tabs'], {
+      config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
+      stdout: sink().stream,
+      fetchImpl,
+    });
+
+    expect(requests).toEqual([
+      { url: 'https://api.example.com/v1/sessions', method: 'POST', body: { name: 'research' } },
+      { url: 'https://api.example.com/v1/sessions/session_named/name', method: 'POST', body: { name: 'research' } },
+      { url: 'https://api.example.com/v1/browser/research/commands', method: 'POST', body: expect.anything() },
+    ]);
+  });
+
   it('normalizes aliases and case across hosted Session create/list/close', async () => {
     const session = {
       id: 'session_abc', kind: 'explicit', profileId: 'profile_work', runtimeState: 'idle',
@@ -2388,7 +2436,7 @@ describe('runHostedCli', () => {
 
   it.each([
     { argv: ['browser', 'tabs'], code: 'SESSION_REQUIRED' },
-    { argv: ['--session', 'work', 'browser', 'tabs'], code: 'INVALID_SESSION_SELECTOR' },
+    { argv: ['--session', 'not a session', 'browser', 'tabs'], code: 'INVALID_SESSION_SELECTOR' },
   ])('rejects an unusable raw selector before hosted transport: $code', async ({ argv, code }) => {
     const stderr = sink();
     const fetchImpl = vi.fn<typeof fetch>();

--- a/src/hosted/runner.test.ts
+++ b/src/hosted/runner.test.ts
@@ -797,6 +797,8 @@ describe('runHostedCli', () => {
       if (request.url.endsWith('/v1/manifest')) return manifestResponse();
       requests.push(request);
       if (request.url.includes('/v1/browser/')) return new Response(JSON.stringify({ ok: true, result: { tabs: [] } }));
+      // A rename returns a plain Session row; only create carries a live view.
+      if (request.url.includes('/name')) return new Response(JSON.stringify({ ok: true, session: named }));
       return new Response(JSON.stringify({
         ok: true,
         session: { ...named, liveViewUrl: 'https://api.example.com/account/live/session_named' },

--- a/src/hosted/runner.ts
+++ b/src/hosted/runner.ts
@@ -36,6 +36,7 @@ import { HostedClient, HostedClientError, resolveWorkspace } from './client.js';
 import { HOSTED_SESSION_PROTOCOL_VERSION } from './types.js';
 import { parseHostedInvocation } from './args.js';
 import { HostedBrowserHelp, parseHostedBrowserStructure, validateRawBrowserSession } from './browser-args.js';
+import { normalizeSessionName } from '../browser/sessions.js';
 import { materializeHostedOutputs, prepareHostedFiles, rewriteHostedOutputResultPaths } from './files.js';
 import {
   findHostedCommand,
@@ -606,7 +607,7 @@ async function hostedAdapterSourceMetadata(client: HostedClient, key: string): P
 
 type ParsedHostedSessionSurface =
   | { kind: 'help'; output: string }
-  | { kind: 'run'; command: 'create' | 'list' | 'close'; format: string; formatExplicit: boolean; session?: string; force?: boolean; limit?: number };
+  | { kind: 'run'; command: 'create' | 'list' | 'close' | 'rename'; format: string; formatExplicit: boolean; session?: string; force?: boolean; limit?: number; name?: string };
 
 function parseHostedSessionSurface(argv: readonly string[], literal: boolean): ParsedHostedSessionSurface {
   let stdout = '';
@@ -621,11 +622,13 @@ function parseHostedSessionSurface(argv: readonly string[], literal: boolean): P
   root.exitOverride().configureOutput(output);
   session.exitOverride().configureOutput(output);
   const configure = (command: Command, format: string): Command => command.option('-f, --format <fmt>', OUTPUT_FORMAT_HELP, format);
-  const setParsed = (command: 'create' | 'list' | 'close', surface: Command, format: string, extras: Omit<Exclude<ParsedHostedSessionSurface, { kind: 'help' }>, 'kind' | 'command' | 'format' | 'formatExplicit'> = {}): void => {
+  const setParsed = (command: 'create' | 'list' | 'close' | 'rename', surface: Command, format: string, extras: Omit<Exclude<ParsedHostedSessionSurface, { kind: 'help' }>, 'kind' | 'command' | 'format' | 'formatExplicit'> = {}): void => {
     parsed = { kind: 'run', command, format: validateHostedFormat(format), formatExplicit: surface.getOptionValueSource('format') === 'cli', ...extras };
   };
-  const create = configure(session.command('create'), 'yaml');
-  create.action((options: { format: string }) => setParsed('create', create, options.format));
+  const create = configure(session.command('create').option('--name <alias>', 'Reusable Session alias, unique per workspace (e.g. research)'), 'yaml');
+  create.action((options: { format: string; name?: string }) => setParsed('create', create, options.format, options.name === undefined ? {} : { name: normalizeSessionName(options.name) }));
+  const rename = configure(session.command('rename').argument('<session-id>').argument('<alias>'), 'yaml');
+  rename.action((sessionId: string, alias: string, options: { format: string }) => setParsed('rename', rename, options.format, { session: sessionId, name: normalizeSessionName(alias) }));
   const list = configure(session.command('list').option('--limit <number>', 'Maximum Sessions to return (1-100)', parseHostedSessionListLimit, 20), 'table');
   list.action((options: { format: string; limit: number }) => setParsed('list', list, options.format, { limit: options.limit }));
   const close = configure(session.command('close').argument('<session-id>').option('--force', 'Close even while the Session is busy or paused for handoff'), 'yaml');
@@ -648,7 +651,11 @@ async function dispatchHostedSession(
   profile?: string,
 ): Promise<void> {
   if (parsed.command === 'create') {
-    await renderOutput(sessionCreateOutput((await client.createBrowserSession(profile)).session), { fmt: parsed.format, fmtExplicit: parsed.formatExplicit, columns: ['id', 'kind', 'runtimeState'], stdout });
+    await renderOutput(sessionCreateOutput((await client.createBrowserSession(profile, parsed.name)).session), { fmt: parsed.format, fmtExplicit: parsed.formatExplicit, columns: ['id', 'name', 'kind', 'runtimeState'], stdout });
+    return;
+  }
+  if (parsed.command === 'rename') {
+    await renderOutput(sessionCreateOutput((await client.renameBrowserSession(parsed.session!, parsed.name!, profile)).session), { fmt: parsed.format, fmtExplicit: parsed.formatExplicit, columns: ['id', 'name', 'kind', 'runtimeState'], stdout });
     return;
   }
   if (parsed.command === 'list') {
@@ -658,7 +665,7 @@ async function dispatchHostedSession(
       await writeToStream(stdout, `No browser Sessions found${profile ? ` for Profile ${profile}` : ''}.\n`);
       return;
     }
-    await renderOutput(rows, { fmt: parsed.format, fmtExplicit: parsed.formatExplicit, columns: ['id', 'kind', 'runtimeState', 'handoff'], stdout });
+    await renderOutput(rows, { fmt: parsed.format, fmtExplicit: parsed.formatExplicit, columns: ['id', 'name', 'kind', 'runtimeState', 'handoff'], stdout });
     return;
   }
   await renderOutput(await client.closeBrowserSession(parsed.session!, profile, parsed.force === true), { fmt: parsed.format, fmtExplicit: parsed.formatExplicit, stdout });
@@ -677,6 +684,7 @@ function sessionCreateOutput(data: unknown): unknown {
   const row = data as Record<string, unknown>;
   return {
     id: row.id,
+    ...(typeof row.name === 'string' ? { name: row.name } : {}),
     kind: row.kind,
     runtimeState: row.runtimeState,
     ...(typeof row.liveViewUrl === 'string' ? { liveViewUrl: row.liveViewUrl } : {}),

--- a/src/hosted/types.ts
+++ b/src/hosted/types.ts
@@ -92,6 +92,11 @@ export interface HostedBrowserSessionResponse {
   session: HostedCreatedBrowserSession;
 }
 
+export interface HostedRenamedBrowserSessionResponse {
+  ok: true;
+  session: HostedBrowserSession;
+}
+
 export interface HostedBrowserSessionsResponse {
   ok: true;
   sessions: HostedBrowserSession[];

--- a/src/hosted/types.ts
+++ b/src/hosted/types.ts
@@ -72,6 +72,8 @@ export interface HostedProfilesResponse {
 
 export interface HostedBrowserSession {
   id: string;
+  /** Present only when the Session has an alias and the server honours it. */
+  name?: string;
   kind: 'explicit' | 'adapter-default';
   profileId: string;
   runtimeState: 'active' | 'idle';


### PR DESCRIPTION
Closes #340.

Browser sessions were addressable only by opaque UUID, while profiles already had aliases via `webcmd profile rename`. An internal agent-behaviour eval showed the consequence: agents told to work in a named session could not resolve the name, so they created a new session and carried on as if they had complied. The isolation the caller asked for silently did not happen.

## What changed

- `webcmd session create --name <alias>` stores the alias on the Session record. The name is threaded through the daemon protocol (`sessionName`), and if a running daemon is old enough to drop it, `session create` fails with `SESSION_NAME_UNSUPPORTED` instead of quietly returning an unnamed Session.
- `--session` accepts a name anywhere it accepts an ID. Resolution runs *before* `requireSessionIdShape`, so `webcmd --session research browser ...` works.
- `webcmd session rename <session-id> <alias>` mirrors `webcmd profile rename <contextId> <alias>`.
- `session list` surfaces a `name` column (local and hosted).
- **Loud failure.** A selector that is neither a known ID nor a known alias now raises `SESSION_NOT_FOUND` with the Sessions that do exist listed in the hint (`session_abc (research), ...`). A malformed selector still raises `INVALID_SESSION_SELECTOR`. Neither path can fall through to creating a new Session.
- Opaque IDs are never looked up as aliases and pass through untouched, so a stale local file cannot mask a Session the runtime knows about. Aliases may not start with `session_`, which keeps that precedence unambiguous.
- `skills/webcmd-browser/SKILL.md` documents naming and the "address it by name, never create a replacement" rule, since the skill is what agents actually read.

## Local vs hosted, and why there is no sync

Hosted and local state are separate, per the cloud architecture rules — there is no implicit sync in either direction, and this PR adds none.

- **Local mode:** the alias lives on the record in `~/.webcmd/browser-sessions.json` and is **unique per Profile**. The CLI resolves it locally before dispatching to the daemon. Round-tripping through the store's validator preserves the name, so a daemon rewrite cannot drop it.
- **Hosted mode:** the CLI does not resolve anything. It forwards the selector verbatim and webcmd-cloud resolves it inside the caller's `(user_id, workspace_id)` scope — the tenant boundary is the server's to enforce, and a client-side alias map would leak across it. Hosted names are **unique per workspace**. See agentrhq/webcmd-cloud for the hosted half.

Consequently a name created locally does not resolve hosted, and vice versa. That is intentional: the two stores have different tenancy models, and syncing them would mean one mode inventing records the other owns.

Wire compatibility: the CLI now advertises `hosted-session-alias-v1` in `x-webcmd-client-capabilities`, and its session-row validator treats `name` as optional, so this CLI keeps working against a cloud deployment that predates Session aliases.

## Tests

`npm install && npm run build && npx vitest run --project unit`

- Baseline (`origin/main`, same machine, after build): **2513 passed, 0 failed, 1 skipped**
- With this change: **2522 passed, 0 failed, 1 skipped**

New coverage: alias round-trip through a store reload (`create --name x` → addressable as `--session x`), unknown alias errors with candidates instead of creating, malformed selector still `INVALID_SESSION_SELECTOR`, alias uniqueness per Profile with the same name reusable in another Profile, rename semantics and ID-shaped-alias rejection, `session list` showing the name, the daemon-dropped-name guard, and the hosted create/rename/alias-selector wire shape.

Note on counts: 56 browser-run tests are gated on a local Chromium binary. A run where that binary is absent reports 2457 passed / 57 skipped on `origin/main` — same zero failures, and none of those tests are touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)