### PR TITLE
fix(cli): clarify adapter authoring help

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -151,6 +151,18 @@ describe('plugin update reconciliation reporting', () => {
 });
 
 describe('site-memory and local adapter authoring', () => {
+  it('keeps adapter help pointed at create vs override commands', () => {
+    const program = createProgram('', '');
+    const browserInit = program.commands.find(cmd => cmd.name() === 'browser')!
+      .commands.find(cmd => cmd.name() === 'init')!;
+    const adapter = program.commands.find(cmd => cmd.name() === 'adapter')!;
+
+    expect(browserInit.helpInformation()).toContain('Create a new private adapter: webcmd browser init <site>/<command>');
+    const adapterHelp = adapter.helpInformation();
+    expect(adapterHelp).toMatch(/Override installed command: webcmd adapter override\s+<site>\/<command>/);
+    expect(adapterHelp).toMatch(/Locate local source: webcmd adapter path\s+<site>\/<command>/);
+  });
+
   it('writes site-memory reads only when --output is requested', async () => {
     const output = path.join(isolatedCliTestHome, 'memory.json');
     const program = createProgram('', '');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -957,7 +957,11 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string, pluginsDi
 
   browser.command('init')
     .argument('<name>', 'Adapter name in site/command format (e.g. hn/top)')
-    .description('Generate adapter scaffold in ~/.webcmd/clis/')
+    .description(`Generate adapter scaffold in ~/.webcmd/clis/
+
+Create a new private adapter: ${CLI_COMMAND} browser init <site>/<command>
+Override an installed command: ${CLI_COMMAND} adapter override <site>/<command>
+Test either local adapter: ${CLI_COMMAND} browser verify <site>/<command>`)
     .action(async (name: string) => {
       try {
         const parts = name.split('/');
@@ -1739,7 +1743,8 @@ cli({
     });
 
   // ── Built-in: adapter management ─────────────────────────────────────────
-  const adapterCmd = program.command('adapter').description('Manage CLI adapters');
+  const adapterCmd = program.command('adapter')
+    .description('Manage CLI adapters');
   // Snapshot before applyRootSubcommandSummaries() rewrites .description() to a child-name listing.
   const originalAdapterDescription = adapterCmd.description();
 
@@ -1876,7 +1881,7 @@ cli({
 
   adapterCmd
     .command('override')
-    .description('Fork an installed plugin command into ~/.webcmd/clis so you can modify it')
+    .description(`Override installed command: ${CLI_COMMAND} adapter override <site>/<command>`)
     .argument('<command>', 'Command to override, as <site>/<command>')
     .action(handleAdapterOverride);
 
@@ -1906,6 +1911,7 @@ cli({
     throw new ArgumentError(`Local adapter source put is unavailable. Use webcmd adapter path ${commandKey} and edit that file.`);
   });
   adapterCmd.command('path')
+    .description(`Locate local source: ${CLI_COMMAND} adapter path <site>/<command>`)
     .argument('<command>', 'site/command, or site when followed by the command name')
     .argument('[name]', 'command name when passed as a second token')
     .action((commandKey: string, commandName?: string) => reportLocalAdapterPath(commandKey, commandName));

--- a/src/plugin-scaffold.test.ts
+++ b/src/plugin-scaffold.test.ts
@@ -86,6 +86,8 @@ describe('createPluginScaffold', () => {
     expect(readme).toContain(`webcmd plugin install file://${dir}`);
     expect(readme).toContain('webcmd plugin search test-readme -f json');
     expect(readme).toContain('webcmd plugin install <installSource-from-search>');
+    expect(readme).toContain('Use `webcmd browser init <site>/<command>` for private local adapter iteration.');
+    expect(readme).toContain('Use `webcmd adapter override <site>/<command>` to patch an installed command.');
   });
 
   it('rejects invalid names', () => {

--- a/src/plugin-scaffold.ts
+++ b/src/plugin-scaffold.ts
@@ -155,6 +155,10 @@ webcmd plugin install <installSource-from-search>
 
 ## Development
 
+Use \`webcmd browser init <site>/<command>\` for private local adapter iteration.
+Use \`webcmd adapter override <site>/<command>\` to patch an installed command.
+Use this plugin scaffold when you are ready to publish or raise a PR.
+
 \`\`\`bash
 # Install locally for development (symlinked, changes reflect immediately)
 webcmd plugin install file://${targetDir}

--- a/src/site-memory/commands.test.ts
+++ b/src/site-memory/commands.test.ts
@@ -27,6 +27,14 @@ function program(store: SiteMemoryBackend, io?: { readStdin?: () => Promise<stri
 }
 
 describe('site memory format flags', () => {
+  it('documents concise authoring commands in site-memory help', () => {
+    const help = program(backend()).commands.find(command => command.name() === 'site')!.helpInformation();
+
+    expect(help).toContain('webcmd site note add <site> --text');
+    expect(help).toContain('webcmd site endpoint set <site> <name> --url');
+    expect(help).toContain('webcmd site fixture put <site/command>');
+  });
+
   it('accepts -f json on site fixture get', async () => {
     const store = backend();
     await program(store).parseAsync(['site', 'fixture', 'get', 'quotes-toscrape/list', '-f', 'json'], { from: 'user' });

--- a/src/site-memory/commands.ts
+++ b/src/site-memory/commands.ts
@@ -49,7 +49,14 @@ export function registerSiteCommands(
   stdout?: NodeJS.WritableStream,
   io: SiteCommandIo = {},
 ): void {
-  const site = root.command('site').description('Read and write site memory');
+  const site = root.command('site')
+    .description(`Read and write site memory
+
+Authoring:
+  webcmd site note add <site> --text <markdown>
+  webcmd site endpoint set <site> <name> --url <url> --method GET
+  webcmd site fixture put <site/command> <path>
+  webcmd site sample add <site/command> <path>`);
   const memory = site.command('memory').description('Inspect site memory');
   const show = addOutputFormatOption(memory.command('show').argument('<site>').option('--kind <kind>').option('-o, --output <path>'), 'json');
   show.action(async (name, opts: { kind?: string; output?: string; format?: string }) => {


### PR DESCRIPTION
## Summary

- Clarify `webcmd browser init`, `webcmd adapter override`, and `webcmd adapter path` help so agents can choose new private adapters vs installed-command overrides.
- Add concise site-memory authoring commands to existing help.
- Update plugin scaffold README guidance to keep private iteration separate from publishable plugin scaffolds.

## Verification

- `npx vitest run src/site-memory/commands.test.ts src/plugin-scaffold.test.ts src/cli.test.ts` — 3 files, 157 tests passed.
- `npm run typecheck` — passed.
- `npm run build` — passed.
- `npm run check:hosted-contract` — passed; generated `cli-manifest.json` and `hosted-contract.json` match committed bytes.

## Hosted impact

Hosted impact: B — rides the pin bump
Trigger: none
Cloud files: none
Why: CLI help/guidance changes live in the WebCMD package; `check:hosted-contract` shows no hosted contract/schema drift, and no cloud-owned route/body/storage shape changes. Hosted behavior reaches Cloud at the next `npm run bump:webcmd`.
Sequencing: no webcmd-cloud PR required.
