### PR TITLE
fix(linkedin): bump webcmd peer-dependency floor to >=0.7.4

### DIFF
--- a/plugins/linkedin/package.json
+++ b/plugins/linkedin/package.json
@@ -4,6 +4,6 @@
   "type": "module",
   "description": "LinkedIn profile, network, messaging, job, and Sales Navigator commands for WebCMD",
   "peerDependencies": {
-    "@agentrhq/webcmd": ">=0.7.3"
+    "@agentrhq/webcmd": ">=0.7.4"
   }
 }

--- a/plugins/linkedin/webcmd-plugin.json
+++ b/plugins/linkedin/webcmd-plugin.json
@@ -2,7 +2,7 @@
   "name": "linkedin",
   "version": "0.1.0",
   "description": "LinkedIn profile, network, messaging, job, and Sales Navigator commands for WebCMD",
-  "webcmd": ">=0.7.3",
+  "webcmd": ">=0.7.4",
   "author": {
     "name": "WebCMD Agent",
     "handle": "agentrhq"

--- a/webcmd-plugin.json
+++ b/webcmd-plugin.json
@@ -638,7 +638,7 @@
       "path": "plugins/linkedin",
       "version": "0.1.0",
       "description": "LinkedIn profile, network, messaging, job, and Sales Navigator commands for WebCMD",
-      "webcmd": ">=0.7.3",
+      "webcmd": ">=0.7.4",
       "author": {
         "name": "WebCMD Agent",
         "handle": "agentrhq"


### PR DESCRIPTION
## Summary
- The 0.7.4 release bumped the root package version, but `plugins/linkedin`'s webcmd peer-dependency floor (in `plugins/linkedin/package.json`, `plugins/linkedin/webcmd-plugin.json`, and the root `webcmd-plugin.json`) was left at `>=0.7.3`.
- This failed the manifest-parity test in `src/build-plugin-command-manifest.test.ts`, which blocked the publish step of the [0.7.4 release run](https://github.com/agentrhq/webcmd/actions/runs/32282118090) — 0.7.4 was never actually published to npm.

## Test plan
- [x] `vitest run src/build-plugin-command-manifest.test.ts` — 13/13 passing