### PR TITLE
fix(browser): make page.request usable in the run sandbox

### DIFF
--- a/src/browser/run/generated/playwright-client.js
+++ b/src/browser/run/generated/playwright-client.js
@@ -8929,7 +8929,7 @@ ${"=".repeat(headerLength)}`;
         let encodedParams = void 0;
         if (typeof options.params === "string")
           encodedParams = options.params;
-        else if (options.params instanceof URLSearchParams)
+        else if (globalThis.URLSearchParams && options.params instanceof URLSearchParams)
           encodedParams = options.params.toString();
         const headersObj = options.headers || options.request?.headers();
         const headers = headersObj ? headersObjectToArray(headersObj) : void 0;
@@ -8942,8 +8942,8 @@ ${"=".repeat(headerLength)}`;
             if (isJsonContentType(headers))
               jsonData = isJsonParsable(options.data) ? options.data : JSON.stringify(options.data);
             else
-              postDataBuffer = Buffer.from(options.data, "utf8");
-          } else if (Buffer.isBuffer(options.data)) {
+              postDataBuffer = quickjsEncoding.encodeText(options.data);
+          } else if (options.data instanceof Uint8Array) {
             postDataBuffer = options.data;
           } else if (typeof options.data === "object" || typeof options.data === "number" || typeof options.data === "boolean") {
             jsonData = JSON.stringify(options.data);
@@ -9020,7 +9020,7 @@ ${"=".repeat(headerLength)}`;
     const typeOfValue = typeof value;
     if (isFilePayload(value)) {
       const payload = value;
-      if (!Buffer.isBuffer(payload.buffer))
+      if (!(payload.buffer instanceof Uint8Array))
         throw new Error(`Unexpected buffer type of 'data.${name}'`);
       return { name, file: filePayloadToJson(payload) };
     } else if (typeOfValue === "string" || typeOfValue === "number" || typeOfValue === "boolean") {
@@ -9094,7 +9094,7 @@ ${"=".repeat(headerLength)}`;
     }
     async text() {
       const content = await this.body();
-      return content.toString("utf8");
+      return quickjsEncoding.decodeText(content);
     }
     async json() {
       const content = await this.text();

--- a/src/browser/run/playwright-client/README.md
+++ b/src/browser/run/playwright-client/README.md
@@ -17,6 +17,7 @@ This is the client-only subset of Playwright that runs in Webcmd's QuickJS sandb
 - `vendor/client/elementHandle.ts` accepts only in-memory upload payloads and rejects filesystem paths before attempting any filesystem operation.
 - `vendor/protocol/{serializers,validatorPrimitives}.ts` use injected base64 codecs and `Uint8Array` rather than `Buffer`.
 - `vendor/client/network.ts` decodes response bodies and post data with the injected UTF-8 codec; `Buffer.prototype.toString('utf8')` is unavailable and `Uint8Array.prototype.toString` would comma-join the bytes.
+- `vendor/client/fetch.ts` guards the `URLSearchParams` `instanceof` check behind `globalThis`, decodes `APIResponse.text()` with the injected UTF-8 codec, and treats request/multipart payloads as `Uint8Array`; `URLSearchParams` and `Buffer` are absent from the sandbox.
 - `vendor/isomorphic/time.ts` falls back to QuickJS's native `Date` when the browser `performance` global is absent.
 - Vendored TypeScript files are marked `@ts-nocheck`: the checked bundle is esbuild's transpiled artifact, while their upstream monorepo type aliases are intentionally not part of Webcmd's host compilation.
 

--- a/src/browser/run/playwright-client/vendor-manifest.json
+++ b/src/browser/run/playwright-client/vendor-manifest.json
@@ -2,5 +2,5 @@
   "version": "1.61.1",
   "commit": "39e3553a4f283a41134d75d7e404484bd9e6865a",
   "license": "Apache-2.0",
-  "vendorSha256": "d4d52ae934a794e60cc1e8fd6d09988c997322ab0e1d7ad25e2c98735c30ee8d"
+  "vendorSha256": "9fa452abf2ca9b89192260fad12ef90f4e0df87d0b16b67a4e15108e882acf9d"
 }

--- a/src/browser/run/playwright-client/vendor/client/fetch.ts
+++ b/src/browser/run/playwright-client/vendor/client/fetch.ts
@@ -25,6 +25,7 @@ import { RawHeaders } from './network';
 import { Tracing } from './tracing';
 import { mkdirIfNeeded } from './fileUtils';
 import { TimeoutSettings } from './timeoutSettings';
+import { quickjsEncoding } from '../../quickjs-platform';
 
 import type { Playwright } from './playwright';
 import type { ClientCertificate, FilePayload, Headers, RemoteAddr, SecurityDetails, SetStorageState, StorageState, TimeoutOptions } from './types';
@@ -183,7 +184,7 @@ export class APIRequestContext extends ChannelOwner<channels.APIRequestContextCh
       let encodedParams = undefined;
       if (typeof options.params === 'string')
         encodedParams = options.params;
-      else if (options.params instanceof URLSearchParams)
+      else if (globalThis.URLSearchParams && options.params instanceof URLSearchParams)
         encodedParams = options.params.toString();
       // Cannot call allHeaders() here as the request may be paused inside route handler.
       const headersObj = options.headers || options.request?.headers();
@@ -197,8 +198,8 @@ export class APIRequestContext extends ChannelOwner<channels.APIRequestContextCh
           if (isJsonContentType(headers))
             jsonData = isJsonParsable(options.data) ? options.data : JSON.stringify(options.data);
           else
-            postDataBuffer = Buffer.from(options.data, 'utf8');
-        } else if (Buffer.isBuffer(options.data)) {
+            postDataBuffer = quickjsEncoding.encodeText(options.data);
+        } else if (options.data instanceof Uint8Array) {
           postDataBuffer = options.data;
         } else if (typeof options.data === 'object' || typeof options.data === 'number' || typeof options.data === 'boolean') {
           jsonData = JSON.stringify(options.data);
@@ -278,7 +279,7 @@ async function toFormField(platform: Platform, name: string, value: string | num
   const typeOfValue = typeof value;
   if (isFilePayload(value)) {
     const payload = value as FilePayload;
-    if (!Buffer.isBuffer(payload.buffer))
+    if (!(payload.buffer instanceof Uint8Array))
       throw new Error(`Unexpected buffer type of 'data.${name}'`);
     return { name, file: filePayloadToJson(payload) };
   } else if (typeOfValue === 'string' || typeOfValue === 'number' || typeOfValue === 'boolean') {
@@ -366,7 +367,7 @@ export class APIResponse implements api.APIResponse {
 
   async text(): Promise<string> {
     const content = await this.body();
-    return content.toString('utf8');
+    return quickjsEncoding.decodeText(content);
   }
 
   async json(): Promise<object> {

--- a/src/browser/run/runner.test.ts
+++ b/src/browser/run/runner.test.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import { createRequire } from 'node:module';
@@ -555,6 +556,46 @@ afterAll(async () => {
       text: '{"id":1,"title":"Essence"}',
       json: { id: 1, title: 'Essence' },
     });
+  });
+
+  it('fetches through page.request and decodes the response as text', async () => {
+    const server = http.createServer((request, response) => {
+      const chunks: Buffer[] = [];
+      request.on('data', chunk => chunks.push(chunk));
+      request.on('end', () => {
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({
+          method: request.method,
+          title: 'Ess\u00e9nce',
+          body: Buffer.concat(chunks).toString('utf8'),
+        }));
+      });
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address() as import('node:net').AddressInfo;
+    try {
+      const output = await run(`
+        const response = await page.request.get('http://127.0.0.1:${port}/api');
+        const posted = await page.request.post('http://127.0.0.1:${port}/api', {
+          data: { ok: true },
+        });
+        return {
+          status: response.status(),
+          text: await response.text(),
+          json: await response.json(),
+          posted: await posted.json(),
+        };
+      `);
+
+      expect(output.result).toEqual({
+        status: 200,
+        text: '{"method":"GET","title":"Ess\u00e9nce","body":""}',
+        json: { method: 'GET', title: 'Ess\u00e9nce', body: '' },
+        posted: { method: 'POST', title: 'Ess\u00e9nce', body: '{"ok":true}' },
+      });
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
   });
 
   it('waits for downloads', async () => {


### PR DESCRIPTION
Closes #359

> **Stacked on #357** (`fix/browser-run-response-text`) and targets that branch — merge after #357. It builds on the `quickjsEncoding.decodeText(...)` pattern #357 established and on its regenerated bundle, so branching from `main` would have guaranteed a conflict in `src/browser/run/generated/playwright-client.js`.

## Diagnosis confirmed

The issue's diagnosis is correct, verified against the installed daemon before touching anything:

```
$ webcmd --session <id> browser run --stdin --no-snapshot-diff <<'JS'
const r = await page.request.get('https://dummyjson.com/products/1');
return { status: r.status(), body: (await r.text()).slice(0, 40) };
JS

✖  runtime_command_failed: QuickJS promise rejected: 'URLSearchParams' is not defined
```

After, on a daemon restarted from this branch (`Runtime: cloak connected (v0.5.7)`):

```json
{
  "ok": true,
  "result": {
    "status": 200,
    "body": "{\"id\":1,\"title\":\"Essence Mascara Lash Pr",
    "postStatus": 201,
    "postBody": "{\"id\":195,\"title\":\"Essénce\"}"
  }
}
```

Real JSON text, not comma-joined bytes, and the non-ASCII round-trip through `POST { data: {...} }` confirms the UTF-8 codec path.

## Guard, not a polyfill

Guarded the `instanceof` rather than adding a `URLSearchParams` global:

- **No capability is lost.** `_innerFetch` already accepts `params` as a string (`encodedParams`) or as a plain object (`params: typeof options.params === 'object' ? objectToArray(...)`). `URLSearchParams` only ever fed the `.toString()` shortcut.
- **Sandbox code cannot construct one anyway.** With no global there is no way for a `browser run` program to produce a `URLSearchParams` instance for the branch to match, so a polyfill would add a whole spec surface for zero new reachable behaviour.
- **Upstream already uses this exact idiom** eleven lines below: `if (globalThis.FormData && options.form instanceof FormData)`.

## Also fixed (reachable once the guard lands)

- `APIResponse.text()` — `content.toString('utf8')` → `quickjsEncoding.decodeText(content)`. `content` is a plain `Uint8Array` in the sandbox, so the old call comma-joined the bytes and dropped the encoding argument. Same defect #357 fixed for `Response.text()`.
- `Buffer.from(options.data, 'utf8')` → `quickjsEncoding.encodeText(options.data)`, and `Buffer.isBuffer(options.data)` → `options.data instanceof Uint8Array`. `Buffer` is also absent from the sandbox, and this pair is on the hot path: **`page.request.post(url, { data: {...} })` hits `Buffer.isBuffer` for any non-string `data`**, so JSON POSTs would have traded the `URLSearchParams` error for a `Buffer` one. `tBinary` already validates `Uint8Array`, so `postData` serializes unchanged.
- `toFormField` — `!Buffer.isBuffer(payload.buffer)` → `!(payload.buffer instanceof Uint8Array)`, reachable via plain-object `multipart` with a file payload.

## Left alone (unreachable — noted rather than fixed)

- `fetch.ts:230`, `Buffer.from(await value.arrayBuffer())` — inside the `globalThis.FormData &&` branch; there is no `FormData` global in the sandbox.
- `fetch.ts:417`, `readStreamToJson` / `Buffer.isBuffer(stream.path)` — takes an `fs.ReadStream`, and `quickjsPlatform.streamReadable` throws.
- `APIRequestContext.storageState({ path })` writes through the artifact-only `fs` stub; unchanged and out of scope here.

`Buffer` is referenced widely elsewhere in the vendored bundle (`route.fulfill`, `websocket`, `Request.fallback`). Those are separate reachability questions and not touched here.

## Verification

- `node scripts/build-playwright-sandbox-client.mjs --check` passes; `vendorSha256` bumped and a "Local patches" bullet added to `src/browser/run/playwright-client/README.md`.
- New regression test in `src/browser/run/runner.test.ts`. It uses a loopback `node:http` server rather than the `context.route` fixture: **`context.route` does not intercept `APIRequestContext` traffic** — routes only see page/frame network, so a routed URL fails with `getaddrinfo ENOTFOUND`. The test covers `get()` + `text()`/`json()` and `post({ data })` with a non-ASCII body.
- `npx tsc --noEmit` clean. `npx vitest run --project unit src/browser/` — 45 files, 685 tests, all passing.
- The full `--project unit` run in this worktree fails 117 tests across `src/hosted/*`, `src/doctor.test.ts`, and `src/build-plugin-command-manifest.test.ts`. These are an environment artifact, not a regression: the worktree has no `dist/` build, so those suites die on `ENOENT ... /dist/src/registry-api.js`. Nothing in the failure set touches `src/browser/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
