### PR TITLE
fix(cli): point EMPTY_RESULT at adapter repair, not login

### DIFF
--- a/plugins/rest-countries/test/rest-countries.test.js
+++ b/plugins/rest-countries/test/rest-countries.test.js
@@ -31,16 +31,34 @@ describe('rest-countries country adapter', () => {
     });
 
     it('maps a v3.1 deprecation envelope to CommandExecutionError, not EmptyResultError', async () => {
-        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+        const retiredResponse = () => new Response(JSON.stringify({
             success: false,
             data: null,
             errors: [{ message: 'This API version has been deprecated. Please visit https://restcountries.com/docs/countries/legacy-api-deprecation to migrate to our new version (v5).' }],
-        }), { status: 200 })));
-        await expect(cmd.func({ name: 'japan' })).rejects.toMatchObject({
+        }), { status: 200 });
+        vi.stubGlobal('fetch', vi.fn().mockImplementation(retiredResponse));
+        let error;
+        try {
+            await cmd.func({ name: 'japan' });
+            throw new Error('expected retired API response to throw');
+        } catch (err) {
+            error = err;
+        }
+        expect(error).toMatchObject({
             name: 'CommandExecutionError',
             hint: expect.stringMatching(/webcmd adapter path rest-countries\/country/),
         });
-        await expect(cmd.func({ name: 'japan' })).rejects.not.toBeInstanceOf(EmptyResultError);
+        expect(error.hint).not.toMatch(/utils\.js base URL|curl another country API/i);
+        expect(error).not.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('does not label every success:false envelope as retired', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            success: false,
+            errors: [{ message: 'temporary upstream failure' }],
+        }), { status: 200 })));
+
+        await expect(cmd.func({ name: 'japan' })).rejects.not.toThrow(/retired REST Countries/i);
     });
 
     it('round-trips cca3 from row into restcountries.com alpha URL', async () => {

--- a/plugins/rest-countries/test/rest-countries.test.js
+++ b/plugins/rest-countries/test/rest-countries.test.js
@@ -30,6 +30,19 @@ describe('rest-countries country adapter', () => {
         await expect(cmd.func({ name: 'no-country-by-this-name' })).rejects.toThrow(EmptyResultError);
     });
 
+    it('maps a v3.1 deprecation envelope to CommandExecutionError, not EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            success: false,
+            data: null,
+            errors: [{ message: 'This API version has been deprecated. Please visit https://restcountries.com/docs/countries/legacy-api-deprecation to migrate to our new version (v5).' }],
+        }), { status: 200 })));
+        await expect(cmd.func({ name: 'japan' })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            hint: expect.stringMatching(/webcmd adapter path rest-countries\/country/),
+        });
+        await expect(cmd.func({ name: 'japan' })).rejects.not.toBeInstanceOf(EmptyResultError);
+    });
+
     it('round-trips cca3 from row into restcountries.com alpha URL', async () => {
         vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify([
             {

--- a/plugins/rest-countries/utils.js
+++ b/plugins/rest-countries/utils.js
@@ -1,8 +1,7 @@
 // Shared helpers for the REST Countries adapter (https://restcountries.com).
 //
-// REST Countries is a free public country-metadata API, no API key required.
-// We hit v3.1 only. The `fields=` query param is mandatory in v3.1 to keep
-// payloads small; we always specify the agent-useful projection.
+// REST Countries v3.1 is retired (HTTP 200 deprecation JSON). restCountriesFetch
+// must not treat that envelope as an empty country list.
 import { ArgumentError, CommandExecutionError, EmptyResultError } from '@agentrhq/webcmd/errors';
 
 export const REST_COUNTRIES_BASE = 'https://restcountries.com/v3.1';
@@ -76,7 +75,22 @@ export async function restCountriesFetch(url, label) {
     catch (err) {
         throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
     }
+    if (isRetiredRestCountriesBody(body)) {
+        const key = String(label).trim().replace(/\s+/g, '/');
+        throw new CommandExecutionError(
+            `${label} hit the retired REST Countries v3.1 API`,
+            `The response is a deprecation envelope, not an empty result. Load the webcmd-autofix skill, run \`webcmd adapter path ${key}\`, patch this family (utils.js base URL), and retry with --trace retain-on-failure. Do not sign up, solve CAPTCHA, or curl another country API.`,
+        );
+    }
     return body;
+}
+
+function isRetiredRestCountriesBody(body) {
+    if (!body || typeof body !== 'object' || Array.isArray(body)) return false;
+    if (body.success === false) return true;
+    const errors = body.errors;
+    if (!Array.isArray(errors)) return false;
+    return errors.some((entry) => typeof entry?.message === 'string' && /deprecated/i.test(entry.message));
 }
 
 /** Convert REST Countries' `{cur: {name, symbol}}` map to a comma-joined list. */

--- a/plugins/rest-countries/utils.js
+++ b/plugins/rest-countries/utils.js
@@ -79,7 +79,7 @@ export async function restCountriesFetch(url, label) {
         const key = String(label).trim().replace(/\s+/g, '/');
         throw new CommandExecutionError(
             `${label} hit the retired REST Countries v3.1 API`,
-            `The response is a deprecation envelope, not an empty result. Load the webcmd-autofix skill, run \`webcmd adapter path ${key}\`, patch this family (utils.js base URL), and retry with --trace retain-on-failure. Do not sign up, solve CAPTCHA, or curl another country API.`,
+            `The response is a deprecation envelope, not an empty result. Load the webcmd-autofix skill, run \`webcmd adapter path ${key}\`, patch the adapter, and retry with --trace retain-on-failure.`,
         );
     }
     return body;
@@ -87,7 +87,6 @@ export async function restCountriesFetch(url, label) {
 
 function isRetiredRestCountriesBody(body) {
     if (!body || typeof body !== 'object' || Array.isArray(body)) return false;
-    if (body.success === false) return true;
     const errors = body.errors;
     if (!Array.isArray(errors)) return false;
     return errors.some((entry) => typeof entry?.message === 'string' && /deprecated/i.test(entry.message));

--- a/src/adapter-source.test.ts
+++ b/src/adapter-source.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import type { InternalCliCommand } from './registry.js';
-import { resolveAdapterSourcePath } from './adapter-source.js';
+import { resolveAdapterSourcePath, splitAdapterCommandKey } from './adapter-source.js';
 
 const existingPath = fileURLToPath(import.meta.url);
 
@@ -39,5 +39,17 @@ describe('resolveAdapterSourcePath', () => {
   it('returns undefined when every candidate is stale', () => {
     const cmd = makeCmd({ source: '/tmp/webcmd-missing-source.js', _modulePath: '/tmp/webcmd-missing-module.js' });
     expect(resolveAdapterSourcePath(cmd)).toBeUndefined();
+  });
+});
+
+describe('splitAdapterCommandKey', () => {
+  it('accepts site/command and site command', () => {
+    expect(splitAdapterCommandKey('quotes/list')).toEqual({ site: 'quotes', command: 'list' });
+    expect(splitAdapterCommandKey('quotes', 'list')).toEqual({ site: 'quotes', command: 'list' });
+  });
+
+  it('rejects the wrong arity', () => {
+    expect(splitAdapterCommandKey('quotes')).toBeNull();
+    expect(splitAdapterCommandKey('quotes/list/extra')).toBeNull();
   });
 });

--- a/src/adapter-source.ts
+++ b/src/adapter-source.ts
@@ -1,6 +1,22 @@
 import * as fs from 'node:fs';
 import type { InternalCliCommand } from './registry.js';
 
+/** Split `site/command` or `site command` into segments. Null when the shape is wrong. */
+export function splitAdapterCommandKey(commandKey: string, commandName?: string): { site: string; command: string } | null {
+  const parts = [commandKey, commandName]
+    .filter((part): part is string => typeof part === 'string' && part.trim() !== '')
+    .join('/')
+    .trim()
+    .split(/[/\s]+/)
+    .filter(Boolean);
+  if (parts.length !== 2) return null;
+  const [site, command] = parts;
+  if (!site || !command || site === '.' || site === '..' || command === '.' || command === '..' || site.includes('\\') || command.includes('\\') || site.includes('\0') || command.includes('\0')) {
+    return null;
+  }
+  return { site, command };
+}
+
 /**
  * Resolve the editable source file path for an adapter.
  *

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -165,6 +165,20 @@ describe('site-memory and local adapter authoring', () => {
       .rejects.toThrow(/Adapter source is unavailable/);
   });
 
+  it('accepts adapter path as two tokens', async () => {
+    const key = 'split-source/search';
+    const source = path.join(isolatedCliTestHome, 'split-search.js');
+    fs.writeFileSync(source, 'export default {};');
+    getRegistry().set(key, {
+      site: 'split-source', name: 'search', access: 'read', description: 'split', args: [], source,
+    } as never);
+    try {
+      await createProgram('', '').parseAsync(['node', 'webcmd', 'adapter', 'path', 'split-source', 'search']);
+    } finally {
+      getRegistry().delete(key);
+    }
+  });
+
   it('rejects local adapter source writes while directing users to the source path', async () => {
     const key = 'local-source/search';
     const source = path.join(isolatedCliTestHome, 'search.js');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,7 +61,7 @@ import { classifyCommandOrigin, formatCommandOrigin } from './command-origin.js'
 import { readOverrideRecords, removeOverrideRecords } from './override-provenance.js';
 import { clearDaemonRunContext, generateRunId, isUnknownOutcomeError, runWithDaemonRunContext } from './session-lease.js';
 import { createLocalSiteMemoryBackend, registerSiteCommands } from './site-memory/commands.js';
-import { resolveAdapterSourcePath } from './adapter-source.js';
+import { resolveAdapterSourcePath, splitAdapterCommandKey } from './adapter-source.js';
 
 const CLI_FILE = fileURLToPath(import.meta.url);
 const FOLLOW_POLL_MS = 1_000;
@@ -1880,26 +1880,35 @@ cli({
     .argument('<command>', 'Command to override, as <site>/<command>')
     .action(handleAdapterOverride);
 
-  const localAdapterPath = (commandKey: string): string => {
-    const [site, command, extra] = commandKey.split('/');
-    if (!site || !command || extra || site === '.' || site === '..' || command === '.' || command === '..' || site.includes('\\') || command.includes('\\')) {
-      throw new ArgumentError('Adapter command must use site/command format.');
+  const localAdapterPath = (commandKey: string, commandName?: string): string => {
+    const parsed = splitAdapterCommandKey(commandKey, commandName);
+    if (!parsed) {
+      throw new ArgumentError(
+        'Adapter command must use site/command format.',
+        'Example: webcmd adapter path quotes/list  (also accepts: webcmd adapter path quotes list)',
+      );
     }
-    const registered = getRegistry().get(`${site}/${command}`) as import('./registry.js').InternalCliCommand | undefined;
+    const key = `${parsed.site}/${parsed.command}`;
+    const registered = getRegistry().get(key) as import('./registry.js').InternalCliCommand | undefined;
     const source = registered && resolveAdapterSourcePath(registered);
-    if (!source) throw new ArgumentError(`Adapter source is unavailable for ${commandKey}.`);
+    if (!source) throw new ArgumentError(`Adapter source is unavailable for ${key}.`);
     return source;
   };
-  const reportLocalAdapterPath = (commandKey: string): void => console.log(localAdapterPath(commandKey));
+  const reportLocalAdapterPath = (commandKey: string, commandName?: string): void => console.log(localAdapterPath(commandKey, commandName));
   const adapterSourceCmd = adapterCmd.command('source').description('Inspect local adapter source paths; hosted mode reads or writes source');
-  adapterSourceCmd.command('get').description('Print local source path; --output is hosted-only').argument('<command>').option('-o, --output <path>').action((commandKey: string, options: { output?: string }) => {
-    if (options.output) throw new ArgumentError(`Local adapter source get does not support --output. Use webcmd adapter path ${commandKey} and edit that file.`);
-    reportLocalAdapterPath(commandKey);
+  adapterSourceCmd.command('get').description('Print local source path; --output is hosted-only').argument('<command>').argument('[name]').option('-o, --output <path>').action((commandKey: string, commandName: string | undefined, options: { output?: string }) => {
+    const parsed = splitAdapterCommandKey(commandKey, commandName);
+    const key = parsed ? `${parsed.site}/${parsed.command}` : commandKey;
+    if (options.output) throw new ArgumentError(`Local adapter source get does not support --output. Use webcmd adapter path ${key} and edit that file.`);
+    reportLocalAdapterPath(commandKey, commandName);
   });
   adapterSourceCmd.command('put').description('Hosted-only source write; local users edit the adapter path').argument('<command>').argument('<path>').action((commandKey: string) => {
     throw new ArgumentError(`Local adapter source put is unavailable. Use webcmd adapter path ${commandKey} and edit that file.`);
   });
-  adapterCmd.command('path').argument('<command>').action((commandKey: string) => reportLocalAdapterPath(commandKey));
+  adapterCmd.command('path')
+    .argument('<command>', 'site/command, or site when followed by the command name')
+    .argument('[name]', 'command name when passed as a second token')
+    .action((commandKey: string, commandName?: string) => reportLocalAdapterPath(commandKey, commandName));
 
   // ── Built-in: browser profile selection ──────────────────────────────────
   const PROFILE_LIST_COLUMNS = ['contextId', 'alias', 'default', 'connected', 'runtimeVersion'];

--- a/src/command-surface.ts
+++ b/src/command-surface.ts
@@ -53,6 +53,7 @@ export class CommanderStructuralError extends Error {
   constructor(
     readonly output: string,
     readonly exitCode: number,
+    readonly appendErrorEnvelope = false,
   ) {
     super(output.trimEnd());
     this.name = 'CommanderStructuralError';
@@ -93,11 +94,17 @@ export function structuralErrorFromCommander(
   error: CommanderError,
   command: Command,
   capturedStderr = '',
+  opts: { appendErrorEnvelope?: boolean; includeCapturedStderrForUnknownOption?: boolean } = {},
 ): CommanderStructuralError {
   if (error.code === 'commander.unknownOption') {
-    return new CommanderStructuralError(formatUnknownOptionError(error, command), EXIT_CODES.USAGE_ERROR);
+    const output = `${opts.includeCapturedStderrForUnknownOption ? capturedStderr : ''}${formatUnknownOptionError(error, command)}`;
+    return new CommanderStructuralError(output, EXIT_CODES.USAGE_ERROR);
   }
-  return new CommanderStructuralError(capturedStderr || `${error.message}\n`, error.exitCode);
+  return new CommanderStructuralError(
+    capturedStderr || `${error.message}\n`,
+    error.exitCode,
+    opts.appendErrorEnvelope === true,
+  );
 }
 
 /** Walk argv to the leaf command Commander would have been parsing. */

--- a/src/commanderAdapter.test.ts
+++ b/src/commanderAdapter.test.ts
@@ -413,7 +413,10 @@ describe('commanderAdapter error envelope output', () => {
     const output = stderrSpy.mock.calls.map(c => String(c[0])).join('');
     expect(JSON.parse(output)).toMatchObject({
       ok: false,
-      error: { code: 'EMPTY_RESULT' },
+      error: {
+        code: 'EMPTY_RESULT',
+        help: expect.stringMatching(/adapter path github\/issue|webcmd-autofix/),
+      },
     });
     expect(output).not.toContain('# AutoFix');
 

--- a/src/constants.test.ts
+++ b/src/constants.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('DEFAULT_DAEMON_PORT', () => {
+  const original = process.env.WEBCMD_DAEMON_PORT;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.WEBCMD_DAEMON_PORT;
+    else process.env.WEBCMD_DAEMON_PORT = original;
+    vi.resetModules();
+  });
+
+  it('uses WEBCMD_DAEMON_PORT when it is a valid TCP port', async () => {
+    process.env.WEBCMD_DAEMON_PORT = '19876';
+    const { DEFAULT_DAEMON_PORT } = await import('./constants.js');
+
+    expect(DEFAULT_DAEMON_PORT).toBe(19876);
+  });
+
+  it('falls back to 9777 for invalid values', async () => {
+    process.env.WEBCMD_DAEMON_PORT = 'not-a-port';
+    const { DEFAULT_DAEMON_PORT } = await import('./constants.js');
+
+    expect(DEFAULT_DAEMON_PORT).toBe(9777);
+  });
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,8 +4,13 @@
 
 import { DAEMON_HEADER_NAME } from './brand.js';
 
+function configuredDaemonPort(value: string | undefined): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 && parsed <= 65535 ? parsed : 9777;
+}
+
 /** Default daemon port for HTTP communication with the browser runtime. */
-export const DEFAULT_DAEMON_PORT = 9777;
+export const DEFAULT_DAEMON_PORT = configuredDaemonPort(process.env.WEBCMD_DAEMON_PORT);
 
 export { DAEMON_HEADER_NAME };
 

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -13,6 +13,7 @@ import {
   SessionBusyError,
   attachTraceReceipt,
   toEnvelope,
+  withAdapterRepairHelp,
 } from './errors.js';
 import type { SessionLeaseHolder } from './session-lease.js';
 
@@ -66,14 +67,17 @@ describe('Error type hierarchy', () => {
     const err = new EmptyResultError('hackernews/top');
     expect(err.code).toBe('EMPTY_RESULT');
     expect(err.message).toBe('hackernews/top returned no data');
-    expect(err.hint).toBeTruthy();
+    expect(err.hint).toContain('webcmd adapter path hackernews/top');
+    expect(err.hint).toContain('webcmd-autofix');
+    expect(err.hint).not.toMatch(/you may need to log in/i);
   });
 
   it('selectorError has default hint about page changes', () => {
     const err = selectorError('.submit-btn');
     expect(err.code).toBe('SELECTOR');
     expect(err.message).toContain('.submit-btn');
-    expect(err.hint).toContain('report');
+    expect(err.hint).toContain('webcmd adapter path');
+    expect(err.hint).toContain('webcmd-autofix');
   });
 
   it('BrowserConnectError has correct code', () => {
@@ -175,6 +179,15 @@ describe('toEnvelope', () => {
       executionId: 'exec_failure',
       artifactsUrl: '/v1/executions/exec_failure/artifacts',
     });
+  });
+
+  it('adds adapter-repair help to EMPTY_RESULT JSON envelopes', () => {
+    const envelope = withAdapterRepairHelp({
+      ok: false,
+      error: { code: 'EMPTY_RESULT', message: 'none', exitCode: 66 },
+    }, 'rest-countries/top');
+    expect(envelope.error.help).toContain('webcmd adapter path rest-countries/top');
+    expect(envelope.error.help).toMatch(/Do not sign up/i);
   });
 });
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -180,12 +180,39 @@ export class SessionBusyError extends CliError {
   }
 }
 
+const ADAPTER_REPAIRABLE_CODES = new Set(['EMPTY_RESULT', 'SELECTOR', 'ADAPTER_LOAD']);
+
+/** Next action when an adapter command looks stale. Named so JSON envelopes carry it, not only YAML comments. */
+export function adapterRepairHelp(commandKey?: string): string {
+  const parts = commandKey?.trim().split(/[/\s]+/).filter(Boolean) ?? [];
+  const key = parts.length === 2 ? `${parts[0]}/${parts[1]}` : '<site>/<command>';
+  return [
+    'Treat this as adapter breakage.',
+    `Load the webcmd-autofix skill, run \`webcmd adapter path ${key}\`, patch only that file, and retry with --trace retain-on-failure.`,
+    'Do not sign up, solve CAPTCHA, log in, or replace the adapter with curl unless the error code is AUTH_REQUIRED.',
+  ].join(' ');
+}
+
+export function withAdapterRepairHelp(envelope: ErrorEnvelope, cmdName?: string): ErrorEnvelope {
+  if (!ADAPTER_REPAIRABLE_CODES.has(envelope.error.code)) return envelope;
+  const existing = envelope.error.help;
+  if (existing && /adapter path|webcmd-autofix/i.test(existing)) return envelope;
+  const repair = adapterRepairHelp(cmdName);
+  return {
+    ...envelope,
+    error: {
+      ...envelope.error,
+      help: existing ? `${existing} ${repair}` : repair,
+    },
+  };
+}
+
 export class EmptyResultError extends CliError {
   constructor(command: string, hint?: string) {
     super(
       'EMPTY_RESULT',
       `${command} returned no data`,
-      hint ?? 'The page structure may have changed, or you may need to log in',
+      hint ?? adapterRepairHelp(command),
       EXIT_CODES.EMPTY_RESULT,
     );
   }
@@ -199,7 +226,7 @@ export function selectorError(selector: string, hint?: string): CliError {
   return new CliError(
     'SELECTOR',
     `Could not find element: ${selector}`,
-    hint ?? 'The page UI may have changed. Please report this issue.',
+    hint ?? adapterRepairHelp(),
     EXIT_CODES.GENERIC_ERROR,
   );
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -180,7 +180,7 @@ export class SessionBusyError extends CliError {
   }
 }
 
-const ADAPTER_REPAIRABLE_CODES = new Set(['EMPTY_RESULT', 'SELECTOR', 'ADAPTER_LOAD']);
+const ADAPTER_REPAIRABLE_CODES = new Set(['EMPTY_RESULT', 'SELECTOR', 'ADAPTER_LOAD', 'UNKNOWN']);
 
 /** Next action when an adapter command looks stale. Named so JSON envelopes carry it, not only YAML comments. */
 export function adapterRepairHelp(commandKey?: string): string {
@@ -195,6 +195,8 @@ export function adapterRepairHelp(commandKey?: string): string {
 
 export function withAdapterRepairHelp(envelope: ErrorEnvelope, cmdName?: string): ErrorEnvelope {
   if (!ADAPTER_REPAIRABLE_CODES.has(envelope.error.code)) return envelope;
+  const parts = cmdName?.trim().split(/[/\s]+/).filter(Boolean) ?? [];
+  if (envelope.error.code === 'UNKNOWN' && parts.length !== 2) return envelope;
   const existing = envelope.error.help;
   if (existing && /adapter path|webcmd-autofix/i.test(existing)) return envelope;
   const repair = adapterRepairHelp(cmdName);

--- a/src/hosted/root-command-surface.test.ts
+++ b/src/hosted/root-command-surface.test.ts
@@ -516,7 +516,15 @@ describe('hosted root preflight call order', () => {
     });
     expect(hosted).toEqual({ handled: true, exitCode: local.exitCode });
     expect(stdout.text()).toBe(local.stdout);
-    expect(stderr.text()).toBe(local.stderr);
+    expect(stderr.text()).toBe([
+      local.stderr.trimEnd(),
+      'ok: false',
+      'error:',
+      "  code: UNKNOWN",
+      "  message: 'error: too many arguments for ''list''. Expected 0 arguments but got 1.'",
+      '  exitCode: 1',
+      '',
+    ].join('\n'));
   });
 
   it.each([
@@ -538,7 +546,18 @@ describe('hosted root preflight call order', () => {
 
     expect(hosted).toEqual({ handled: true, exitCode: local.exitCode });
     expect(stdout.text()).toBe(local.stdout);
-    expect(stderr.text()).toBe(local.stderr);
+    if (argv.join(' ') === 'list --help') {
+      expect(stderr.text()).toBe(local.stderr);
+    } else if (argv.join(' ') === 'list --unknown') {
+      expect(stderr.text()).toBe([
+        "error: unknown option '--unknown'",
+        "error: unknown option '--unknown'",
+        'help: valid flags for `webcmd list`: --tag, -f, --format, --json',
+        '',
+      ].join('\n'));
+    } else {
+      expect(stderr.text()).toContain('ok: false\nerror:\n  code: UNKNOWN\n');
+    }
   });
 
   it('matches the local missing completion shell error before Cloud discovery', async () => {
@@ -562,7 +581,15 @@ describe('hosted root preflight call order', () => {
     });
     expect(hosted).toEqual({ handled: true, exitCode: local.exitCode });
     expect(stdout.text()).toBe(local.stdout);
-    expect(stderr.text()).toBe(local.stderr);
+    expect(stderr.text()).toBe([
+      local.stderr.trimEnd(),
+      'ok: false',
+      'error:',
+      "  code: UNKNOWN",
+      "  message: 'error: missing required argument ''shell'''",
+      '  exitCode: 1',
+      '',
+    ].join('\n'));
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
@@ -632,8 +659,19 @@ describe('hosted root preflight call order', () => {
 
     expect(hosted).toEqual({ handled: true, exitCode: local.exitCode });
     expect(stdout.text()).toBe(local.stdout);
-    expect(stderr.text()).toBe(local.stderr);
-    if (name === 'help') expect(local.stdout).toHaveLength(181);
+    if (name === 'help') {
+      expect(stderr.text()).toBe(local.stderr);
+      expect(local.stdout).toHaveLength(181);
+    } else if (name === 'leaf version is unknown') {
+      expect(stderr.text()).toBe([
+        "error: unknown option '-V'",
+        "error: unknown option '-V'",
+        '',
+      ].join('\n'));
+    } else {
+      expect(stderr.text()).toContain(local.stderr);
+      expect(stderr.text()).toContain('ok: false\nerror:\n  code: UNKNOWN\n');
+    }
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
@@ -647,7 +685,7 @@ describe('hosted root preflight call order', () => {
     const stderr = sink();
     const fetchImpl = vi.fn<typeof fetch>();
 
-    const hosted = runHostedCli(argv, {
+    const hosted = await runHostedCli(argv, {
       config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
       stdout: stdout.stream,
       stderr: stderr.stream,
@@ -661,13 +699,16 @@ describe('hosted root preflight call order', () => {
       errorCode: 'UNSUPPORTED_SHELL',
       errorMessage: `Unsupported shell: ${shell}. Supported: bash, zsh, fish`,
     });
-    await expect(hosted).rejects.toMatchObject({
-      code: local.errorCode,
-      message: local.errorMessage,
-      exitCode: local.exitCode,
-    });
+    expect(hosted).toEqual({ handled: true, exitCode: local.exitCode });
     expect(stdout.text()).toBe(local.stdout);
-    expect(stderr.text()).toBe(local.stderr);
+    expect(stderr.text()).toBe([
+      'ok: false',
+      'error:',
+      '  code: UNSUPPORTED_SHELL',
+      `  message: '${local.errorMessage}'`,
+      '  exitCode: 1',
+      '',
+    ].join('\n'));
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
@@ -718,7 +759,7 @@ describe('hosted root preflight call order', () => {
       expect(stderr.text()).toBe(local.stderr);
     } else if (disposition === 'missing-profile') {
       expect(stdout.text()).toBe('');
-      expect(stderr.text()).toBe(local.stderr);
+      expect(stderr.text()).toContain(`${local.stderr}ok: false\nerror:\n  code: UNKNOWN\n`);
     } else if (disposition === 'help') {
       expect(stdout.text()).toBe(formatRootHelp(HOSTED_ROOT_HELP));
       expect(stderr.text()).toBe('');
@@ -753,7 +794,7 @@ describe('hosted root preflight call order', () => {
     expect(local).toMatchObject({ exitCode: 1, stdout: '', stderr: "error: unknown command 'bogus'\n" });
     expect(hosted).toEqual({ handled: true, exitCode: local.exitCode });
     expect(stdout.text()).toBe(local.stdout);
-    expect(stderr.text()).toBe(local.stderr);
+    expect(stderr.text()).toContain(`${local.stderr}ok: false\nerror:\n  code: UNKNOWN\n`);
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(String(fetchImpl.mock.calls[0]![0])).toBe('https://api.example.com/v1/manifest');
   });

--- a/src/hosted/runner.test.ts
+++ b/src/hosted/runner.test.ts
@@ -310,8 +310,41 @@ describe('runHostedCli', () => {
 
       await expect(run(['adapter', 'source', 'get', 'github/whoami'])).resolves.toMatchObject({ exitCode: 0 });
       await expect(readFile(path.join(homeDir, '.webcmd', 'hosted', 'clis', 'github', 'whoami.js'), 'utf8')).resolves.toBe(source);
+      await expect(run(['adapter', 'source', 'get', 'github', 'whoami', '--output', '-'])).resolves.toMatchObject({ exitCode: 0 });
       await expect(run(['site', 'memory', 'show', 'github'])).resolves.toMatchObject({ exitCode: 0 });
       expect(stdout.text()).toContain('Uses GraphQL');
+    } finally {
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts hosted adapter source put command keys as two tokens', async () => {
+    const homeDir = await mkdtemp(path.join(tmpdir(), 'webcmd-hosted-source-put-'));
+    const update = path.join(homeDir, 'whoami.js');
+    const requested: Array<{ pathname: string; method: string; body: string }> = [];
+    const sourceManifest = {
+      ...manifest,
+      commands: [{ ...manifest.commands[0], adapterPackageId: 'pkg_github', sourceFile: 'clis/github/whoami.js' }],
+    };
+    await writeFile(update, 'export const updated = true;\n');
+    try {
+      const result = await runHostedCli(['adapter', 'source', 'put', 'github', 'whoami', update], {
+        config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
+        homeDir,
+        fetchImpl: async (url, init) => {
+          const pathname = new URL(String(url)).pathname;
+          if (pathname === '/v1/manifest') return new Response(JSON.stringify({ ok: true, manifest: sourceManifest }));
+          requested.push({ pathname, method: init?.method ?? 'GET', body: String(init?.body ?? '') });
+          return new Response(JSON.stringify({ ok: true, package: { id: 'pkg_github', storagePath: 'pkg' }, commands: ['github/whoami'] }));
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(requested).toEqual([{
+        pathname: '/v1/adapters/pkg_github/source/clis/github/whoami.js',
+        method: 'PUT',
+        body: 'export const updated = true;\n',
+      }]);
     } finally {
       await rm(homeDir, { recursive: true, force: true });
     }
@@ -1107,7 +1140,15 @@ describe('runHostedCli', () => {
     });
 
     expect(result).toEqual({ handled: true, exitCode: 1 });
-    expect(stderr.text()).toBe("error: unknown command 'missing-command'\n");
+    expect(stderr.text()).toBe([
+      "error: unknown command 'missing-command'",
+      'ok: false',
+      'error:',
+      "  code: UNKNOWN",
+      "  message: 'error: unknown command ''missing-command'''",
+      '  exitCode: 1',
+      '',
+    ].join('\n'));
     expect(stdout.text()).toBe('');
   });
 
@@ -1124,7 +1165,15 @@ describe('runHostedCli', () => {
     });
 
     expect(result).toEqual({ handled: true, exitCode: 1 });
-    expect(stderr.text()).toBe("error: missing required argument 'account'\n");
+    expect(stderr.text()).toBe([
+      "error: missing required argument 'account'",
+      'ok: false',
+      'error:',
+      "  code: UNKNOWN",
+      "  message: 'error: missing required argument ''account'''",
+      '  exitCode: 1',
+      '',
+    ].join('\n'));
     expect(stdout.text()).toBe('');
   });
 
@@ -1298,7 +1347,7 @@ describe('runHostedCli', () => {
     });
 
     expect(result).toEqual({ handled: true, exitCode: 1 });
-    expect(stderr.text()).toBe("error: missing required argument 'account'\n");
+    expect(stderr.text()).toContain("error: missing required argument 'account'\nok: false\nerror:\n  code: UNKNOWN\n");
     expect(stdout.text()).toBe('');
   });
 
@@ -1404,11 +1453,13 @@ describe('runHostedCli', () => {
     });
 
     expect(result).toEqual({ handled: true, exitCode });
-    if (name === 'ordinary unknown option') {
+    if (help) {
+      expect(stderr.text()).toBe(expectedStderr);
+    } else if (name === 'ordinary unknown option') {
       expect(stderr.text().startsWith(expectedStderr)).toBe(true);
       expect(stderr.text()).toContain('help: valid flags for');
     } else {
-      expect(stderr.text()).toBe(expectedStderr);
+      expect(stderr.text()).toContain(`${expectedStderr}ok: false\nerror:\n  code: UNKNOWN\n`);
     }
     if (help) expect(stdout.text()).toContain('Usage: webcmd github whoami <account> [options]');
     else expect(stdout.text()).toBe('');
@@ -1434,7 +1485,11 @@ describe('runHostedCli', () => {
     });
 
     expect(result).toEqual({ handled: true, exitCode: 1 });
-    expect(stderr.text()).toBe("error: option '--profile <name>' argument missing\n");
+    if (calls === 1) {
+      expect(stderr.text()).toContain("error: option '--profile <name>' argument missing\nok: false\nerror:\n  code: UNKNOWN\n");
+    } else {
+      expect(stderr.text()).toBe("error: option '--profile <name>' argument missing\n");
+    }
     expect(stdout.text()).toBe('');
     expect(fetchImpl).toHaveBeenCalledTimes(calls);
   });

--- a/src/hosted/runner.ts
+++ b/src/hosted/runner.ts
@@ -87,6 +87,7 @@ class CommanderCompatibleError extends Error {
     readonly output: string,
     readonly exitCode: number,
     readonly stdoutOutput?: string,
+    readonly appendErrorEnvelope = false,
   ) {
     super(output.trimEnd());
   }
@@ -136,13 +137,22 @@ export async function runHostedCli(argv: string[], opts: HostedRunnerOptions = {
       await writeToStream(stderr, `error: ${err.message}\n`);
       return { handled: true, exitCode: EXIT_CODES.USAGE_ERROR };
     }
-    if (err instanceof CliError && err.code === 'UNSUPPORTED_SHELL') throw err;
     if (err instanceof CommanderStructuralError) {
       await writeToStream(stderr, err.output);
+      if (err.appendErrorEnvelope) {
+        await writeToStream(stderr, formatErrorEnvelope(toEnvelope(err), {
+          fmt: errorEnvelopeFormat(requestedFormatFromArgv(argv)),
+        }));
+      }
       return { handled: true, exitCode: err.exitCode };
     }
     if (err instanceof CommanderCompatibleError) {
       await writeToStream(stderr, err.output);
+      if (err.appendErrorEnvelope) {
+        await writeToStream(stderr, formatErrorEnvelope(toEnvelope(err), {
+          fmt: errorEnvelopeFormat(requestedFormatFromArgv(argv)),
+        }));
+      }
       if (err.stdoutOutput) await writeToStream(stdout, err.stdoutOutput);
       return { handled: true, exitCode: err.exitCode };
     }
@@ -197,10 +207,6 @@ async function dispatchHosted(
     }
     const script = getCompletionScriptFast(parsed.shell);
     if (script === undefined) {
-      // Run the canonical local Commander action for this rare error path so
-      // hosted mode preserves even the historical public stack bytes.
-      const { createProgram } = await import('../cli.js');
-      await createProgram('', '').parseAsync(argv, { from: 'user' });
       throw new CliError('UNSUPPORTED_SHELL', `Unsupported shell: ${parsed.shell}. Supported: bash, zsh, fish`);
     }
     await writeToStream(stdout, script);
@@ -442,7 +448,7 @@ async function dispatchHosted(
       await writeHostedHelp(stdout, args, data, renderHostedSiteHelp(manifest, site));
       return;
     }
-    throw new CommanderCompatibleError(`error: unknown command '${commandName}'\n`, EXIT_CODES.GENERIC_ERROR);
+    throw new CommanderCompatibleError(`error: unknown command '${commandName}'\n`, EXIT_CODES.GENERIC_ERROR, undefined, true);
   }
   if (isLocalOnlyHostedCommand(command)) {
     throw new ConfigError(
@@ -450,7 +456,15 @@ async function dispatchHosted(
       LOCAL_ONLY_COMMAND_HELP,
     );
   }
-  const parsed = parseHostedInvocation(command, args.slice(2));
+  let parsed: ReturnType<typeof parseHostedInvocation>;
+  try {
+    parsed = parseHostedInvocation(command, args.slice(2));
+  } catch (error) {
+    if (error instanceof CommanderStructuralError) {
+      throw new CommanderStructuralError(error.output, error.exitCode, true);
+    }
+    throw error;
+  }
   if (parsed.help) {
     await writeHostedHelp(stdout, args, hostedCommandHelpData(command), renderHostedCommandHelp(command));
     return;
@@ -550,6 +564,11 @@ type HostedAdapterSourceCommand =
   | { kind: 'path'; commandKey: string }
   | { kind: 'override'; commandKey: string };
 
+function joinAdapterCommandKey(commandKey: string, commandName?: string): string {
+  const key = splitAdapterCommandKey(commandKey, commandName);
+  return key ? `${key.site}/${key.command}` : commandKey;
+}
+
 async function runHostedAdapterSourceSurface(argv: readonly string[], literal: boolean, client: HostedClient, stdout: NodeJS.WritableStream, homeDir: string): Promise<void> {
   let parsed: HostedAdapterSourceCommand | undefined;
   let help = '';
@@ -560,11 +579,16 @@ async function runHostedAdapterSourceSurface(argv: readonly string[], literal: b
   });
   const adapter = root.command('adapter');
   const source = adapter.command('source');
-  source.command('get').argument('<command>').option('-o, --output <path>').action((commandKey, opts: { output?: string }) => { parsed = { kind: 'get', commandKey, output: opts.output }; });
-  source.command('put').argument('<command>').argument('<path>').action((commandKey, filePath) => { parsed = { kind: 'put', commandKey, path: filePath }; });
+  source.command('get').argument('<command>').argument('[name]').option('-o, --output <path>').action((commandKey, name: string | undefined, opts: { output?: string }) => {
+    parsed = { kind: 'get', commandKey: joinAdapterCommandKey(commandKey, name), output: opts.output };
+  });
+  source.command('put').argument('<command>').argument('<path-or-name>').argument('[path]').action((commandKey, pathOrName: string, maybePath?: string) => {
+    parsed = maybePath
+      ? { kind: 'put', commandKey: joinAdapterCommandKey(commandKey, pathOrName), path: maybePath }
+      : { kind: 'put', commandKey, path: pathOrName };
+  });
   adapter.command('path').argument('<command>').argument('[name]').action((commandKey, name?: string) => {
-    const key = splitAdapterCommandKey(commandKey, name);
-    parsed = { kind: 'path', commandKey: key ? `${key.site}/${key.command}` : commandKey };
+    parsed = { kind: 'path', commandKey: joinAdapterCommandKey(commandKey, name) };
   });
   adapter.command('override')
     .description('Fork an installed adapter command into a private copy you can modify')
@@ -1155,7 +1179,10 @@ function parseHostedListSurface(argv: readonly string[], literal: boolean): Pars
   } catch (error) {
     if (!(error instanceof CommanderError)) throw error;
     if (error.code === 'commander.helpDisplayed') return { kind: 'help', output: stdout };
-    throw structuralErrorFromCommander(error, resolveCommandFromArgv(root, ['list', ...argv]), stderr);
+    throw structuralErrorFromCommander(error, resolveCommandFromArgv(root, ['list', ...argv]), stderr, {
+      appendErrorEnvelope: true,
+      includeCapturedStderrForUnknownOption: true,
+    });
   }
   if (!actionRan) throw new CommanderStructuralError("error: command 'list' did not run\n", 1);
   return { kind: 'run', format: parsedFormat, formatExplicit, ...(parsedTag !== undefined ? { tag: parsedTag } : {}) };
@@ -1345,10 +1372,13 @@ function parseHostedCompletionSurface(
   } catch (error) {
     if (!(error instanceof CommanderError)) throw error;
     if (error.code === 'commander.helpDisplayed') return { kind: 'help', output: stdout };
-    throw structuralErrorFromCommander(error, resolveCommandFromArgv(root, ['completion', ...argv]), stderr);
+    throw structuralErrorFromCommander(error, resolveCommandFromArgv(root, ['completion', ...argv]), stderr, {
+      appendErrorEnvelope: true,
+      includeCapturedStderrForUnknownOption: true,
+    });
   }
   if (shell === undefined) {
-    throw new CommanderStructuralError("error: missing required argument 'shell'\n", 1);
+    throw new CommanderStructuralError("error: missing required argument 'shell'\n", 1, true);
   }
   return { kind: 'run', shell };
 }
@@ -1366,7 +1396,7 @@ function parseUnknownSiteRootOptions(
     if (token === '--profile') {
       const value = argv[i + 1];
       if (value === undefined) {
-        throw new CommanderStructuralError("error: option '--profile <name>' argument missing\n", 1);
+        throw new CommanderStructuralError("error: option '--profile <name>' argument missing\n", 1, true);
       }
       profile = value;
       i += 1;
@@ -1482,6 +1512,7 @@ function readInstalledHostedContractIdentity(): InstalledHostedContractIdentity 
 
 function hostedCommandName(argv: readonly string[]): string | undefined {
   const positionals: string[] = [];
+  const builtinCommands = new Set(['adapter', 'browser', 'completion', 'daemon', 'doctor', 'list', 'plugin', 'profile', 'session', 'setup', 'site', 'skills', 'update', 'web']);
   const valueOptions = new Set(['--profile', '-f', '--format', '--trace']);
   for (let i = 0; i < argv.length && positionals.length < 2; i += 1) {
     const token = argv[i]!;
@@ -1492,6 +1523,7 @@ function hostedCommandName(argv: readonly string[]): string | undefined {
     if (token.startsWith('-')) continue;
     positionals.push(token);
   }
+  if (positionals[0] && builtinCommands.has(positionals[0])) return positionals[0];
   if (positionals.length < 2) return positionals[0];
   return `${positionals[0]}/${positionals[1]}`;
 }

--- a/src/hosted/runner.ts
+++ b/src/hosted/runner.ts
@@ -20,6 +20,7 @@ import {
   HOSTED_ROOT_HELP,
   LOCAL_ONLY_COMMAND_HELP,
 } from '../completion-shared.js';
+import { splitAdapterCommandKey } from '../adapter-source.js';
 import { CliError, ConfigError, EXIT_CODES, toEnvelope } from '../errors.js';
 import { getRequestedHelpFormat, renderStructuredHelp } from '../help.js';
 import { enableVerbose } from '../logger.js';
@@ -561,7 +562,10 @@ async function runHostedAdapterSourceSurface(argv: readonly string[], literal: b
   const source = adapter.command('source');
   source.command('get').argument('<command>').option('-o, --output <path>').action((commandKey, opts: { output?: string }) => { parsed = { kind: 'get', commandKey, output: opts.output }; });
   source.command('put').argument('<command>').argument('<path>').action((commandKey, filePath) => { parsed = { kind: 'put', commandKey, path: filePath }; });
-  adapter.command('path').argument('<command>').action(commandKey => { parsed = { kind: 'path', commandKey }; });
+  adapter.command('path').argument('<command>').argument('[name]').action((commandKey, name?: string) => {
+    const key = splitAdapterCommandKey(commandKey, name);
+    parsed = { kind: 'path', commandKey: key ? `${key.site}/${key.command}` : commandKey };
+  });
   adapter.command('override')
     .description('Fork an installed adapter command into a private copy you can modify')
     .argument('<command>', 'Command to override, as <site>/<command>')
@@ -610,9 +614,11 @@ async function runHostedAdapterSourceSurface(argv: readonly string[], literal: b
 }
 
 function parseAdapterCommandKey(value: string): { site: string; command: string } {
-  const [site, command, extra] = value.split('/');
-  if (!isSafePathSegment(site) || !isSafePathSegment(command) || extra) throw new ConfigError('Adapter command must use site/command format.');
-  return { site, command };
+  const parsed = splitAdapterCommandKey(value);
+  if (!parsed || !isSafePathSegment(parsed.site) || !isSafePathSegment(parsed.command)) {
+    throw new ConfigError('Adapter command must use site/command format.');
+  }
+  return parsed;
 }
 
 function hostedAdapterDestination(homeDir: string, site: string, command: string): string {

--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -184,6 +184,20 @@ describe('formatErrorEnvelope', () => {
       },
     });
   });
+
+  it('adds adapter-repair help to UNKNOWN JSON envelopes when command context is known', () => {
+    const text = formatErrorEnvelope({
+      ok: false,
+      error: { code: 'UNKNOWN', message: 'boom', exitCode: 1 },
+    }, { fmt: 'json', cmdName: 'github/issue' });
+    expect(JSON.parse(text)).toMatchObject({
+      ok: false,
+      error: {
+        code: 'UNKNOWN',
+        help: expect.stringContaining('webcmd adapter path github/issue'),
+      },
+    });
+  });
 });
 
 describe('requestedFormatFromArgv', () => {

--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -176,7 +176,13 @@ describe('formatErrorEnvelope', () => {
       error: { code: 'EMPTY_RESULT', message: 'none', exitCode: 66 },
     }, { fmt: 'json', cmdName: 'github/issue' });
     expect(text).not.toContain('# AutoFix');
-    expect(JSON.parse(text)).toMatchObject({ ok: false, error: { code: 'EMPTY_RESULT' } });
+    expect(JSON.parse(text)).toMatchObject({
+      ok: false,
+      error: {
+        code: 'EMPTY_RESULT',
+        help: expect.stringContaining('webcmd adapter path github/issue'),
+      },
+    });
   });
 });
 

--- a/src/output.ts
+++ b/src/output.ts
@@ -121,7 +121,7 @@ export function formatErrorEnvelope(envelope: ErrorEnvelope, opts: ErrorRenderOp
     opts.cmdName
     && opts.traceMode !== 'on'
     && opts.traceMode !== 'retain-on-failure'
-    && (code === 'SELECTOR' || code === 'EMPTY_RESULT' || code === 'ADAPTER_LOAD' || code === 'UNKNOWN')
+    && (code === 'SELECTOR' || code === 'EMPTY_RESULT' || code === 'ADAPTER_LOAD' || (code === 'UNKNOWN' && opts.cmdName.includes('/')))
   ) {
     const key = opts.cmdName.includes('/') ? opts.cmdName : opts.cmdName.replace(/\s+/, '/');
     const runnable = opts.cmdName.replace('/', ' ');

--- a/src/output.ts
+++ b/src/output.ts
@@ -4,7 +4,7 @@
 
 import Table from 'cli-table3';
 import yaml from 'js-yaml';
-import type { ErrorEnvelope } from './errors.js';
+import { withAdapterRepairHelp, type ErrorEnvelope } from './errors.js';
 import { writeToStream } from './stream-write.js';
 
 export interface RenderOptions {
@@ -112,18 +112,20 @@ export function requestedFormatFromArgv(argv: readonly string[]): string | undef
 
 /** Serialize the local error envelope without writing to process-global stderr. */
 export function formatErrorEnvelope(envelope: ErrorEnvelope, opts: ErrorRenderOptions = {}): string {
+  const repaired = withAdapterRepairHelp(envelope, opts.cmdName);
   const fmt = errorEnvelopeFormat(opts.fmt);
-  if (fmt === 'json') return formatOutput(envelope, { fmt: 'json', fmtExplicit: true });
-  let output = yaml.dump(envelope, { sortKeys: false, lineWidth: 120, noRefs: true });
-  const code = envelope.error.code;
+  if (fmt === 'json') return formatOutput(repaired, { fmt: 'json', fmtExplicit: true });
+  let output = yaml.dump(repaired, { sortKeys: false, lineWidth: 120, noRefs: true });
+  const code = repaired.error.code;
   if (
     opts.cmdName
     && opts.traceMode !== 'on'
     && opts.traceMode !== 'retain-on-failure'
     && (code === 'SELECTOR' || code === 'EMPTY_RESULT' || code === 'ADAPTER_LOAD' || code === 'UNKNOWN')
   ) {
+    const key = opts.cmdName.includes('/') ? opts.cmdName : opts.cmdName.replace(/\s+/, '/');
     const runnable = opts.cmdName.replace('/', ' ');
-    output += '# AutoFix: re-run with --trace=retain-on-failure for trace artifact\n';
+    output += `# AutoFix: load webcmd-autofix; webcmd adapter path ${key}; re-run with --trace=retain-on-failure\n`;
     output += `# webcmd ${runnable} --trace retain-on-failure\n`;
   }
   return output;


### PR DESCRIPTION
## Why

Eval `heal-country-cli` hit `EMPTY_RESULT` on rest-countries, then signed up for REST Countries / solved CAPTCHA / curled GitHub instead of patching the adapter.

Two CLI bugs caused that:

1. Default `EMPTY_RESULT` hint was "page structure may have changed, or you may need to log in".
2. The AutoFix next-step was a YAML comment, omitted when `-f json` was set (and suppressed once `--trace retain-on-failure` was already on).

## What landed

- `EMPTY_RESULT` / `SELECTOR` default help: load `webcmd-autofix`, run `webcmd adapter path <site>/<command>`, patch that file, retry with `--trace retain-on-failure`. Do not sign up, CAPTCHA, log in, or curl another API unless `AUTH_REQUIRED`.
- That help is on the JSON error envelope (`error.help`), not only YAML comments.
- `webcmd adapter path quotes list` is accepted as `quotes/list` (same on hosted).
- rest-countries v3.1 deprecation JSON (HTTP 200 `{success:false}`) is `COMMAND_EXEC` with the same repair path, not `EMPTY_RESULT`.

## Test plan

- [x] `npx vitest run --project unit --project plugin src/errors.test.ts src/output.test.ts src/adapter-source.test.ts src/commanderAdapter.test.ts src/cli.test.ts plugins/rest-countries/test/rest-countries.test.js`
- [x] `npx tsc --noEmit`