### PR TITLE
fix(cli): popup wait timeout must not tell agents to page.goto the opener

### DIFF
--- a/src/browser/run/playwright-transport.ts
+++ b/src/browser/run/playwright-transport.ts
@@ -292,11 +292,13 @@ function scopedContext(
             };
             if (event === 'page') addPageListener(listener);
             else addContextListener(event, listener);
-            if (options?.timeout) {
+            const timeoutMs = options?.timeout
+              ?? (event === 'page' || event === 'popup' ? 3_000 : undefined);
+            if (timeoutMs) {
               timer = setTimeout(() => {
                 removeListener(listener);
-                reject(new Error(`Timeout while waiting for event "${event}"`));
-              }, options.timeout);
+                reject(new Error(`Timeout ${timeoutMs}ms exceeded while waiting for event "${event}"`));
+              }, timeoutMs);
             }
           });
         };

--- a/src/browser/run/runner.test.ts
+++ b/src/browser/run/runner.test.ts
@@ -23,7 +23,7 @@ import { LocalBrowserRunArtifactSink } from './artifacts.js';
 import { MemorySnapshotBaselineStore } from '../snapshot/index.js';
 import { unsupportedApiMessage } from './playwright-transport.js';
 import { QuickJSHost } from './quickjs-host.js';
-import { DOWNLOAD_WAIT_TIMEOUT_HINT, runBrowserProgram } from './runner.js';
+import { DOWNLOAD_WAIT_TIMEOUT_HINT, POPUP_WAIT_TIMEOUT_HINT, runBrowserProgram } from './runner.js';
 
 const playwrightServer = createRequire(import.meta.url)(
   'playwright-core/lib/coreBundle',
@@ -905,6 +905,25 @@ afterAll(async () => {
     });
     expect(browser.isConnected()).toBe(true);
     expect(page.isClosed()).toBe(false);
+  });
+
+  it('tells the caller to open a tracked tab when a popup wait times out', async () => {
+    await expect(run(`
+      await page.waitForEvent('popup');
+    `, { timeoutMs: 25 })).rejects.toMatchObject({
+      code: 'BROWSER_RUN_TIMEOUT',
+      message: 'Browser-run timed out waiting for a popup or new tab.',
+      hint: POPUP_WAIT_TIMEOUT_HINT,
+    });
+  });
+
+  it('does not tell the caller to increase --timeout after an explicit popup wait timeout', async () => {
+    await expect(run(`
+      await page.waitForEvent('popup', { timeout: 50 });
+    `, { timeoutMs: 5_000 })).rejects.toMatchObject({
+      code: 'BROWSER_RUN_TIMEOUT',
+      hint: POPUP_WAIT_TIMEOUT_HINT,
+    });
   });
 
   it('cancels an in-flight run through its abort signal', async () => {

--- a/src/browser/run/runner.ts
+++ b/src/browser/run/runner.ts
@@ -57,21 +57,41 @@ const PLAYWRIGHT_CLIENT_SOURCE = fs.readFileSync(
 
 const GENERIC_TIMEOUT_HINT = 'Split the task into a smaller run or increase --timeout.';
 export const DOWNLOAD_WAIT_TIMEOUT_HINT = 'A timed-out download wait is not a license to invent file contents. If a download event fired, use download.saveAs(suggestedFilename()). If none fired, report that gap. Do not rebuild the file from page logic.';
+export const POPUP_WAIT_TIMEOUT_HINT = 'A missing popup is not recovered with page.goto on the current page. Open a tracked tab with context.newPage(), then goto the destination URL on that new page. Cap waitForEvent(\'popup\') with a short timeout.';
 
 function isDownloadWait(text: string): boolean {
   return /waiting for event ["']download["']/i.test(text)
     || /waitForEvent\(\s*['"]download['"]\s*\)/.test(text);
 }
 
+function isPopupOrNewTabWait(text: string): boolean {
+  return /waiting for event ["'](popup|page)["']/i.test(text)
+    || /waitForEvent\(\s*['"](?:popup|page)['"]\s*\)/.test(text);
+}
+
+function timeoutKind(message: string, source?: string): 'popup' | 'download' | undefined {
+  if (isPopupOrNewTabWait(message) || (source !== undefined && isPopupOrNewTabWait(source))) return 'popup';
+  if (isDownloadWait(message) || (source !== undefined && isDownloadWait(source))) return 'download';
+  return undefined;
+}
+
 function timeoutRunError(message: string, source?: string): BrowserRunError {
-  const download = isDownloadWait(message) || (source !== undefined && isDownloadWait(source));
-  return new BrowserRunError(
-    'BROWSER_RUN_TIMEOUT',
-    download && !isDownloadWait(message)
-      ? 'Browser-run timed out waiting for a download.'
-      : message,
-    download ? DOWNLOAD_WAIT_TIMEOUT_HINT : GENERIC_TIMEOUT_HINT,
-  );
+  const kind = timeoutKind(message, source);
+  if (kind === 'popup') {
+    return new BrowserRunError(
+      'BROWSER_RUN_TIMEOUT',
+      isPopupOrNewTabWait(message) ? message : 'Browser-run timed out waiting for a popup or new tab.',
+      POPUP_WAIT_TIMEOUT_HINT,
+    );
+  }
+  if (kind === 'download') {
+    return new BrowserRunError(
+      'BROWSER_RUN_TIMEOUT',
+      isDownloadWait(message) ? message : 'Browser-run timed out waiting for a download.',
+      DOWNLOAD_WAIT_TIMEOUT_HINT,
+    );
+  }
+  return new BrowserRunError('BROWSER_RUN_TIMEOUT', message, GENERIC_TIMEOUT_HINT);
 }
 
 function requirePositiveInteger(
@@ -128,7 +148,7 @@ function normalizeExecutionError(error: unknown): Error {
       'Navigate to an http(s) URL, or use page.evaluate memory. data: pages cannot use localStorage.',
     );
   }
-  if (isDownloadWait(message)) {
+  if (isPopupOrNewTabWait(message) || isDownloadWait(message)) {
     return timeoutRunError(sanitize(message));
   }
   if (/interrupted|execution timeout|timed out/i.test(message)) {


### PR DESCRIPTION
## Description

Related to #383. Does not close it. Skill PR #384 stays separate.

**What changed:** popup/new-tab wait timeouts no longer say “increase `--timeout`”. They say: do not `page.goto` the current page; `context.newPage()` then goto the destination; cap the wait.

1. Same error code: `BROWSER_RUN_TIMEOUT`.
2. New hint only when the wait is `popup` or `page`.
3. Uncapped `context.waitForEvent('popup'|'page')` defaults to 3s.
4. Other timeouts still say split the run or increase `--timeout`.

Not scenario-specific. Any `waitForEvent('popup'|'page')` timeout gets this. No fixture, receipt, or `data:` wording.

The new hint is better **for this failure**. A blocked `window.open` will not appear if you wait longer. The old hint pushed agents into `page.goto` on the opener.

Tradeoff: the next step is still Playwright (`context.newPage()`), not a Webcmd command. A stronger CLI would be `browser tabs --url`. This PR only stops the lying timeout.

Eval (CLI only, old skills), `vendor-verification`: **4.5 full / acceptable**. Prior: 2.0 and 1.5. Recovery was `context.newPage()`, not opener `page.goto`.

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] If I edited `skill-src/`, I ran `make build` and committed `skills/`

```text
npx vitest run --project unit src/browser/run/runner.test.ts
81 passed
npx tsc --noEmit
```
