### PR TITLE
skills: force-load adapter-author when creating a command

### DIFF
--- a/skill-src/webcmd-adapter-author/SKILL.src.md
+++ b/skill-src/webcmd-adapter-author/SKILL.src.md
@@ -257,6 +257,8 @@ Check these off step by step:
 - Adapters import only `@agentrhq/webcmd/registry` and `@agentrhq/webcmd/errors`; do not add third-party dependencies.
 - Browser-run’s Playwright-style `page` and adapter `func(page,args)` are different contracts. Preserve evidence and behavior, not syntax. Implement adapters with the existing `IPage`, pipeline, Node-fetch, or interceptor APIs.
 - The `columns` array and `func` return object keys must match exactly, including order.
+- CLI flags map onto `args` by the declared `name`. `{ name: 'note-id' }` is `args['note-id']`, not `args.noteId`. A `type: 'boolean'` flag is `true` when passed. Do not grep the framework for camelCase aliases.
+- Verification is `webcmd browser verify` / `webcmd verify`. Do not add a second command whose name ends in verify.
 - **Intermediate parsing object keys must not overlap any `columns` entry.** Otherwise silent-column-drop audits can misread the adapter. Use dedicated internal names and destructure with aliases when pushing rows.
 - **The `browser:` field determines the `func` signature:** `browser:false -> (args)`, `browser:true -> (page, args)`. If this is reversed, `args` may actually be a debug flag and all external parameters can silently fall back to defaults.
 - Throw the correct typed error for known failures according to [`references/typed-errors.md`](./references/typed-errors.md). **Do not** silently `return []`, **do not** silently `return [{sentinel}]`, and **do not** silently clamp external parameters with `Math.max/min`.
@@ -284,4 +286,9 @@ Author-only. Stripped by litprompt, so it costs the running agent nothing.
 Append one dated line whenever a correction lands, or whenever an approach
 is tried and rejected. Record what was tried and why it failed, not just
 what won.
+
+- 2026-08-21: Agents skipped this skill, wrote notes next to the adapter, and
+  invented a sibling verify command. Usage now force-loads this skill for
+  create/revise/override. Args keys match declared `name`, not Commander camelCase (#386).
 -->
+

--- a/skill-src/webcmd-usage/SKILL.src.md
+++ b/skill-src/webcmd-usage/SKILL.src.md
@@ -41,6 +41,8 @@ Do not install Node.js or silently fall back to `npx`.
 
 **REQUIRED SUB-SKILL:** Before raw browser work, load `webcmd-browser`.
 
+**REQUIRED SUB-SKILL:** Before creating, revising, or privately overriding a command, load `webcmd-adapter-author`.
+
 ## Install
 
 ```bash
@@ -282,6 +284,8 @@ Do not invoke these removed commands:
 - Do not assume every adapter needs a browser; check `strategy`.
 - Do not silently fall back from a failing adapter to hand-rolled `fetch`; use `--trace retain-on-failure` first.
 - Do not treat a raw 403 or challenge from a direct fetch as a browser gate; run `webcmd web fetch --url <url>` first.
+- Do not store authoring notes in a hand-written file next to the adapter; use the site-memory commands (`webcmd site note`, `webcmd site endpoint`, `webcmd site field-map`).
+- Do not invent a sibling verify command; use `webcmd verify` or `webcmd browser verify`.
 
 <!-- @
 ## Learnings log
@@ -290,6 +294,10 @@ Author-only. Stripped by litprompt, so it costs the running agent nothing.
 Append one dated line whenever a correction lands, or whenever an approach
 is tried and rejected. Record what was tried and why it failed, not just
 what won.
+
+- 2026-08-21: Usage force-loaded `webcmd-browser` for raw browser work but not
+  `webcmd-adapter-author` for create/revise/override. Agents then skipped
+  site-memory and invented a sibling verify command (#386).
 
 - 2026-08-20: A prior generic-client 403 is not authority to escalate to the
   browser; browser use remains gated on Webcmd returning `FETCH_BLOCKED` or

--- a/skills/webcmd-adapter-author/SKILL.md
+++ b/skills/webcmd-adapter-author/SKILL.md
@@ -257,6 +257,8 @@ Check these off step by step:
 - Adapters import only `@agentrhq/webcmd/registry` and `@agentrhq/webcmd/errors`; do not add third-party dependencies.
 - Browser-run’s Playwright-style `page` and adapter `func(page,args)` are different contracts. Preserve evidence and behavior, not syntax. Implement adapters with the existing `IPage`, pipeline, Node-fetch, or interceptor APIs.
 - The `columns` array and `func` return object keys must match exactly, including order.
+- CLI flags map onto `args` by the declared `name`. `{ name: 'note-id' }` is `args['note-id']`, not `args.noteId`. A `type: 'boolean'` flag is `true` when passed. Do not grep the framework for camelCase aliases.
+- Verification is `webcmd browser verify` / `webcmd verify`. Do not add a second command whose name ends in verify.
 - **Intermediate parsing object keys must not overlap any `columns` entry.** Otherwise silent-column-drop audits can misread the adapter. Use dedicated internal names and destructure with aliases when pushing rows.
 - **The `browser:` field determines the `func` signature:** `browser:false -> (args)`, `browser:true -> (page, args)`. If this is reversed, `args` may actually be a debug flag and all external parameters can silently fall back to defaults.
 - Throw the correct typed error for known failures according to [`references/typed-errors.md`](./references/typed-errors.md). **Do not** silently `return []`, **do not** silently `return [{sentinel}]`, and **do not** silently clamp external parameters with `Math.max/min`.

--- a/skills/webcmd-usage/SKILL.md
+++ b/skills/webcmd-usage/SKILL.md
@@ -41,6 +41,8 @@ Do not install Node.js or silently fall back to `npx`.
 
 **REQUIRED SUB-SKILL:** Before raw browser work, load `webcmd-browser`.
 
+**REQUIRED SUB-SKILL:** Before creating, revising, or privately overriding a command, load `webcmd-adapter-author`.
+
 ## Install
 
 ```bash
@@ -282,3 +284,5 @@ Do not invoke these removed commands:
 - Do not assume every adapter needs a browser; check `strategy`.
 - Do not silently fall back from a failing adapter to hand-rolled `fetch`; use `--trace retain-on-failure` first.
 - Do not treat a raw 403 or challenge from a direct fetch as a browser gate; run `webcmd web fetch --url <url>` first.
+- Do not store authoring notes in a hand-written file next to the adapter; use the site-memory commands (`webcmd site note`, `webcmd site endpoint`, `webcmd site field-map`).
+- Do not invent a sibling verify command; use `webcmd verify` or `webcmd browser verify`.

--- a/src/skills.test.ts
+++ b/src/skills.test.ts
@@ -198,6 +198,10 @@ describe('webcmd skills content', () => {
       'utf8',
     );
     expect(usage).toMatch(/existing adapter command first[\s\S]{0,220}load `webcmd-browser`[\s\S]{0,120}root `--session <session-id>`/i);
+    expect(usage).toContain('Before creating, revising, or privately overriding a command, load `webcmd-adapter-author`');
+    expect(usage).toContain('Do not invent a sibling verify command');
+    expect(author).toContain("args['note-id']");
+    expect(author).toContain('Do not add a second command whose name ends in verify');
     expect(browser).toMatch(/`tabs`, `bind --page`, `snapshot`, and `run`/i);
     expect(browser).toContain('webcmd --session <session-id> browser tabs');
     expect(browser).toContain('webcmd --session <session-id> browser bind --page');


### PR DESCRIPTION
Fixes #386.

## Problem

`webcmd-usage` force-loads `webcmd-browser` before raw browser work,
but had no equivalent requirement for authoring. An agent could
discover `webcmd browser init` on its own, write a working command,
and never load `webcmd-adapter-author` — skipping the durable
authoring surfaces:

- Notes ended up in a hand-written file next to the adapter instead of
  going through `webcmd site note/endpoint/field-map`.
- A sibling `*_verify` command got invented instead of running
  `webcmd verify` / `webcmd browser verify`.

## Fix

- `webcmd-usage` now has a `REQUIRED SUB-SKILL` line for
  `webcmd-adapter-author` before creating, revising, or privately
  overriding a command, mirroring the existing browser-work
  requirement.
- Added matching `Do Not` lines in both skills: don't hand-write notes
  next to the adapter, don't invent a sibling verify command.
- `webcmd-adapter-author`'s Key Conventions now spells out that CLI
  flags map onto `args` by the declared `name` (e.g. `args['note-id']`),
  not a Commander camelCase alias — a mistake noted in the source eval
  runs.

Skill-doc only change; no runtime/CLI behavior touched.

## Test plan

- `npm run typecheck` — clean.
- `npm run test` — 447 files / 5757 tests pass.
- `make verify` — skill build (`skill-src/` → `skills/`) in sync.
- Updated `src/skills.test.ts` to assert the new force-load line and
  anti-pattern text in both skills.