### PR TITLE
skills: make web fetch the first fetch path

### DIFF
--- a/skill-src/smart-search/SKILL.src.md
+++ b/skill-src/smart-search/SKILL.src.md
@@ -1,6 +1,6 @@
 ---
 name: smart-search
-description: Use when a request needs search, research, source discovery, direct URL fetch, evidence fetching, or search-capable Webcmd adapter discovery.
+description: Use when a request needs search, research, source discovery, direct URL fetch, a blocked/403/Cloudflare retry, evidence fetching, or search-capable Webcmd adapter discovery.
 ---
 
 # Smart Search
@@ -42,6 +42,8 @@ webcmd web fetch --url <url>
 ```
 
 Try fetch once. Only `FETCH_BLOCKED` or `FETCH_REQUIRES_BROWSER` permits browser fallback; otherwise report the returned failure rather than retrying the URL.
+
+If you already fetched the URL outside Webcmd and got non-2xx, 403, blocked, or Cloudflare, still run `webcmd web fetch --url <url>` once. That command does the TLS-impersonating retry. Do not jump to `browser run` from the raw status line.
 
 For browser fallback, create one Session, navigate the failed URL, inspect it, reuse that Session for allowed fallbacks, then close it. Local browser commands use Cloak; hosted browser commands use Webcmd Cloud and Browser Use. `web fetch` remains local in both modes.
 

--- a/skill-src/smart-search/SKILL.src.md
+++ b/skill-src/smart-search/SKILL.src.md
@@ -43,7 +43,7 @@ webcmd web fetch --url <url>
 
 Try fetch once. Only `FETCH_BLOCKED` or `FETCH_REQUIRES_BROWSER` permits browser fallback; otherwise report the returned failure rather than retrying the URL.
 
-If you already fetched the URL outside Webcmd and got non-2xx, 403, blocked, or Cloudflare, still run `webcmd web fetch --url <url>` once. That command does the TLS-impersonating retry. Do not jump to `browser run` from the raw status line.
+If you already fetched the URL outside Webcmd and got non-2xx, 403, blocked, or Cloudflare, still run `webcmd web fetch --url <url>` once. It may retry with TLS impersonation for detected challenges. Do not jump to `browser run` from the raw status line.
 
 For browser fallback, create one Session, navigate the failed URL, inspect it, reuse that Session for allowed fallbacks, then close it. Local browser commands use Cloak; hosted browser commands use Webcmd Cloud and Browser Use. `web fetch` remains local in both modes.
 

--- a/skill-src/smart-search/SKILL.src.md
+++ b/skill-src/smart-search/SKILL.src.md
@@ -161,4 +161,9 @@ Author-only. Stripped by litprompt, so it costs the running agent nothing.
 Append one dated line whenever a correction lands, or whenever an approach
 is tried and rejected. Record what was tried and why it failed, not just
 what won.
+
+- 2026-08-20: Five fresh baseline evaluations of `origin/main` already routed
+  a supplied URL through `webcmd web fetch`; the explicit external non-2xx,
+  403, and Cloudflare wording improves discoverability rather than adding new
+  runtime behavior.
 -->

--- a/skill-src/smart-search/SKILL.src.md
+++ b/skill-src/smart-search/SKILL.src.md
@@ -1,6 +1,6 @@
 ---
 name: smart-search
-description: Use when a request needs search, research, source discovery, direct URL fetch, a blocked/403/Cloudflare retry, evidence fetching, or search-capable Webcmd adapter discovery.
+description: Use when a request needs search, research, source discovery, direct URL fetch, the first-choice Webcmd fetch path, evidence fetching, or search-capable Webcmd adapter discovery.
 ---
 
 # Smart Search
@@ -35,15 +35,13 @@ Prefer primary sources, official docs, and direct content over search snippets. 
 
 ## Direct URL
 
-For a supplied HTTP(S) URL, fetch it:
+For a supplied HTTP(S) URL, use the first-choice Webcmd fetch path:
 
 ```bash
 webcmd web fetch --url <url>
 ```
 
-Try fetch once. Only `FETCH_BLOCKED` or `FETCH_REQUIRES_BROWSER` permits browser fallback; otherwise report the returned failure rather than retrying the URL.
-
-If you already fetched the URL outside Webcmd and got non-2xx, 403, blocked, or Cloudflare, still run `webcmd web fetch --url <url>` once. It may retry with TLS impersonation for detected challenges. Do not jump to `browser run` from the raw status line.
+Run `webcmd web fetch` before browser work or non-Webcmd HTTP clients. Only `FETCH_BLOCKED` or `FETCH_REQUIRES_BROWSER` permits browser fallback; otherwise report the returned failure rather than retrying the URL. If a URL was already fetched outside Webcmd and got non-2xx, 403, blocked, or Cloudflare, that does not change the order: run `webcmd web fetch --url <url>` once before any browser escalation.
 
 For browser fallback, create one Session, navigate the failed URL, inspect it, reuse that Session for allowed fallbacks, then close it. Local browser commands use Cloak; hosted browser commands use Webcmd Cloud and Browser Use. `web fetch` remains local in both modes.
 

--- a/skill-src/webcmd-usage/SKILL.src.md
+++ b/skill-src/webcmd-usage/SKILL.src.md
@@ -10,6 +10,8 @@ Webcmd turns websites, Electron desktop apps, and external CLIs into a uniform `
 
 For any search, research, source discovery, direct URL fetch, evidence gathering, or “look this up” request, load `smart-search` before choosing commands. `smart-search` owns fetch-first search, browser-fetch escalation, last-resort search adapters, and source-summary rules.
 
+If a direct fetch (`webfetch`, `curl`, or any non-webcmd HTTP client) returns non-2xx, 403, blocked, or a Cloudflare challenge, the next command is `webcmd web fetch --url <url>`. Do not open a browser until that command returns `FETCH_BLOCKED` or `FETCH_REQUIRES_BROWSER`.
+
 ## CLI Preflight
 
 Before the first Webcmd command in a session, run:
@@ -274,6 +276,7 @@ Do not invoke these removed commands:
 - Do not emit a large unfiltered registry into a bounded output or infer absence from a truncation warning; filter at the source and narrow until the result is complete.
 - Do not assume every adapter needs a browser; check `strategy`.
 - Do not silently fall back from a failing adapter to hand-rolled `fetch`; use `--trace retain-on-failure` first.
+- Do not treat a raw 403 or challenge from a direct fetch as a browser gate; run `webcmd web fetch --url <url>` first.
 
 <!-- @
 ## Learnings log

--- a/skill-src/webcmd-usage/SKILL.src.md
+++ b/skill-src/webcmd-usage/SKILL.src.md
@@ -285,4 +285,10 @@ Author-only. Stripped by litprompt, so it costs the running agent nothing.
 Append one dated line whenever a correction lands, or whenever an approach
 is tried and rejected. Record what was tried and why it failed, not just
 what won.
+
+- 2026-08-20: A prior generic-client 403 is not authority to escalate to the
+  browser; browser use remains gated on Webcmd returning `FETCH_BLOCKED` or
+  `FETCH_REQUIRES_BROWSER`.
+- 2026-08-20: Review rejected saying `web fetch` always performs a
+  TLS-impersonating retry; it may do so only when it detects a challenge.
 -->

--- a/skill-src/webcmd-usage/SKILL.src.md
+++ b/skill-src/webcmd-usage/SKILL.src.md
@@ -10,7 +10,7 @@ Webcmd turns websites, Electron desktop apps, and external CLIs into a uniform `
 
 For any search, research, source discovery, direct URL fetch, evidence gathering, or “look this up” request, load `smart-search` before choosing commands. `smart-search` owns fetch-first search, browser-fetch escalation, last-resort search adapters, and source-summary rules.
 
-If a direct fetch (`webfetch`, `curl`, or any non-webcmd HTTP client) returns non-2xx, 403, blocked, or a Cloudflare challenge, the next command is `webcmd web fetch --url <url>`. Do not open a browser until that command returns `FETCH_BLOCKED` or `FETCH_REQUIRES_BROWSER`.
+For a known URL, the first-choice Webcmd fetch path is `webcmd web fetch --url <url>`. Use it before browser work or non-Webcmd HTTP clients. Do not open a browser until that command returns `FETCH_BLOCKED` or `FETCH_REQUIRES_BROWSER`.
 
 ## CLI Preflight
 

--- a/skills/smart-search/SKILL.md
+++ b/skills/smart-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: smart-search
-description: Use when a request needs search, research, source discovery, direct URL fetch, evidence fetching, or search-capable Webcmd adapter discovery.
+description: Use when a request needs search, research, source discovery, direct URL fetch, a blocked/403/Cloudflare retry, evidence fetching, or search-capable Webcmd adapter discovery.
 ---
 
 # Smart Search
@@ -42,6 +42,8 @@ webcmd web fetch --url <url>
 ```
 
 Try fetch once. Only `FETCH_BLOCKED` or `FETCH_REQUIRES_BROWSER` permits browser fallback; otherwise report the returned failure rather than retrying the URL.
+
+If you already fetched the URL outside Webcmd and got non-2xx, 403, blocked, or Cloudflare, still run `webcmd web fetch --url <url>` once. That command does the TLS-impersonating retry. Do not jump to `browser run` from the raw status line.
 
 For browser fallback, create one Session, navigate the failed URL, inspect it, reuse that Session for allowed fallbacks, then close it. Local browser commands use Cloak; hosted browser commands use Webcmd Cloud and Browser Use. `web fetch` remains local in both modes.
 

--- a/skills/smart-search/SKILL.md
+++ b/skills/smart-search/SKILL.md
@@ -43,7 +43,7 @@ webcmd web fetch --url <url>
 
 Try fetch once. Only `FETCH_BLOCKED` or `FETCH_REQUIRES_BROWSER` permits browser fallback; otherwise report the returned failure rather than retrying the URL.
 
-If you already fetched the URL outside Webcmd and got non-2xx, 403, blocked, or Cloudflare, still run `webcmd web fetch --url <url>` once. That command does the TLS-impersonating retry. Do not jump to `browser run` from the raw status line.
+If you already fetched the URL outside Webcmd and got non-2xx, 403, blocked, or Cloudflare, still run `webcmd web fetch --url <url>` once. It may retry with TLS impersonation for detected challenges. Do not jump to `browser run` from the raw status line.
 
 For browser fallback, create one Session, navigate the failed URL, inspect it, reuse that Session for allowed fallbacks, then close it. Local browser commands use Cloak; hosted browser commands use Webcmd Cloud and Browser Use. `web fetch` remains local in both modes.
 

--- a/skills/smart-search/SKILL.md
+++ b/skills/smart-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: smart-search
-description: Use when a request needs search, research, source discovery, direct URL fetch, a blocked/403/Cloudflare retry, evidence fetching, or search-capable Webcmd adapter discovery.
+description: Use when a request needs search, research, source discovery, direct URL fetch, the first-choice Webcmd fetch path, evidence fetching, or search-capable Webcmd adapter discovery.
 ---
 
 # Smart Search
@@ -35,15 +35,13 @@ Prefer primary sources, official docs, and direct content over search snippets. 
 
 ## Direct URL
 
-For a supplied HTTP(S) URL, fetch it:
+For a supplied HTTP(S) URL, use the first-choice Webcmd fetch path:
 
 ```bash
 webcmd web fetch --url <url>
 ```
 
-Try fetch once. Only `FETCH_BLOCKED` or `FETCH_REQUIRES_BROWSER` permits browser fallback; otherwise report the returned failure rather than retrying the URL.
-
-If you already fetched the URL outside Webcmd and got non-2xx, 403, blocked, or Cloudflare, still run `webcmd web fetch --url <url>` once. It may retry with TLS impersonation for detected challenges. Do not jump to `browser run` from the raw status line.
+Run `webcmd web fetch` before browser work or non-Webcmd HTTP clients. Only `FETCH_BLOCKED` or `FETCH_REQUIRES_BROWSER` permits browser fallback; otherwise report the returned failure rather than retrying the URL. If a URL was already fetched outside Webcmd and got non-2xx, 403, blocked, or Cloudflare, that does not change the order: run `webcmd web fetch --url <url>` once before any browser escalation.
 
 For browser fallback, create one Session, navigate the failed URL, inspect it, reuse that Session for allowed fallbacks, then close it. Local browser commands use Cloak; hosted browser commands use Webcmd Cloud and Browser Use. `web fetch` remains local in both modes.
 

--- a/skills/webcmd-usage/SKILL.md
+++ b/skills/webcmd-usage/SKILL.md
@@ -10,6 +10,8 @@ Webcmd turns websites, Electron desktop apps, and external CLIs into a uniform `
 
 For any search, research, source discovery, direct URL fetch, evidence gathering, or “look this up” request, load `smart-search` before choosing commands. `smart-search` owns fetch-first search, browser-fetch escalation, last-resort search adapters, and source-summary rules.
 
+If a direct fetch (`webfetch`, `curl`, or any non-webcmd HTTP client) returns non-2xx, 403, blocked, or a Cloudflare challenge, the next command is `webcmd web fetch --url <url>`. Do not open a browser until that command returns `FETCH_BLOCKED` or `FETCH_REQUIRES_BROWSER`.
+
 ## CLI Preflight
 
 Before the first Webcmd command in a session, run:
@@ -274,3 +276,4 @@ Do not invoke these removed commands:
 - Do not emit a large unfiltered registry into a bounded output or infer absence from a truncation warning; filter at the source and narrow until the result is complete.
 - Do not assume every adapter needs a browser; check `strategy`.
 - Do not silently fall back from a failing adapter to hand-rolled `fetch`; use `--trace retain-on-failure` first.
+- Do not treat a raw 403 or challenge from a direct fetch as a browser gate; run `webcmd web fetch --url <url>` first.

--- a/skills/webcmd-usage/SKILL.md
+++ b/skills/webcmd-usage/SKILL.md
@@ -10,7 +10,7 @@ Webcmd turns websites, Electron desktop apps, and external CLIs into a uniform `
 
 For any search, research, source discovery, direct URL fetch, evidence gathering, or “look this up” request, load `smart-search` before choosing commands. `smart-search` owns fetch-first search, browser-fetch escalation, last-resort search adapters, and source-summary rules.
 
-If a direct fetch (`webfetch`, `curl`, or any non-webcmd HTTP client) returns non-2xx, 403, blocked, or a Cloudflare challenge, the next command is `webcmd web fetch --url <url>`. Do not open a browser until that command returns `FETCH_BLOCKED` or `FETCH_REQUIRES_BROWSER`.
+For a known URL, the first-choice Webcmd fetch path is `webcmd web fetch --url <url>`. Use it before browser work or non-Webcmd HTTP clients. Do not open a browser until that command returns `FETCH_BLOCKED` or `FETCH_REQUIRES_BROWSER`.
 
 ## CLI Preflight
 

--- a/src/skills.test.ts
+++ b/src/skills.test.ts
@@ -65,6 +65,7 @@ describe('webcmd skills content', () => {
     expect(skill).toContain('webcmd plugin search');
     expect(skill).toContain('webcmd plugin install');
     expect(skill).toContain('webcmd web fetch --url');
+    expect(skill).toContain('first-choice Webcmd fetch path');
     expect(skill).toContain('FETCH_BLOCKED');
     expect(skill).toContain('FETCH_REQUIRES_BROWSER');
     for (const guide of skills) {
@@ -280,6 +281,7 @@ describe('webcmd skills content', () => {
     const autofix = bundledSkill('webcmd-autofix');
 
     expect(usage).toContain('webcmd session create -f json');
+    expect(usage).toContain('first-choice Webcmd fetch path');
     expect(usage).toContain('webcmd profile create work');
     expect(usage).toContain('webcmd --session session_abc browser');
     expect(usage).toContain('SESSION_BUSY');


### PR DESCRIPTION
## Description

Clarifies the skill-guidance portion of #374 for known URL and source-page fetches: agents should use `webcmd web fetch --url <url>` as the first-choice Webcmd fetch path before browser escalation or non-Webcmd HTTP clients.

The paired product PR supplies CLI/list/help discoverability. This documentation-only PR positions the agent workflow and does not independently fix or close #374.

Dated author-only learnings are retained in `skill-src/**/*.src.md` and stripped by LitPrompt from the published `skills/**/*.md` files. They record the baseline evaluation evidence, browser-escalation gate, and corrected TLS-retry claim without adding runtime-agent context.

Related issue: #374

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful
- [x] If I edited `skill-src/`, I ran `make build` and committed `skills/`

### Adapter Notes

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```text
make build: ok: built 21 file(s)
make check: ok: 21 file(s) checked
make verify: ok: no orphaned published files; no SKILL.md inside skill-src; published files are in sync
quick_validate.py skills/smart-search: Skill is valid!
quick_validate.py skills/webcmd-usage: Skill is valid!
npm test -- src/skills.test.ts: 15 passed
```

