### PR TITLE
feat(fetch): add --raw to web fetch for selector discovery

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -4,6 +4,7 @@
     "name": "fetch",
     "description": "Fetch a URL with local HTTP clients. Use after a blocked, 403, or Cloudflare response; never opens a browser.",
     "access": "read",
+    "example": "webcmd web fetch --url https://example.com --raw -f json",
     "strategy": "public",
     "browser": false,
     "args": [
@@ -33,6 +34,13 @@
         "default": false,
         "required": false,
         "help": "Allow private and loopback destinations"
+      },
+      {
+        "name": "raw",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Return the raw HTML response body instead of extracted article text; use this for CSS selector discovery, meta tags, and inline script payloads"
       }
     ],
     "defaultFormat": "md",

--- a/src/fetch/client.test.ts
+++ b/src/fetch/client.test.ts
@@ -5,6 +5,33 @@ import { webFetch } from './client.js';
 function response(body: string, status = 200, headers: Record<string, string> = { 'content-type': 'text/plain' }) { return new Response(body, { status, headers }); }
 const safeProxy = (close = vi.fn().mockResolvedValue(undefined), policyError: () => Error | undefined = () => undefined) => ({ url: 'http://proxy', close, policyError });
 describe('webFetch', () => {
+  const html = '<html><head><title>T</title></head><body><article><p>Article body that readability keeps.</p></article><script>var a=1;</script></body></html>';
+  it('returns the unprocessed body with metadata when raw is set', async () => {
+    const plainFetch = vi.fn().mockResolvedValue(response(html, 200, { 'content-type': 'text/html; charset=utf-8' }));
+    const result = await webFetch({ url: 'https://example.com', timeoutSeconds: 5, maxChars: 0, allowPrivate: false, raw: true }, { plainFetch, createImpit: vi.fn(), createSafeProxy: async () => safeProxy() });
+    expect(result).toMatchObject({ status: 200, finalUrl: 'https://example.com', contentType: 'text/html; charset=utf-8', extractionSource: 'raw', truncated: false, bytes: Buffer.byteLength(html) });
+    expect(result.content).toBe(html);
+  });
+  it('extracts and omits raw metadata without the raw flag', async () => {
+    const plainFetch = vi.fn().mockResolvedValue(response(html, 200, { 'content-type': 'text/html; charset=utf-8' }));
+    const result = await webFetch({ url: 'https://example.com', timeoutSeconds: 5, maxChars: 0, allowPrivate: false }, { plainFetch, createImpit: vi.fn(), createSafeProxy: async () => safeProxy() });
+    expect(result.content).not.toContain('<script>');
+    expect(result.content).toContain('Article body');
+    expect(result.bytes).toBeUndefined();
+  });
+  it('reports raw truncation instead of cutting silently', async () => {
+    const plainFetch = vi.fn().mockResolvedValue(response(html, 200, { 'content-type': 'text/html' }));
+    const result = await webFetch({ url: 'https://example.com', timeoutSeconds: 5, maxChars: 20, allowPrivate: false, raw: true }, { plainFetch, createImpit: vi.fn(), createSafeProxy: async () => safeProxy() });
+    expect(result.truncated).toBe(true);
+    expect(result.content).toBe(`${html.slice(0, 20)}\n\n[webcmd: truncated at 20 characters; rerun with --max-chars 0]`);
+  });
+  it('still blocks a challenge response when raw is set', async () => {
+    await expect(webFetch({ url: 'https://example.com', timeoutSeconds: 5, maxChars: 0, allowPrivate: false, raw: true }, {
+      plainFetch: vi.fn().mockImplementation(async () => response('challenge', 403, { server: 'cloudflare', 'content-type': 'text/html' })),
+      createImpit: vi.fn(() => ({ fetch: vi.fn().mockImplementation(async () => response('challenge', 403, { server: 'cloudflare', 'content-type': 'text/html' })) })),
+      createSafeProxy: async () => safeProxy(),
+    })).rejects.toMatchObject({ code: 'FETCH_BLOCKED' });
+  });
   it('uses healthy plain responses without escalation', async () => {
     const plainFetch = vi.fn().mockResolvedValue(response('ok'));
     const createImpit = vi.fn();

--- a/src/fetch/client.ts
+++ b/src/fetch/client.ts
@@ -5,10 +5,10 @@ import { extractFetchedContent, type ExtractFetchedContentResult } from './extra
 import { createSafeProxy, type SafeProxy } from './safe-proxy.js';
 import { isChallengeResponse, isJavaScriptShell } from './classify.js';
 
-export interface WebFetchOptions { url: string; timeoutSeconds: number; maxChars: number; allowPrivate: boolean; }
+export interface WebFetchOptions { url: string; timeoutSeconds: number; maxChars: number; allowPrivate: boolean; raw?: boolean; }
 export interface WebFetchResult {
   status: number; requestedUrl: string; finalUrl: string; contentType: string; tier: 'plain' | 'impit'; profile?: 'chrome' | 'firefox';
-  title: string; extractionSource: ExtractFetchedContentResult['source']; truncated: boolean; content: string;
+  title: string; extractionSource: ExtractFetchedContentResult['source']; truncated: boolean; content: string; bytes?: number;
 }
 type ResponseLike = Pick<Response, 'status' | 'headers' | 'url'> & { body?: ReadableStream<Uint8Array> | null; bytes?: () => Promise<Uint8Array>; };
 type FetchLike = (url: string, options?: Record<string, unknown>) => Promise<ResponseLike>;
@@ -42,9 +42,10 @@ async function readBody(response: ResponseLike, deadline: number, timeoutSeconds
   while (true) { const { done, value } = await beforeDeadline(reader.read(), deadline, timeoutSeconds, () => { void reader.cancel(); }); if (done) break; size += value.byteLength; if (size > MAX_BODY_BYTES) { await reader.cancel(); throw new CliError('FETCH_BODY_TOO_LARGE', 'Fetched body exceeds 10 MiB'); } chunks.push(value); }
   return new TextDecoder().decode(Buffer.concat(chunks));
 }
-function truncate(content: string, limit: number): { content: string; truncated: boolean } {
+function truncate(content: string, limit: number, raw = false): { content: string; truncated: boolean } {
   if (!limit || content.length <= limit) return { content, truncated: false };
-  const end = Math.max(content.lastIndexOf('\n\n', limit), content.lastIndexOf('\n#', limit), 0) || limit;
+  // Raw bodies are cut at the exact limit: markup has no paragraph boundaries worth snapping to.
+  const end = raw ? limit : Math.max(content.lastIndexOf('\n\n', limit), content.lastIndexOf('\n#', limit), 0) || limit;
   return { content: `${content.slice(0, end)}\n\n[webcmd: truncated at ${limit} characters; rerun with --max-chars 0]`, truncated: true };
 }
 
@@ -72,9 +73,11 @@ export async function webFetch(options: WebFetchOptions, dependencies: WebFetchD
           if (browser === 'firefox') throw new CliError('FETCH_BLOCKED', 'The site blocked non-browser fetches.', BROWSER_WORKFLOW);
           continue;
         }
-        const extracted = extractFetchedContent({ body, contentType: response.headers.get('content-type') ?? '', url: options.url });
-        const clipped = truncate(extracted.content, options.maxChars);
-        return { status: response.status, requestedUrl: options.url, finalUrl: response.url || options.url, contentType: response.headers.get('content-type') ?? '', tier: browser ? 'impit' : 'plain', ...(browser && { profile: browser }), title: extracted.title, extractionSource: extracted.source, truncated: clipped.truncated, content: clipped.content };
+        const extracted = options.raw
+          ? { title: '', content: body, source: 'raw' as const }
+          : extractFetchedContent({ body, contentType: response.headers.get('content-type') ?? '', url: options.url });
+        const clipped = truncate(extracted.content, options.maxChars, options.raw === true);
+        return { status: response.status, requestedUrl: options.url, finalUrl: response.url || options.url, contentType: response.headers.get('content-type') ?? '', tier: browser ? 'impit' : 'plain', ...(browser && { profile: browser }), title: extracted.title, extractionSource: extracted.source, truncated: clipped.truncated, content: clipped.content, ...(options.raw && { bytes: Buffer.byteLength(body) }) };
       } catch (error) {
         const policyError = proxy.policyError();
         if (policyError) throw new CliError('FETCH_UNSAFE_ADDRESS', policyError.message);

--- a/src/fetch/command.test.ts
+++ b/src/fetch/command.test.ts
@@ -46,13 +46,25 @@ describe('web fetch command', () => {
   it('accepts hosted root options without importing execution', async () => {
     await runWebFetchCommand(['--profile', 'work', '--workspace', 'test', 'web', 'fetch', '--url', 'https://example.com']);
 
-    expect(mockWebFetch).toHaveBeenCalledWith({ url: 'https://example.com', timeoutSeconds: 30, maxChars: 50_000, allowPrivate: false });
+    expect(mockWebFetch).toHaveBeenCalledWith({ url: 'https://example.com', timeoutSeconds: 30, maxChars: 50_000, allowPrivate: false, raw: false });
   });
 
   it('uses Commander coercion for canonical fetch options', async () => {
     await program().parseAsync(['web', 'fetch', '--url=https://example.com', '--timeout=9', '--max-chars=1200', '--allow-private=false', '--format=json'], { from: 'user' });
 
-    expect(mockWebFetch).toHaveBeenCalledWith({ url: 'https://example.com', timeoutSeconds: 9, maxChars: 1200, allowPrivate: false });
+    expect(mockWebFetch).toHaveBeenCalledWith({ url: 'https://example.com', timeoutSeconds: 9, maxChars: 1200, allowPrivate: false, raw: false });
+  });
+
+  it('passes --raw through to the client and reports raw metadata in markdown', async () => {
+    await program().parseAsync(['web', 'fetch', '--url=https://example.com', '--raw'], { from: 'user' });
+    expect(mockWebFetch).toHaveBeenCalledWith({ url: 'https://example.com', timeoutSeconds: 30, maxChars: 50_000, allowPrivate: false, raw: true });
+    expect(webFetchCommand.args.find(arg => arg.name === 'raw')?.help).toMatch(/raw HTML/i);
+    expect(webFetchCommand.example).toContain('--raw');
+
+    const rawResult = { ...plainResult, contentType: 'text/html', content: '<html></html>', bytes: 13, truncated: true };
+    expect(formatWebFetchMarkdown(rawResult)).toContain('Bytes: 13');
+    expect(formatWebFetchMarkdown(rawResult)).toContain('Truncated: true');
+    expect(formatWebFetchMarkdown(plainResult)).not.toContain('Bytes:');
   });
 
   it('shows help without requiring a URL', async () => {

--- a/src/fetch/command.ts
+++ b/src/fetch/command.ts
@@ -9,12 +9,14 @@ export const webFetchCommand = cli({
   site: 'web', name: 'fetch', access: 'read', strategy: Strategy.PUBLIC, browser: false,
   clientOwned: true,
   description: 'Fetch a URL with local HTTP clients. Use after a blocked, 403, or Cloudflare response; never opens a browser.', defaultFormat: 'md',
+  example: 'webcmd web fetch --url https://example.com --raw -f json',
   renderMarkdown: data => (isWebFetchResult(data) ? formatWebFetchMarkdown(data) : undefined),
   args: [
     { name: 'url', type: 'string', required: true, help: 'HTTP or HTTPS URL to fetch' },
     { name: 'timeout', type: 'int', default: 30, help: 'Total fetch budget in seconds' },
     { name: 'max-chars', type: 'int', default: 50_000, help: 'Maximum extracted characters; 0 disables truncation' },
     { name: 'allow-private', type: 'boolean', default: false, help: 'Allow private and loopback destinations' },
+    { name: 'raw', type: 'boolean', default: false, help: 'Return the raw HTML response body instead of extracted article text; use this for CSS selector discovery, meta tags, and inline script payloads' },
   ],
   validateArgs: validateWebFetchArgs,
   func: async (kwargs) => {
@@ -37,6 +39,7 @@ function clientOptionsFromKwargs(kwargs: CommandArgs): WebFetchOptions {
     timeoutSeconds: Number(kwargs.timeout ?? 30),
     maxChars: Number(kwargs['max-chars'] ?? 50000),
     allowPrivate: kwargs['allow-private'] === true,
+    raw: kwargs.raw === true,
   };
 }
 
@@ -54,5 +57,5 @@ function isWebFetchResult(data: unknown): data is WebFetchResult {
 }
 
 export function formatWebFetchMarkdown(result: WebFetchResult): string {
-  return [`# ${result.title || 'Fetched content'}`, '', `Source: ${result.requestedUrl}`, `Final URL: ${result.finalUrl}`, `Content type: ${result.contentType || 'unknown'}`, `Extraction: ${result.extractionSource}`, '', result.content].join('\n');
+  return [`# ${result.title || 'Fetched content'}`, '', `Source: ${result.requestedUrl}`, `Final URL: ${result.finalUrl}`, `Content type: ${result.contentType || 'unknown'}`, `Extraction: ${result.extractionSource}`, ...(result.bytes === undefined ? [] : [`Bytes: ${result.bytes}`, `Truncated: ${result.truncated}`]), '', result.content].join('\n');
 }


### PR DESCRIPTION
`webcmd web fetch` could only ever return readability-extracted article text, so an agent hunting for a CSS selector, a meta tag, or an inline `<script>` payload had no way to see the HTML — two recent eval scenarios abandoned webcmd here and fell back to `curl | grep -P`, which does not exist on macOS, losing the task.

## What changed

1. `--raw` (boolean, default false) on `web fetch`: returns the response body verbatim — no readability, no markdown conversion.
2. Raw bodies honour `--max-chars` with a hard cut at the limit plus the existing `[webcmd: truncated at N characters; rerun with --max-chars 0]` marker, and `truncated: true`. Never a silent cut.
3. Raw results carry `bytes` (body byte length) alongside the existing `status`, `finalUrl`, `contentType`, `truncated` fields; markdown output gains `Bytes:`/`Truncated:` lines. Non-raw results are byte-identical to before — no new fields.
4. Help text names the use case ("CSS selector discovery, meta tags, and inline script payloads") and the command `example` now shows `--raw`; `cli-manifest.json` regenerated.
5. Untouched: safe proxy / `--allow-private` gating, timeouts, the challenge ladder, `FETCH_BLOCKED`, `FETCH_REQUIRES_BROWSER`, and the 10 MiB body cap.

## Before / After

Before — no way to get HTML:
```
$ webcmd web fetch --url https://example.com --raw
error: unknown option '--raw'
```

After:
```
$ node dist/src/main.js web fetch --url https://example.com --raw --json
{
  "status": 200,
  "requestedUrl": "https://example.com",
  "finalUrl": "https://example.com/",
  "contentType": "text/html",
  "tier": "impit",
  "profile": "chrome",
  "title": "",
  "extractionSource": "raw",
  "truncated": false,
  "content": "<!doctype html><html lang=\"en\"><head><title>Example Domain</title><link rel=\"icon\" href=\"data:,\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style></head><body><div><h1>Example Domain</h1><p>This domain is for use in documentation examples without needing permission. Avoid use in operations.</p><p><a href=\"https://iana.org/domains/example\">Learn more</a></p></div></body></html>\n",
  "bytes": 559
}
```

Default path, unchanged:
```
$ node dist/src/main.js web fetch --url https://example.com
# Example Domain

Source: https://example.com
Final URL: https://example.com/
Content type: text/html
Extraction: readability

This domain is for use in documentation examples without needing permission. Avoid use in operations.

[Learn more](https://iana.org/domains/example)
```

Truncation is announced, not silent:
```
$ node dist/src/main.js web fetch --url https://example.com --raw --max-chars 120
# Fetched content

Source: https://example.com
Final URL: https://example.com/
Content type: text/html
Extraction: raw
Bytes: 559
Truncated: true

<!doctype html><html lang="en"><head><title>Example Domain</title><link rel="icon" href="data:,"><meta name="viewport" c

[webcmd: truncated at 120 characters; rerun with --max-chars 0]
```

## Tests

`npm run typecheck` clean. `npx vitest run --project unit src/fetch src/hosted/manifest.test.ts src/check-hosted-contract.test.ts` — 82 passed. New cases: raw returns the unprocessed body with metadata; non-raw still extracts and omits `bytes`; raw truncation is reported; a Cloudflare challenge with `--raw` still ends in `FETCH_BLOCKED`; `--raw` reaches the client and markdown metadata renders.

Full `--project unit` run: 123 failures with this change vs 122 on `origin/main` — the one delta was the hosted-contract byte check, fixed by regenerating `cli-manifest.json` (now committed); the remaining 122 are pre-existing on main in this environment (hosted lifecycle, playwright sandbox provenance, plugin manifest) and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
