### PR TITLE
fix(cli): name the owning Profile when a Session lookup misses

### DIFF
--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -48,7 +48,7 @@ Common Session codes:
 | `SESSION_REQUIRED` | A raw browser command needs a root Session selector. | Run `webcmd session create -f json`, then retry as `webcmd --session <session-id> browser ...`. |
 | `INVALID_SESSION_SELECTOR` | The selector is not an opaque Webcmd Session ID. | Use an ID returned by `webcmd session create` or `webcmd session list`. |
 | `SESSION_SELECTOR_POSITION` | `--session` was placed after the command name. | Move it before the command: `webcmd --session <session-id> browser ...`. |
-| `SESSION_NOT_FOUND` | The selected Session is missing for the current Profile. | Run `webcmd session list -f json`; create a new Session if needed. |
+| `SESSION_NOT_FOUND` | The selected Session is missing for the current Profile. | When the ID belongs to another Profile the hint names it — retry with `webcmd --profile <owner> session close <session-id>`. Otherwise run `webcmd session list -f json`; create a new Session if needed. |
 | `INVALID_SESSION_LIMIT` | `session list --limit` is outside 1-100. | Retry with a limit from 1 to 100. |
 | `SESSION_BUSY` | Another command is writing in the same Session or site scope. | Wait for the holder to finish; if it is dead, use `webcmd session close <session-id> --force` as the last resort. |
 | `SESSION_PAUSED_FOR_HUMAN_HANDOFF` | The Session is waiting for user action such as sign-in. | Finish the action in the browser, then run the returned verifier before retrying. |

--- a/src/browser/sessions.test.ts
+++ b/src/browser/sessions.test.ts
@@ -47,6 +47,44 @@ describe('LocalBrowserSessionStore', () => {
     expect(() => store.find('profile_work', 'work')).toThrowError(expect.objectContaining({ code: 'INVALID_SESSION_SELECTOR' }));
   });
 
+  it('names the owning profile when the session exists under a different one', () => {
+    // A cleanup command that omits `--profile` looks up a real Session ID in
+    // the wrong Profile. A bare "not found" sent agents into retrying the same
+    // command; naming the owner and the retry shape ends that loop.
+    const store = new LocalBrowserSessionStore({ baseDir: tempDir(), idFactory: () => 'session_a' });
+    const created = store.create('profile_work');
+
+    expect(() => store.require('profile_personal', created.id)).toThrowError(expect.objectContaining({
+      code: 'SESSION_NOT_FOUND',
+      ownerProfileId: 'profile_work',
+      message: `Session not found in Profile profile_personal: ${created.id}`,
+      hint: `Session ${created.id} belongs to Profile profile_work. Re-run the same command with \`--profile profile_work\`, for example \`webcmd --profile profile_work session close ${created.id}\`.`,
+    }));
+  });
+
+  it('names the owning profile on mutating lookups too', () => {
+    // `remove`/`touch`/handoff updates resolve the record through a separate
+    // lookup, so the close path must not fall back to the anonymous message.
+    const store = new LocalBrowserSessionStore({ baseDir: tempDir(), idFactory: () => 'session_a' });
+    const created = store.create('profile_work');
+
+    expect(() => store.remove('profile_personal', created.id)).toThrowError(expect.objectContaining({
+      code: 'SESSION_NOT_FOUND',
+      ownerProfileId: 'profile_work',
+    }));
+  });
+
+  it('keeps the generic hint when no profile owns the session', () => {
+    const store = new LocalBrowserSessionStore({ baseDir: tempDir() });
+
+    expect(() => store.require('profile_work', 'session_missing')).toThrowError(expect.objectContaining({
+      code: 'SESSION_NOT_FOUND',
+      ownerProfileId: undefined,
+      message: 'Session not found: session_missing',
+      hint: 'Run `webcmd --profile profile_work session list` to choose an existing Session, then `webcmd session close <session-id>`. If it belongs to another Profile, pass `--profile <name>`.',
+    }));
+  });
+
   it('resolves one lazy adapter-default per profile without list side effects', () => {
     const store = new LocalBrowserSessionStore({
       baseDir: tempDir(),

--- a/src/browser/sessions.ts
+++ b/src/browser/sessions.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { CONFIG_DIR_NAME, ENV_PREFIX } from '../brand.js';
+import { CLI_COMMAND, CONFIG_DIR_NAME, ENV_PREFIX } from '../brand.js';
 import { CliError, ConfigError, EXIT_CODES } from '../errors.js';
 
 export interface BrowserSessionRecord {
@@ -30,13 +30,24 @@ type StateFile = { version: 1; sessions: BrowserSessionRecord[] };
 const SESSION_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 
 export class SessionNotFoundError extends CliError {
-  constructor(sessionId: string, profileId: string) {
+  /** Profile that actually owns the Session, when the ID exists under a different one. */
+  readonly ownerProfileId?: string;
+
+  constructor(sessionId: string, profileId: string, ownerProfileId?: string) {
+    // A Session ID is only ever looked up inside the selected Profile, so a
+    // caller that omits `--profile` sees "not found" for a Session that does
+    // exist. Naming the owner turns a dead end into a one-step retry.
     super(
       'SESSION_NOT_FOUND',
-      `Session not found: ${sessionId}`,
-      `Run \`webcmd --profile ${profileId} session list\` to choose an existing Session, then \`webcmd session close <session-id>\`. If it belongs to another Profile, pass \`--profile <name>\`.`,
+      ownerProfileId
+        ? `Session not found in Profile ${profileId}: ${sessionId}`
+        : `Session not found: ${sessionId}`,
+      ownerProfileId
+        ? `Session ${sessionId} belongs to Profile ${ownerProfileId}. Re-run the same command with \`--profile ${ownerProfileId}\`, for example \`${CLI_COMMAND} --profile ${ownerProfileId} session close ${sessionId}\`.`
+        : `Run \`${CLI_COMMAND} --profile ${profileId} session list\` to choose an existing Session, then \`${CLI_COMMAND} session close <session-id>\`. If it belongs to another Profile, pass \`--profile <name>\`.`,
       EXIT_CODES.EMPTY_RESULT,
     );
+    this.ownerProfileId = ownerProfileId;
   }
 }
 
@@ -84,7 +95,7 @@ export class LocalBrowserSessionStore {
     requireSessionIdShape(id);
     const state = this.load();
     const record = state.sessions.find((row) => row.id === id && row.profileId === profileId);
-    if (!record) throw new SessionNotFoundError(id, profileId);
+    if (!record) throw new SessionNotFoundError(id, profileId, findOwnerProfileId(state, id));
     this.touchRecord(state, record);
     return { ...record };
   }
@@ -176,7 +187,7 @@ export class LocalBrowserSessionStore {
   private requireMutable(state: StateFile, profileId: string, sessionId: string): BrowserSessionRecord {
     requireSessionIdShape(sessionId);
     const record = state.sessions.find((row) => row.id === sessionId && row.profileId === profileId);
-    if (!record) throw new SessionNotFoundError(sessionId, profileId);
+    if (!record) throw new SessionNotFoundError(sessionId, profileId, findOwnerProfileId(state, sessionId));
     return record;
   }
 
@@ -223,6 +234,13 @@ export class LocalBrowserSessionStore {
   private statePath(): string {
     return path.join(this.baseDir, 'browser-sessions.json');
   }
+}
+
+// Every Profile's Sessions share one state file, so the owning Profile of a
+// Session that missed the scoped lookup is already in hand — no daemon or
+// provider round trip is needed to name it.
+function findOwnerProfileId(state: StateFile, sessionId: string): string | undefined {
+  return state.sessions.find((row) => row.id === sessionId)?.profileId;
 }
 
 function validateState(value: unknown): StateFile {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -939,7 +939,10 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string, pluginsDi
         console.log(`No browser Sessions found for Profile ${profileId}.`);
         return;
       }
-      await renderOutput(output, { fmt, fmtExplicit: outputFormatIsExplicit(command), columns: ['id', 'kind', 'runtimeState', 'handoff'] });
+      // `profileId` is a column because these rows are scoped to the selected
+      // Profile. Without it the table reads as every Session on the machine,
+      // which is what led agents to act on Sessions from unrelated Profiles.
+      await renderOutput(output, { fmt, fmtExplicit: outputFormatIsExplicit(command), columns: ['id', 'profileId', 'kind', 'runtimeState', 'handoff'] });
     });
 
   const sessionCloseCmd = addOutputFormatOption(sessionCmd


### PR DESCRIPTION
Fixes #388.

## Problem

A Session ID only ever resolves inside the selected Profile, so a command that omits `--profile` reports `Session not found` for a Session that plainly exists. The eval runs in the issue show the loop this creates: the agent has a valid ID from `session create`, drops the flag on the follow-up `session close`, reads the error as "already gone", and then either retries the identical command or starts inspecting unrelated `default` Sessions.

`session list` fed the same confusion from the other side — the rows were always scoped to the selected Profile, but the table never said so, so a list of `default` Sessions read as the whole machine.

## Fix

Every Profile's Sessions live in one `browser-sessions.json` keyed by `profileId`, so when the scoped lookup misses, the owning Profile is already in hand — no daemon or provider round trip is needed to name it.

- `SessionNotFoundError` takes an optional owner. When known, the message becomes `Session not found in Profile <selected>: <id>` and the hint names the owner plus the exact retry, `webcmd --profile <owner> session close <id>`. With no owner the message and hint are byte-for-byte unchanged.
- Both throw sites are covered: `require`, and the private `requireMutable` behind `remove` / `touch` / handoff updates — so the close path cannot fall back to the anonymous message.
- The daemon provider (`local-cloak/provider.ts`) and the CLI local fallback both resolve through this same store, so one store-level change serves both paths. That also settles the issue's open question about local-only versus daemon lookup: it is local, and it is correct for both.
- `session list` gains a `profileId` table column. JSON and YAML already carried the field; `columns` only affects table/markdown/csv.
- `docs/troubleshooting.mdx` documents the new `SESSION_NOT_FOUND` behaviour.

## Acceptance criteria

- [x] Closing a Session from the wrong Profile names the owning Profile when known.
- [x] The retry hint includes `webcmd --profile <owner> session close <session-id>`.
- [x] Session list output does not look global when it is Profile-scoped.
- [x] Agents get a one-step retry instead of a dead end.

## Open questions from the issue

- **Should `session list` without `--profile` ever show all Profiles?** Left scoped, with the scope now visible in the table. Showing every Profile by default is the behaviour the issue calls a safety problem for hosted and multi-tenant use.
- **Local-only or daemon lookup?** Local. Both paths share the store, so it is already consistent.
- **Is the skill troubleshooting line still needed?** Not addressed here — the CLI error is now explicit, so that line can be revisited separately.

## Tests

Three store-level tests (owner named on `require`, owner named on the mutating path, generic hint preserved when no Profile owns the ID) and one CLI-level test that drives `session close` without `--profile` end to end.

155/155 pass across `sessions.test.ts`, `cli.test.ts`, and `session-docs-sync.test.ts`; `tsc --noEmit` is clean.

Note for reviewers on Windows: the four symlink tests in `src/site-memory/local-store.test.ts` fail on a clean `main` in my environment (symlink permissions), unrelated to this change.

## Non-goals

No `profile create` changes, no broad profile cleanup command, and no eval-specific aliases in user-facing text.
