### PR TITLE
Fix Cloak E2E profile setup

### DIFF
--- a/tests/e2e/cloak-runtime.test.ts
+++ b/tests/e2e/cloak-runtime.test.ts
@@ -34,7 +34,7 @@ function browserRun(session: string, source: string, options: Parameters<typeof 
 
 async function createSession(options: Parameters<typeof runCli>[1] = {}) {
   const result = await runCli(['session', 'create', '-f', 'json'], isolatedOptions(options));
-  expect(result.code).toBe(0);
+  expect(result.code, `${result.stdout}\n${result.stderr}`).toBe(0);
   return JSON.parse(result.stdout).id as string;
 }
 
@@ -42,6 +42,8 @@ beforeAll(async () => {
   sharedConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-cloak-suite-'));
   sharedProfile = `cloak-suite-${Date.now()}`;
   sourceDirs.push(sharedConfigDir);
+  const created = await runCli(['profile', 'create', sharedProfile], isolatedOptions({ timeout: 120_000 }));
+  expect(created.code, `${created.stdout}\n${created.stderr}`).toBe(0);
   server = http.createServer((req, res) => {
     if (req.url === '/cookie') {
       res.setHeader('Set-Cookie', 'webcmd_smoke=ok; Path=/');
@@ -111,6 +113,7 @@ describe('Cloak runtime e2e', () => {
         WEBCMD_PROFILE: profile,
       },
     });
+    expect((await run(['profile', 'create', profile])).code).toBe(0);
     const waitForStoppedDaemon = async () => {
       let status = await run(['daemon', 'status']);
       for (let attempt = 0; attempt < 20 && !status.stdout.includes('Daemon: not running'); attempt += 1) {


### PR DESCRIPTION
## Description

Creates the temporary Cloak profiles used by `tests/e2e/cloak-runtime.test.ts` before calling `session create`. Latest `main` now rejects unknown `WEBCMD_PROFILE` values with `PROFILE_NOT_FOUND`, so the E2E setup needs to create its isolated profiles explicitly.

Related issue: none

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New site adapter
- [ ] Documentation
- [ ] Refactor
- [x] CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful
- [x] If I edited `skill-src/`, I ran `make build` and committed `skills/` (not applicable)

### Adapter Notes

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```
PATH=/Users/ankitranjan/.nvm/versions/node/v22.17.0/bin:$PATH WEBCMD_E2E=0 npx vitest run --project e2e-fixed-port --project e2e tests/e2e/browser-tabs.test.ts tests/e2e/cloak-runtime.test.ts --reporter=verbose
Test Files  2 passed (2)
Tests  4 passed (4)

PATH=/Users/ankitranjan/.nvm/versions/node/v22.17.0/bin:$PATH npm run typecheck
exit 0

PATH=/Users/ankitranjan/.nvm/versions/node/v22.17.0/bin:$PATH npm test
Test Files  448 passed (448)
Tests  5855 passed | 1 skipped (5856)

PATH=/Users/ankitranjan/.nvm/versions/node/v22.17.0/bin:$PATH npm run build
exit 0

git diff --check
exit 0
```