### PR TITLE
fix(cli): fail validate on unknown target instead of PASS

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1948,6 +1948,25 @@ describe('structured output for data-returning built-ins', () => {
     });
   });
 
+  it('rejects validate for an unknown target instead of passing zero commands', async () => {
+    await expect(createProgram('', '').parseAsync(['node', 'webcmd', 'validate', 'nope']))
+      .rejects.toThrow(/No command matches "nope"/);
+  });
+
+  it('sets a non-zero exit code when validate finds command errors', async () => {
+    const key = 'validate-fail-exit/broken';
+    getRegistry().set(key, {
+      site: 'validate-fail-exit', name: 'broken', access: 'read', description: 'broken', args: [],
+    } as never);
+    try {
+      await createProgram('', '').parseAsync(['node', 'webcmd', 'validate', 'validate-fail-exit']);
+      expect(process.exitCode).toBe(1);
+      expect(stdout()).toContain('FAIL');
+    } finally {
+      getRegistry().delete(key);
+    }
+  });
+
   it('keeps the human validate report when no format is requested', async () => {
     await createProgram('', '').parseAsync(['node', 'webcmd', 'validate']);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -693,6 +693,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string, pluginsDi
     const report = validateClisWithTarget([BUILTIN_CLIS, USER_CLIS], target);
     if (fmt === 'table') console.log(renderValidationReport(report));
     else await renderOutput(report, { fmt, fmtExplicit });
+    process.exitCode = report.ok ? EXIT_CODES.SUCCESS : EXIT_CODES.GENERIC_ERROR;
   });
 
   const verifyCmd = program

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -10,7 +10,35 @@
 import { describe, it, expect } from 'vitest';
 import { getRegisteredStepNames, registerStep } from './pipeline/registry.js';
 import { cli, getRegistry, Strategy } from './registry.js';
+import { ArgumentError } from './errors.js';
 import { validateClisWithTarget } from './validate.js';
+
+function registerValidateFixture(site: string, name: string, aliases?: string[]): void {
+  cli({
+    site,
+    name,
+    ...(aliases ? { aliases } : {}),
+    access: 'read',
+    browser: false,
+    strategy: Strategy.PUBLIC,
+    args: [],
+    func: async () => [],
+  });
+}
+
+function withValidateFixtures<T>(keys: string[], run: () => T): T {
+  const reg = getRegistry();
+  const originals = keys.map(key => [key, reg.get(key)] as const);
+  for (const key of keys) reg.delete(key);
+  try {
+    return run();
+  } finally {
+    for (const key of keys) reg.delete(key);
+    for (const [key, original] of originals) {
+      if (original) reg.set(key, original);
+    }
+  }
+}
 
 describe('validate.ts pipeline step allowlist', () => {
   it('uses every step name registered in pipeline/registry.ts', () => {
@@ -90,5 +118,76 @@ describe('validate.ts pipeline step allowlist', () => {
       // leaving it registered is harmless because the test step name is
       // namespaced and never used outside this file.
     }
+  });
+});
+
+describe('validateClisWithTarget unknown target', () => {
+  it('rejects an unknown site instead of passing zero commands', () => {
+    const site = 'validate-unknown-site';
+    const key = `${site}/search`;
+    withValidateFixtures([key], () => {
+      registerValidateFixture(site, 'search');
+
+      let thrown: unknown;
+      try {
+        validateClisWithTarget([], 'nope');
+      } catch (err) {
+        thrown = err;
+      }
+
+      expect(thrown).toBeInstanceOf(ArgumentError);
+      const error = thrown as ArgumentError;
+      expect(error.exitCode).toBe(2);
+      expect(error.message).toContain('No command matches "nope"');
+      expect(error.message).toContain(`Valid sites:`);
+      expect(error.message).toContain(site);
+      expect(error.hint).toContain('usage: webcmd validate <site|site/name>');
+      expect(error.hint).toMatch(/example: webcmd validate /);
+    });
+  });
+
+  it('enumerates commands when the site exists but the command does not', () => {
+    const site = 'validate-unknown-cmd';
+    const keys = [`${site}/search`, `${site}/synonyms`];
+    withValidateFixtures(keys, () => {
+      registerValidateFixture(site, 'search');
+      registerValidateFixture(site, 'synonyms');
+
+      expect(() => validateClisWithTarget([], `${site}/nope`)).toThrow(ArgumentError);
+      try {
+        validateClisWithTarget([], `${site}/nope`);
+      } catch (err) {
+        expect(err).toBeInstanceOf(ArgumentError);
+        expect((err as ArgumentError).message).toBe(
+          `No command matches "${site}/nope". Valid commands for ${site}: search, synonyms`,
+        );
+        expect((err as ArgumentError).hint).toBe(
+          `usage: webcmd validate <site|site/name>\nexample: webcmd validate ${site}/search`,
+        );
+      }
+    });
+  });
+
+  it('still validates an alias target after resolving it', () => {
+    const site = 'validate-alias-target';
+    const keys = [`${site}/search`, `${site}/find`];
+    withValidateFixtures(keys, () => {
+      registerValidateFixture(site, 'search', ['find']);
+      const report = validateClisWithTarget([], `${site}/find`);
+      expect(report.ok).toBe(true);
+      expect(report.commands).toBe(1);
+      expect(report.results[0]?.label).toBe(`${site}/search`);
+    });
+  });
+
+  it('still validates a known site', () => {
+    const site = 'validate-known-site';
+    const key = `${site}/search`;
+    withValidateFixtures([key], () => {
+      registerValidateFixture(site, 'search');
+      const report = validateClisWithTarget([], site);
+      expect(report.ok).toBe(true);
+      expect(report.commands).toBe(1);
+    });
   });
 });

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -2,6 +2,9 @@
 import { getRegistry, fullName, type CliCommand, type InternalCliCommand } from './registry.js';
 import { getRegisteredStepNames } from './pipeline/registry.js';
 import { CLI_COMMAND } from './brand.js';
+import { ArgumentError } from './errors.js';
+
+const SITE_LIST_LIMIT = 20;
 
 /**
  * Pipeline step names — derived from the live pipeline registry on each
@@ -36,10 +39,17 @@ export interface ValidationReport {
  */
 export function validateClisWithTarget(_dirs: string[], target?: string): ValidationReport {
   const registry = getRegistry();
-  const results: CommandValidationResult[] = [];
-  let errors = 0; let warnings = 0;
+  const commands = collectCanonicalCommands(registry);
+  const normalizedTarget = target?.trim();
+  const selected = normalizedTarget
+    ? commandsMatchingTarget(commands, resolveValidateTarget(registry, normalizedTarget))
+    : commands;
 
-  if (registry.size === 0) {
+  if (normalizedTarget && selected.length === 0) {
+    throwUnknownValidateTarget(normalizedTarget, commands);
+  }
+
+  if (commands.length === 0) {
     const r: CommandValidationResult = {
       label: '(registry)',
       errors: [],
@@ -48,31 +58,9 @@ export function validateClisWithTarget(_dirs: string[], target?: string): Valida
     return { ok: true, results: [r], errors: 0, warnings: 1, commands: 0 };
   }
 
-  // Resolve alias target: if target is "site/alias", resolve to canonical "site/name"
-  let resolvedTarget = target;
-  if (target?.includes('/')) {
-    const cmd = registry.get(target);
-    if (cmd) resolvedTarget = fullName(cmd);
-  }
-
-  // Deduplicate: registry maps both canonical "site/name" and aliases to the same command
-  const seen = new Set<CliCommand>();
-
-  for (const [key, cmd] of registry) {
-    if (seen.has(cmd)) continue;
-    // Only validate via canonical key to avoid duplicates from aliases
-    if (key !== fullName(cmd)) continue;
-    seen.add(cmd);
-
-    // Target filter: "site" or "site/name"
-    if (resolvedTarget) {
-      if (resolvedTarget.includes('/')) {
-        if (key !== resolvedTarget) continue;
-      } else {
-        if (cmd.site !== resolvedTarget) continue;
-      }
-    }
-
+  const results: CommandValidationResult[] = [];
+  let errors = 0; let warnings = 0;
+  for (const cmd of selected) {
     const r = validateCommand(cmd);
     results.push(r);
     errors += r.errors.length;
@@ -80,6 +68,62 @@ export function validateClisWithTarget(_dirs: string[], target?: string): Valida
   }
 
   return { ok: errors === 0, results, errors, warnings, commands: results.length };
+}
+
+function collectCanonicalCommands(registry: Map<string, CliCommand>): CliCommand[] {
+  const seen = new Set<CliCommand>();
+  const commands: CliCommand[] = [];
+  for (const [key, cmd] of registry) {
+    if (seen.has(cmd) || key !== fullName(cmd)) continue;
+    seen.add(cmd);
+    commands.push(cmd);
+  }
+  return commands;
+}
+
+function resolveValidateTarget(registry: Map<string, CliCommand>, target: string): string {
+  if (!target.includes('/')) return target;
+  const cmd = registry.get(target);
+  return cmd ? fullName(cmd) : target;
+}
+
+function commandsMatchingTarget(commands: CliCommand[], target: string): CliCommand[] {
+  if (target.includes('/')) return commands.filter(cmd => fullName(cmd) === target);
+  return commands.filter(cmd => cmd.site === target);
+}
+
+function throwUnknownValidateTarget(target: string, commands: CliCommand[]): never {
+  const usage = `usage: ${CLI_COMMAND} validate <site|site/name>`;
+  const sites = [...new Set(commands.map(cmd => cmd.site))].sort((a, b) => a.localeCompare(b));
+
+  if (target.includes('/')) {
+    const site = target.slice(0, target.indexOf('/'));
+    const names = commands.filter(cmd => cmd.site === site).map(cmd => cmd.name).sort((a, b) => a.localeCompare(b));
+    if (names.length > 0) {
+      throw new ArgumentError(
+        `No command matches "${target}". Valid commands for ${site}: ${names.join(', ')}`,
+        `${usage}\nexample: ${CLI_COMMAND} validate ${site}/${names[0]}`,
+      );
+    }
+  }
+
+  if (sites.length === 0) {
+    const search = target.includes('/') ? target.slice(0, target.indexOf('/')) : target;
+    throw new ArgumentError(
+      `No command matches "${target}". No sites are installed.`,
+      `${usage}\nSearch: ${CLI_COMMAND} plugin search ${search}`,
+    );
+  }
+
+  const listed = sites.slice(0, SITE_LIST_LIMIT);
+  const siteList = sites.length > SITE_LIST_LIMIT
+    ? `Valid sites (${listed.length} of ${sites.length}): ${listed.join(', ')}`
+    : `Valid sites: ${listed.join(', ')}`;
+  const more = sites.length > SITE_LIST_LIMIT ? `\nList all: ${CLI_COMMAND} list` : '';
+  throw new ArgumentError(
+    `No command matches "${target}". ${siteList}`,
+    `${usage}\nexample: ${CLI_COMMAND} validate ${sites[0]}${more}`,
+  );
 }
 
 function validateCommand(cmd: CliCommand): CommandValidationResult {

--- a/tests/e2e/management.test.ts
+++ b/tests/e2e/management.test.ts
@@ -96,6 +96,14 @@ describe('management commands E2E', () => {
     expect(stdout).toContain('PASS');
   });
 
+  it('validate unknown target fails instead of passing zero commands', async () => {
+    const { stdout, stderr, code } = await runManagementCli(['validate', 'nope']);
+    expect(code).toBe(2);
+    expect(stdout).not.toContain('PASS');
+    expect(stderr).toContain('No command matches "nope"');
+    expect(stderr).toContain(FIXTURE_SITE);
+  });
+
   // ── verify ──
   it('verify runs validation without smoke tests', async () => {
     const { stdout, code } = await runManagementCli(['verify']);


### PR DESCRIPTION
`webcmd validate nope` printed `PASS`, checked 0 commands, and exited 0. Agents treated that as a successful validation.

## After

```
$ webcmd validate nope
# stderr, exit 2
ok: false
error:
  code: ARGUMENT
  message: No command matches "nope". Valid sites: dictionary, …
  help: |
    usage: webcmd validate <site|site/name>
    example: webcmd validate dictionary
```

- Unknown `site` enumerates installed sites (capped at 20, then `webcmd list`).
- Unknown `site/command` enumerates that site's commands and gives a working example.
- `webcmd validate` on a real definition failure now exits 1, matching `verify`.
- Alias targets still resolve to the canonical command.

## Hosted impact

```
Hosted impact: A — no hosted impact
Trigger: none
Why: local-only webcmd validate / verify; not exported, not in src/hosted/, not consumed by cloud.
Sequencing: none
```

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run --project unit src/validate.test.ts src/cli.test.ts` — 137 passed