### PR TITLE
fix(cli): download wait timeout must not tell agents to invent file contents

### DIFF
--- a/src/browser/run/runner.test.ts
+++ b/src/browser/run/runner.test.ts
@@ -23,7 +23,7 @@ import { LocalBrowserRunArtifactSink } from './artifacts.js';
 import { MemorySnapshotBaselineStore } from '../snapshot/index.js';
 import { unsupportedApiMessage } from './playwright-transport.js';
 import { QuickJSHost } from './quickjs-host.js';
-import { runBrowserProgram } from './runner.js';
+import { DOWNLOAD_WAIT_TIMEOUT_HINT, runBrowserProgram } from './runner.js';
 
 const playwrightServer = createRequire(import.meta.url)(
   'playwright-core/lib/coreBundle',
@@ -669,6 +669,46 @@ afterAll(async () => {
     `);
 
     expect(output.result).toBe('hello.txt');
+  });
+
+  it('captures a generated blob object-URL download as an artifact', async () => {
+    await page.setContent(`
+      <button id="convert">Normalize and download</button>
+      <pre id="preview"></pre>
+      <script>
+        convert.onclick = () => {
+          const text = 'name,amount\\nalpha,10.00\\nbeta,20.50\\ngamma,30.00\\n';
+          preview.textContent = text;
+          const a = document.createElement('a');
+          a.download = 'normalized.csv';
+          a.href = URL.createObjectURL(new Blob([text], { type: 'text/csv' }));
+          a.click();
+        };
+      </script>
+    `);
+
+    const output = await run(`
+      const downloadPromise = page.waitForEvent('download');
+      await page.locator('#convert').click();
+      const download = await downloadPromise;
+      await download.saveAs(download.suggestedFilename());
+      return { filename: download.suggestedFilename() };
+    `);
+
+    expect(output.result).toEqual({ filename: 'normalized.csv' });
+    expect(output.artifacts).toEqual([
+      expect.objectContaining({ filename: 'normalized.csv', byteSize: 47 }),
+    ]);
+  });
+
+  it('tells the caller not to recompute bytes when a download wait times out', async () => {
+    await expect(run(`
+      await page.waitForEvent('download');
+    `, { timeoutMs: 25 })).rejects.toMatchObject({
+      code: 'BROWSER_RUN_TIMEOUT',
+      message: 'Browser-run timed out waiting for a download.',
+      hint: DOWNLOAD_WAIT_TIMEOUT_HINT,
+    });
   });
 
   it('exposes only the supplied context from a shared browser', async () => {

--- a/src/browser/run/runner.ts
+++ b/src/browser/run/runner.ts
@@ -55,6 +55,25 @@ const PLAYWRIGHT_CLIENT_SOURCE = fs.readFileSync(
   'utf8',
 );
 
+const GENERIC_TIMEOUT_HINT = 'Split the task into a smaller run or increase --timeout.';
+export const DOWNLOAD_WAIT_TIMEOUT_HINT = 'A timed-out download wait is not a license to invent file contents. If a download event fired, use download.saveAs(suggestedFilename()). If none fired, report that gap. Do not rebuild the file from page logic.';
+
+function isDownloadWait(text: string): boolean {
+  return /waiting for event ["']download["']/i.test(text)
+    || /waitForEvent\(\s*['"]download['"]\s*\)/.test(text);
+}
+
+function timeoutRunError(message: string, source?: string): BrowserRunError {
+  const download = isDownloadWait(message) || (source !== undefined && isDownloadWait(source));
+  return new BrowserRunError(
+    'BROWSER_RUN_TIMEOUT',
+    download && !isDownloadWait(message)
+      ? 'Browser-run timed out waiting for a download.'
+      : message,
+    download ? DOWNLOAD_WAIT_TIMEOUT_HINT : GENERIC_TIMEOUT_HINT,
+  );
+}
+
 function requirePositiveInteger(
   value: number | undefined,
   fallback: number,
@@ -109,12 +128,11 @@ function normalizeExecutionError(error: unknown): Error {
       'Navigate to an http(s) URL, or use page.evaluate memory. data: pages cannot use localStorage.',
     );
   }
+  if (isDownloadWait(message)) {
+    return timeoutRunError(sanitize(message));
+  }
   if (/interrupted|execution timeout|timed out/i.test(message)) {
-    return new BrowserRunError(
-      'BROWSER_RUN_TIMEOUT',
-      'Browser-run execution exceeded its time limit.',
-      'Split the task into a smaller run or increase --timeout.',
-    );
+    return timeoutRunError('Browser-run execution exceeded its time limit.');
   }
   if (/out of memory|memory limit/i.test(message)) {
     return new BrowserRunError(
@@ -550,10 +568,9 @@ export async function runBrowserProgram(
     } finally {
       timings.client_bundle_init_ms = Math.max(0, Date.now() - clientBundleInitStartedAt);
     }
-    const timeoutError = () => new BrowserRunError(
-      'BROWSER_RUN_TIMEOUT',
+    const timeoutError = () => timeoutRunError(
       `Browser-run execution exceeded ${timeoutMs}ms.`,
-      'Split the task into a smaller run or increase --timeout.',
+      source,
     );
     const beforeSnapshot = snapshotDiffEnabled
       ? baselineStore.get(input.pageId) ?? await captureSnapshot(input.page)


### PR DESCRIPTION
## Description

Related to #379. Does not close it.

**What changed:** download wait timeouts no longer say “increase `--timeout`”. They say: do not invent file contents; `download.saveAs(suggestedFilename())` if the event fired; report the gap if it did not.

1. Same error code: `BROWSER_RUN_TIMEOUT`.
2. New hint only when the wait is `download`.
3. Other timeouts still say split the run or increase `--timeout`.
4. Unit test: blob `createObjectURL` + `saveAs` yields `normalized.csv` (47 bytes).

Not scenario-specific. Any `waitForEvent('download')` timeout gets this. No converter, CSV, or fixture wording.

The new hint is better **for a download that never started**. Waiting longer does not create a missing file. A slow real download can still need more time; this hint does not forbid that.

Will conflict with #397 (both add `timeoutRunError` in `runner.ts`). Rebase whichever lands second.

Eval `csv-report-conversion` against this CLI: **4.0**. Download *did* fire; `saveAs` wrote a cache artifact, not cwd. This hint does not fix that path.

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] If I edited `skill-src/`, I ran `make build` and committed `skills/`

```text
npx vitest run --project unit src/browser/run/runner.test.ts -t download
3 passed
npx tsc --noEmit
```