### PR TITLE
fix(cli): add recovery hints for common misguesses

### DIFF
--- a/src/browser/sessions.ts
+++ b/src/browser/sessions.ts
@@ -34,7 +34,7 @@ export class SessionNotFoundError extends CliError {
     super(
       'SESSION_NOT_FOUND',
       `Session not found: ${sessionId}`,
-      `Run \`webcmd --profile ${profileId} session list\` to choose an existing Session.`,
+      `Run \`webcmd --profile ${profileId} session list\` to choose an existing Session, then \`webcmd session close <session-id>\`. If it belongs to another Profile, pass \`--profile <name>\`.`,
       EXIT_CODES.EMPTY_RESULT,
     );
   }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -664,6 +664,27 @@ describe('createProgram root help descriptions', () => {
     }
   });
 
+  it('suggests canonical discovery commands for unambiguous root noun mistakes', async () => {
+    const stderr = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const previousExitCode = process.exitCode;
+    const program = createProgram('', '');
+    program.outputHelp = vi.fn();
+
+    try {
+      await program.parseAsync(['catalog'], { from: 'user' });
+
+      expect(stderr.mock.calls.map(([line]) => line).join('\n')).toContain([
+        'Unknown command "catalog".',
+        'Did you mean: webcmd plugin catalog list',
+      ].join('\n'));
+      expect(program.outputHelp).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(2);
+    } finally {
+      process.exitCode = previousExitCode;
+      stderr.mockRestore();
+    }
+  });
+
   it('keeps site adapters out of root commands and lists sites in the root help tail', () => {
     const registry = getRegistry();
     const snapshot = new Map(registry);
@@ -2447,6 +2468,16 @@ describe('browser Session lifecycle commands', () => {
       alreadyIdle: true,
       session: 'session_idle',
     });
+  });
+
+  it('uses positional close syntax and profile guidance when a Session is missing', async () => {
+    mockSendCommand.mockRejectedValueOnce(new Error('daemon unavailable'));
+
+    await expect(createProgram('', '').parseAsync(['node', 'webcmd', 'session', 'close', 'session_missing']))
+      .rejects.toMatchObject({
+        code: 'SESSION_NOT_FOUND',
+        hint: expect.stringContaining('webcmd session close <session-id>'),
+      });
   });
 
   it.each([

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -83,6 +83,22 @@ function parseSessionListLimit(value: string): number {
   return parsed;
 }
 
+function rootCommandSuggestion(name: string): string | undefined {
+  const canonical: Record<string, string> = {
+    catalog: `${CLI_COMMAND} plugin catalog list`,
+    catalogs: `${CLI_COMMAND} plugin catalog list`,
+    command: `${CLI_COMMAND} list`,
+    commands: `${CLI_COMMAND} list`,
+    cmds: `${CLI_COMMAND} list`,
+    ls: `${CLI_COMMAND} list`,
+    marketplace: `${CLI_COMMAND} plugin search <query>`,
+    plugins: `${CLI_COMMAND} plugin list`,
+    pluginlist: `${CLI_COMMAND} plugin list`,
+    search: `${CLI_COMMAND} plugin search <query>`,
+  };
+  return canonical[name.toLowerCase()];
+}
+
 type BrowserNetworkItem = {
   url: string;
   method: string;
@@ -2205,6 +2221,12 @@ cli({
 
   program.on('command:*', (operands: string[]) => {
     const binary = operands[0]!;
+    const suggestion = rootCommandSuggestion(binary);
+    if (suggestion) {
+      console.error(`Unknown command "${binary}".\nDid you mean: ${suggestion}`);
+      process.exitCode = EXIT_CODES.USAGE_ERROR;
+      return;
+    }
     console.error(missingPluginGuidance(binary));
     program.outputHelp();
     process.exitCode = EXIT_CODES.USAGE_ERROR;

--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -9,6 +9,7 @@ import {
   onAfterExecute,
   emitHook,
   clearAllHooks,
+  shouldRunStartupSideEffects,
   type HookContext,
 } from './hooks.js';
 
@@ -104,6 +105,16 @@ describe('no-op when no hooks registered', () => {
     await emitHook('onBeforeExecute', { command: 'test/cmd', args: {} });
     await emitHook('onAfterExecute', { command: 'test/cmd', args: {} }, []);
     await emitHook('onStartup', { command: '__startup__', args: {} });
+  });
+});
+
+describe('startup hook gating', () => {
+  it.each([
+    ['--help'],
+    ['list', '--format', 'json'],
+    ['list', '--json'],
+  ])('skips startup side effects for help or requested data output: %j', (...argv) => {
+    expect(shouldRunStartupSideEffects(argv)).toBe(false);
   });
 });
 

--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -112,6 +112,7 @@ describe('no-op when no hooks registered', () => {
 describe('startup hook gating', () => {
   it.each([
     ['--help'],
+    ['agent-context', '--json'],
     ['list', '--format', 'json'],
     ['list', '--json'],
   ])('skips startup side effects for help or requested data output: %j', (...argv) => {

--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -9,6 +9,7 @@ import {
   onAfterExecute,
   emitHook,
   clearAllHooks,
+  shouldEmitStartupHook,
   shouldRunStartupSideEffects,
   type HookContext,
 } from './hooks.js';
@@ -115,6 +116,25 @@ describe('startup hook gating', () => {
     ['list', '--json'],
   ])('skips startup side effects for help or requested data output: %j', (...argv) => {
     expect(shouldRunStartupSideEffects(argv)).toBe(false);
+  });
+
+  it('keeps startup side effects for completion discovery', () => {
+    expect(shouldRunStartupSideEffects(['--get-completions', '--cursor', '1'])).toBe(true);
+  });
+
+  it.each([
+    ['demo', 'state', '--json'],
+    ['demo', 'state', '-f', 'json'],
+  ])('keeps startup side effects for real plugin command execution: %j', (...argv) => {
+    expect(shouldRunStartupSideEffects(argv)).toBe(true);
+    expect(shouldEmitStartupHook(argv)).toBe(true);
+  });
+
+  it.each([
+    ['--help'],
+    ['--get-completions'],
+  ])('skips startup hooks for terminal help/completion paths: %j', (...argv) => {
+    expect(shouldEmitStartupHook(argv)).toBe(false);
   });
 });
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -83,14 +83,69 @@ export async function emitHook(name: HookName, ctx: HookContext, result?: unknow
   }
 }
 
+const BUILTIN_COMMANDS = new Set([
+  'adapter',
+  'auth',
+  'browser',
+  'completion',
+  'convention-audit',
+  'daemon',
+  'doctor',
+  'external',
+  'list',
+  'plugin',
+  'profile',
+  'session',
+  'skills',
+  'update',
+  'validate',
+  'verify',
+  'web',
+]);
+
 export function shouldRunStartupSideEffects(argv: readonly string[]): boolean {
+  if (isHelp(argv)) return false;
+  return !(hasExplicitOutputFormat(argv) && BUILTIN_COMMANDS.has(rootCommand(argv) ?? ''));
+}
+
+export function shouldEmitStartupHook(argv: readonly string[]): boolean {
+  return !isHelp(argv) && !isCompletion(argv);
+}
+
+function isHelp(argv: readonly string[]): boolean {
+  for (const token of argv) {
+    if (token === '--') return false;
+    if (token === '--help' || token === '-h') return true;
+  }
+  return false;
+}
+
+function isCompletion(argv: readonly string[]): boolean {
+  return argv.includes('--get-completions');
+}
+
+function hasExplicitOutputFormat(argv: readonly string[]): boolean {
   for (let i = 0; i < argv.length; i += 1) {
     const token = argv[i]!;
-    if (token === '--') return true;
-    if (token === '--help' || token === '-h' || token === '--json') return false;
-    if (token === '-f' || token === '--format' || /^-f.+/.test(token) || token.startsWith('--format=')) return false;
+    if (token === '--') return false;
+    if (token === '--json') return true;
+    if (token === '-f' || token === '--format' || /^-f.+/.test(token) || token.startsWith('--format=')) return true;
   }
-  return true;
+  return false;
+}
+
+function rootCommand(argv: readonly string[]): string | undefined {
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i]!;
+    if (token === '--') return argv[i + 1];
+    if (token === '--profile' || token === '--session' || token === '--workspace') {
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--profile=') || token.startsWith('--session=') || token.startsWith('--workspace=')) continue;
+    if (!token.startsWith('-') || token === '-') return token;
+  }
+  return undefined;
 }
 
 /**

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -83,6 +83,16 @@ export async function emitHook(name: HookName, ctx: HookContext, result?: unknow
   }
 }
 
+export function shouldRunStartupSideEffects(argv: readonly string[]): boolean {
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i]!;
+    if (token === '--') return true;
+    if (token === '--help' || token === '-h' || token === '--json') return false;
+    if (token === '-f' || token === '--format' || /^-f.+/.test(token) || token.startsWith('--format=')) return false;
+  }
+  return true;
+}
+
 /**
  * Remove all registered hooks. Intended for testing only.
  */

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -84,6 +84,7 @@ export async function emitHook(name: HookName, ctx: HookContext, result?: unknow
 }
 
 const BUILTIN_COMMANDS = new Set([
+  'agent-context',
   'adapter',
   'auth',
   'browser',

--- a/src/hosted/main-lifecycle.test.ts
+++ b/src/hosted/main-lifecycle.test.ts
@@ -216,6 +216,19 @@ describe('hosted CLI process lifecycle', () => {
     expect(fixture.requests).toEqual([]);
     await expect(readFile(fixture.discoverySentinel, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
   }, 20_000);
+
+  it.each([
+    { name: 'json alias', formatArgs: ['--json'] },
+    { name: 'format option', formatArgs: ['-f', 'json'] },
+  ])('fires plugin onStartup before local command execution with $name', async ({ formatArgs }) => {
+    const fixture = await createLocalStartupPluginFixture();
+
+    const result = await runCli(['startup', 'state', ...formatArgs], fixture.env);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(JSON.parse(result.stdout)).toEqual({ value: 'ready' });
+  }, 20_000);
 });
 
 async function createHostedFixture(outcome: 'success' | 'failure' | 'browser'): Promise<{
@@ -342,6 +355,44 @@ async function createHostedFixture(outcome: 'success' | 'failure' | 'browser'): 
     requests,
     runStarted,
     releaseRun,
+    env: {
+      ...process.env,
+      HOME: root,
+      USERPROFILE: root,
+      WEBCMD_CONFIG_DIR: configDir,
+      WEBCMD_NO_UPDATE_CHECK: '1',
+    },
+  };
+}
+
+async function createLocalStartupPluginFixture(): Promise<{ root: string; env: NodeJS.ProcessEnv }> {
+  const root = await mkdtemp(path.join(tmpdir(), 'webcmd-local-startup-'));
+  tempRoots.push(root);
+  const configDir = path.join(root, 'config');
+  const pluginDir = path.join(root, '.webcmd', 'plugins', 'startup');
+  await mkdir(configDir, { recursive: true });
+  await mkdir(pluginDir, { recursive: true });
+  await writeFile(path.join(configDir, 'config.json'), '{"mode":"local"}\n');
+  await writeFile(path.join(pluginDir, 'state.js'), [
+    "import { cli, onStartup, Strategy } from '@agentrhq/webcmd/registry';",
+    "let value = 'cold';",
+    "onStartup(() => { value = 'ready'; });",
+    'cli({',
+    "  site: 'startup',",
+    "  name: 'state',",
+    "  description: 'Show startup hook state',",
+    "  access: 'read',",
+    '  strategy: Strategy.PUBLIC,',
+    '  browser: false,',
+    '  args: [],',
+    "  columns: ['value'],",
+    '  func: async () => ({ value }),',
+    '});',
+    '',
+  ].join('\n'));
+
+  return {
+    root,
     env: {
       ...process.env,
       HOME: root,

--- a/src/main.ts
+++ b/src/main.ts
@@ -145,7 +145,7 @@ if (getCompIdx !== -1) {
 const { discoverClis, discoverPlugins, ensureUserCliCompatShims, ensureUserAdapters, PLUGINS_DIR } = await import('./discovery.js');
 const { getCompletions } = await import('./completion.js');
 const { runCli } = await import('./cli.js');
-const { emitHook, shouldRunStartupSideEffects } = await import('./hooks.js');
+const { emitHook, shouldEmitStartupHook, shouldRunStartupSideEffects } = await import('./hooks.js');
 const { installNodeNetwork } = await import('./node-network.js');
 const { registerUpdateNoticeOnExit, checkForUpdateBackground } = await import('./update-check.js');
 
@@ -213,7 +213,7 @@ try {
   throw err;
 }
 
-if (runStartupSideEffects) {
+if (shouldEmitStartupHook(argv)) {
   await emitHook('onStartup', { command: '__startup__', args: {} });
 }
 await runCli(BUILTIN_CLIS, USER_CLIS);

--- a/src/main.ts
+++ b/src/main.ts
@@ -145,7 +145,7 @@ if (getCompIdx !== -1) {
 const { discoverClis, discoverPlugins, ensureUserCliCompatShims, ensureUserAdapters, PLUGINS_DIR } = await import('./discovery.js');
 const { getCompletions } = await import('./completion.js');
 const { runCli } = await import('./cli.js');
-const { emitHook } = await import('./hooks.js');
+const { emitHook, shouldRunStartupSideEffects } = await import('./hooks.js');
 const { installNodeNetwork } = await import('./node-network.js');
 const { registerUpdateNoticeOnExit, checkForUpdateBackground } = await import('./update-check.js');
 
@@ -158,22 +158,25 @@ installNodeNetwork();
 //    overrides, and registerCommand is last-write-wins, so loading it after
 //    plugins is what makes an override actually take effect.
 const skipUserDiscovery = argv[0] === 'convention-audit';
+const runStartupSideEffects = shouldRunStartupSideEffects(argv);
 if (skipUserDiscovery) {
   await discoverClis(BUILTIN_CLIS);
 } else {
   const [, ,] = await Promise.all([
-    ensureUserCliCompatShims(),
-    ensureUserAdapters(),
+    runStartupSideEffects ? ensureUserCliCompatShims() : Promise.resolve(),
+    runStartupSideEffects ? ensureUserAdapters() : Promise.resolve(),
     discoverClis(BUILTIN_CLIS),
   ]);
   await discoverPlugins(PLUGINS_DIR);
   await discoverClis(USER_CLIS);
 }
 
-// Register exit hook: notice appears after command output (same as npm/gh/yarn)
-registerUpdateNoticeOnExit();
-// Kick off background fetch for next run (non-blocking)
-checkForUpdateBackground();
+if (runStartupSideEffects) {
+  // Register exit hook: notice appears after command output (same as npm/gh/yarn)
+  registerUpdateNoticeOnExit();
+  // Kick off background fetch for next run (non-blocking)
+  checkForUpdateBackground();
+}
 
 // ── Fallback completion: manifest unavailable, use full registry ─────────
 if (getCompIdx !== -1) {
@@ -210,6 +213,8 @@ try {
   throw err;
 }
 
-await emitHook('onStartup', { command: '__startup__', args: {} });
+if (runStartupSideEffects) {
+  await emitHook('onStartup', { command: '__startup__', args: {} });
+}
 await runCli(BUILTIN_CLIS, USER_CLIS);
 }


### PR DESCRIPTION
## Description

Improve generic CLI recovery for common agent mistakes:

- Suggest canonical discovery commands for unambiguous unknown root nouns like `catalog`.
- Make missing Session close guidance prefer `webcmd session close <session-id>` and mention Profile selection.
- Suppress startup maintenance/update/shim warning noise for help or explicit machine-readable built-in output without skipping plugin `onStartup` for real command execution.

Related issue: Task 1 from `docs/superpowers/plans/2026-08-21-webcmd-cli-ergonomics-prs.md`

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful
- [x] If I edited `skill-src/`, I ran `make build` and committed `skills/`

### Adapter Notes

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Checks run:

- `npm ci` — pass; installed pinned deps. Reported 1 existing high-severity audit finding.
- `npx vitest run --project unit src/cli.test.ts src/hooks.test.ts src/hosted/main-lifecycle.test.ts src/completion.test.ts` — pass, 174 passed.
- `npm run typecheck` — pass.
- `npm run build` — pass; generated manifests matched committed bytes later. Node emitted existing `module.register()` deprecation warning during plugin manifest generation.
- `npm run check:hosted-contract` — pass.
- `npm test` — pass, 447 files, 5,843 passed, 1 skipped.
- `node dist/src/main.js catalog` — exits 2 with `Did you mean: webcmd plugin catalog list`.
- `node dist/src/main.js --help` — exits 0, stderr 0 bytes.
- `node dist/src/main.js list -f json` — exits 0, stdout starts with `[`, stderr 0 bytes.

Hosted impact: A — no hosted impact
Trigger: none
Cloud files: none
Why: local CLI ergonomics only; the diff touches local entrypoint/startup side-effect gating, root unknown-command hints, local Session-store hint text, and tests. `hosted-contract.json` is unchanged and no Cloud-consumed export, HTTP contract, browser command surface, or shared output/error serialization semantics changed.
Sequencing: no cloud PR required.