### PR TITLE
feat(cli): add agent context bootstrap

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2056,6 +2056,56 @@ describe('structured output for data-returning built-ins', () => {
     expect(JSON.parse(stdout())).toEqual(bare);
   });
 
+  it('renders agent context as a compact machine-readable bootstrap', async () => {
+    const registry = getRegistry();
+    const snapshot = new Map(registry);
+    registry.clear();
+    try {
+      cli({
+        site: 'youtube',
+        name: 'search',
+        access: 'read',
+        description: 'Search YouTube',
+        strategy: Strategy.PUBLIC,
+        browser: false,
+      });
+
+      await createProgram('', '').parseAsync(['node', 'webcmd', 'agent-context', '--json']);
+
+      const data = JSON.parse(stdout());
+      expect(data).toMatchObject({
+        command: 'webcmd agent-context',
+        command_families: expect.arrayContaining([
+          expect.objectContaining({ name: 'adapter_commands' }),
+          expect.objectContaining({ name: 'browser_commands' }),
+        ]),
+        output_modes: {
+          formats: expect.arrayContaining(['json', 'yaml']),
+          json_alias: '--json',
+          trace_modes: expect.arrayContaining(['off', 'retain-on-failure']),
+        },
+        discovery_commands: expect.arrayContaining([
+          'webcmd list --json',
+          'webcmd <site> --help -f yaml',
+        ]),
+        common_error_recovery: expect.any(Array),
+        help_surfaces: expect.objectContaining({
+          root: 'webcmd --help -f yaml',
+          site: 'webcmd <site> --help -f yaml',
+        }),
+        adapters: expect.objectContaining({
+          site_adapters: expect.objectContaining({
+            sites: ['youtube'],
+          }),
+        }),
+      });
+      expect(data.root_commands.map((command: { name: string }) => command.name)).toContain('agent-context');
+    } finally {
+      registry.clear();
+      for (const [key, value] of snapshot) registry.set(key, value);
+    }
+  });
+
   it('renders daemon status as JSON', async () => {
     vi.mocked(fetch).mockResolvedValue(daemonStatusResponse());
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,7 @@ import { printCompletionScript } from './completion.js';
 import { loadExternalClis, executeExternalCli, installExternalCli, registerExternalCli, isBinaryInstalled, formatExternalCliLabel } from './external.js';
 import { addWebcmdSkills, listWebcmdSkills, removeWebcmdSkills, updateWebcmdSkill, type WebcmdSkillAddResult } from './skills.js';
 import { registerAllCommands } from './commanderAdapter.js';
-import { buildRootHelpPresentation, classifyAdapter, installCommanderNamespaceStructuredHelp, installRootPresentationHelp, leadingPositionalFromUsage, rootHelpData, type RootAdapterGroups } from './help.js';
+import { agentContextData, buildRootHelpPresentation, classifyAdapter, installCommanderNamespaceStructuredHelp, installRootPresentationHelp, leadingPositionalFromUsage, rootHelpData, type RootAdapterGroups } from './help.js';
 import { EXIT_CODES, getErrorMessage, toEnvelope, BrowserConnectError, CliError, ArgumentError } from './errors.js';
 import { TargetError, type TargetErrorCode } from './browser/target-errors.js';
 import { resolveTargetJs, getTextResolvedJs, getValueResolvedJs, getAttributesResolvedJs, selectResolvedJs, isAutocompleteResolvedJs, type ResolveOptions, type TargetMatchLevel } from './browser/target-resolver.js';
@@ -2184,6 +2184,19 @@ cli({
   }
   const adapterGroups: RootAdapterGroups = { external: externalHelpEntries, apps, sites };
   const adapterNameSet = new Set<string>([...externalNames, ...siteNames]);
+  const agentContextCmd = addOutputFormatOption(program
+    .command('agent-context')
+    .description('Print machine-readable WebCMD bootstrap context'), 'json');
+  agentContextCmd.action(async (opts) => {
+    const fmt = resolveCommandOutputFormat(agentContextCmd, opts.format);
+    if (fmt === null) return;
+    await renderOutput(agentContextData(program, adapterGroups), {
+      fmt,
+      fmtExplicit: outputFormatIsExplicit(agentContextCmd),
+      title: 'webcmd/agent-context',
+      source: 'webcmd agent-context',
+    });
+  });
   installCommanderNamespaceStructuredHelp(browser, { globalCommand: program, description: originalBrowserDescription });
   installCommanderNamespaceStructuredHelp(authCmd, { globalCommand: program, description: 'Inspect website login status' });
   installCommanderNamespaceStructuredHelp(daemonCmd, { globalCommand: program, description: originalDaemonDescription });

--- a/src/help.ts
+++ b/src/help.ts
@@ -2,6 +2,7 @@ import { Command, type Argument as CommanderArgument, type Option as CommanderOp
 import yaml from 'js-yaml';
 import type { CliCommand } from './registry.js';
 import { CLI_COMMAND } from './brand.js';
+import { OUTPUT_FORMATS, TRACE_MODES } from './command-surface.js';
 import {
   classifyAdapterDomain,
   commandHelpData as buildCommandHelpData,
@@ -439,6 +440,71 @@ export function rootHelpData(program: Command, groups: RootAdapterGroups): Recor
       `${CLI_COMMAND} list -f yaml`,
       `${CLI_COMMAND} <site> <command> -f yaml`,
     ],
+  };
+}
+
+export function agentContextData(program: Command, groups: RootAdapterGroups): Record<string, unknown> {
+  const root = rootHelpData(program, groups);
+  return {
+    command: `${CLI_COMMAND} agent-context`,
+    description: 'Machine-readable bootstrap for agents using WebCMD.',
+    command_families: [
+      {
+        name: 'adapter_commands',
+        purpose: 'Run website, app, and plugin commands.',
+        discover: `${CLI_COMMAND} list --json`,
+        inspect: `${CLI_COMMAND} <site> --help -f yaml`,
+        run: `${CLI_COMMAND} <site> <command> [args] [options]`,
+      },
+      {
+        name: 'browser_commands',
+        purpose: 'Use an existing browser session or run browser automation.',
+        discover: `${CLI_COMMAND} browser --help -f yaml`,
+        inspect: `${CLI_COMMAND} browser <command> --help -f yaml`,
+      },
+      {
+        name: 'plugin_commands',
+        purpose: 'Find, install, list, update, and inspect plugins.',
+        discover: `${CLI_COMMAND} plugin --help -f yaml`,
+        search: `${CLI_COMMAND} plugin search <query> --json`,
+      },
+      {
+        name: 'local_management',
+        purpose: 'Inspect health, sessions, profiles, skills, adapters, and daemon state.',
+        discover: `${CLI_COMMAND} --help -f yaml`,
+      },
+    ],
+    output_modes: {
+      formats: [...OUTPUT_FORMATS],
+      json_alias: '--json',
+      trace_modes: [...TRACE_MODES],
+    },
+    discovery_commands: [
+      `${CLI_COMMAND} list --json`,
+      `${CLI_COMMAND} <site> --help -f yaml`,
+      `${CLI_COMMAND} <site> <command> --help -f yaml`,
+      `${CLI_COMMAND} browser --help -f yaml`,
+      `${CLI_COMMAND} plugin search <query> --json`,
+    ],
+    common_error_recovery: [
+      `Unknown site or command: run ${CLI_COMMAND} list --json or ${CLI_COMMAND} plugin search <name> --json.`,
+      `Wrong flags or arguments: run ${CLI_COMMAND} <site> <command> --help -f yaml.`,
+      `Browser/session problem: run ${CLI_COMMAND} doctor --json, ${CLI_COMMAND} session list --json, or ${CLI_COMMAND} browser --help -f yaml.`,
+      'Adapter returned empty or selector errors: retry with --trace retain-on-failure and inspect the adapter path from the error help.',
+    ],
+    help_surfaces: {
+      root: `${CLI_COMMAND} --help -f yaml`,
+      site: `${CLI_COMMAND} <site> --help -f yaml`,
+      command: `${CLI_COMMAND} <site> <command> --help -f yaml`,
+      browser: `${CLI_COMMAND} browser --help -f yaml`,
+      plugin: `${CLI_COMMAND} plugin --help -f yaml`,
+    },
+    root_commands: root.commands,
+    adapters: {
+      external_clis: root.external_clis,
+      app_adapters: root.app_adapters,
+      site_adapters: root.site_adapters,
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- add `webcmd agent-context` as a compact machine-readable bootstrap entrypoint
- reuse root help data plus shared output/trace mode constants
- cover `webcmd agent-context --json` with a focused CLI test

## Verification
- `npx vitest run src/cli.test.ts -t "agent context"` — passed (1 test)
- `npm test -- src/cli.test.ts src/help.test.ts` — passed (152 tests)
- `npm run typecheck` — passed
- `npm run build` — passed
- `npm run check:hosted-contract` — passed; generated `cli-manifest.json` and `hosted-contract.json` match committed bytes

## Hosted impact
Hosted impact: A — no hosted impact
Trigger: none
Cloud files: none
Why: diff is limited to local CLI/help/test surfaces (`src/cli.ts`, `src/help.ts`, `src/cli.test.ts`); package exports and hosted contract bytes are unchanged.
Sequencing: no cloud PR required.