### PR TITLE
fix(cli): make session close accept --session and be idempotent

### DIFF
--- a/src/cli-argv-preprocess.test.ts
+++ b/src/cli-argv-preprocess.test.ts
@@ -38,6 +38,20 @@ describe('rejectMisplacedSessionSelectorArgv', () => {
     expect(rejectMisplacedSessionSelectorArgv(['--session', 'session_a', 'browser', 'run']))
       .toEqual(['--session', 'session_a', 'browser', 'run']);
   });
+
+  it('rewrites --session into the positional for `session close` instead of erroring', () => {
+    expect(rejectMisplacedSessionSelectorArgv(['session', 'close', '--session', 'session_a']))
+      .toEqual(['session', 'close', 'session_a']);
+    expect(rejectMisplacedSessionSelectorArgv(['session', 'close', '--session=session_a', '--force']))
+      .toEqual(['session', 'close', 'session_a', '--force']);
+    expect(rejectMisplacedSessionSelectorArgv(['--profile', 'work', 'session', 'close', '--session', 'session_a']))
+      .toEqual(['--profile', 'work', 'session', 'close', 'session_a']);
+  });
+
+  it('drops a valueless --session on `session close` so the command reports both accepted forms', () => {
+    expect(rejectMisplacedSessionSelectorArgv(['session', 'close', '--session']))
+      .toEqual(['session', 'close']);
+  });
 });
 
 import { escapeLeadingDashPositional } from './cli-argv-preprocess.js';

--- a/src/cli-argv-preprocess.ts
+++ b/src/cli-argv-preprocess.ts
@@ -104,6 +104,17 @@ export function rejectMisplacedSessionSelectorArgv(argv: readonly string[]): str
         ...result.slice(0, index),
         ...result.slice(index + (token === '--session' && sessionId !== '<session-id>' ? 2 : 1)),
       ];
+      // `session close` takes the id as a positional, so `--session` here is not
+      // misplaced — rewrite it into the positional form instead of erroring with
+      // a "corrected" command that would then fail on a missing argument.
+      if (result[commandIndex] === 'session' && result[commandIndex + 1] === 'close') {
+        if (sessionId === '<session-id>') return withoutMisplaced;
+        return [
+          ...withoutMisplaced.slice(0, commandIndex + 2),
+          sessionId,
+          ...withoutMisplaced.slice(commandIndex + 2),
+        ];
+      }
       throw new BrowserSessionArgvError(
         `SESSION_SELECTOR_POSITION: --session must appear before the command. Use: webcmd --session ${sessionId} ${withoutMisplaced.join(' ')}`,
       );

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2512,14 +2512,33 @@ describe('browser Session lifecycle commands', () => {
     });
   });
 
-  it('uses positional close syntax and profile guidance when a Session is missing', async () => {
+  it('closes a missing Session idempotently instead of failing', async () => {
     mockSendCommand.mockRejectedValueOnce(new Error('daemon unavailable'));
 
-    await expect(createProgram('', '').parseAsync(['node', 'webcmd', 'session', 'close', 'session_missing']))
-      .rejects.toMatchObject({
-        code: 'SESSION_NOT_FOUND',
-        hint: expect.stringContaining('webcmd session close <session-id>'),
-      });
+    await createProgram('', '').parseAsync(['node', 'webcmd', 'session', 'close', 'session_missing', '-f', 'json']);
+
+    expect(JSON.parse(consoleLogSpy.mock.calls.flat().join('\n'))).toMatchObject({
+      ok: true,
+      closed: false,
+      alreadyClosed: true,
+      session: 'session_missing',
+    });
+  });
+
+  it('accepts the Session ID from the root --session selector', async () => {
+    mockSendCommand.mockRejectedValueOnce(new Error('daemon unavailable'));
+
+    await createProgram('', '').parseAsync(['node', 'webcmd', '--session', 'session_missing', 'session', 'close', '-f', 'json']);
+
+    expect(JSON.parse(consoleLogSpy.mock.calls.flat().join('\n'))).toMatchObject({
+      alreadyClosed: true,
+      session: 'session_missing',
+    });
+  });
+
+  it('rejects a malformed Session selector as a usage error', async () => {
+    await expect(createProgram('', '').parseAsync(['node', 'webcmd', 'session', 'close', 'badid']))
+      .rejects.toMatchObject({ code: 'INVALID_SESSION_SELECTOR', exitCode: 2 });
   });
 
   it.each([

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -606,6 +606,12 @@ async function requireKnownProfileId(command?: Command): Promise<string> {
   return profileId;
 }
 
+/** True for "this Session does not exist here" errors, from either the durable store or the runtime. */
+function isSessionMissingError(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null)?.code;
+  return code === 'SESSION_NOT_FOUND' || code === 'session_not_found';
+}
+
 function formatHandoff(row: BrowserSessionListRow): string {
   return row.handoff ? `${row.handoff.site} until ${row.handoff.expiresAt}` : '';
 }
@@ -914,33 +920,52 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string, pluginsDi
   const sessionCloseCmd = addOutputFormatOption(sessionCmd
     .command('close')
     .description('Close a browser Session runtime without deleting its durable record')
-    .argument('<session-id>', 'Existing opaque Session ID from `webcmd session create`')
+    .argument('[session-id]', 'Existing opaque Session ID from `webcmd session create` (or pass the root `--session <id>` selector)')
     .option('--force', 'Close even while the Session is busy or paused for handoff'), 'yaml');
-  sessionCloseCmd.action(async (sessionId: string, opts: { format?: string; force?: boolean }, command) => {
+  sessionCloseCmd.action(async (positionalSessionId: string | undefined, opts: { format?: string; force?: boolean }, command) => {
       const fmt = resolveCommandOutputFormat(command, opts.format);
       if (fmt === null) return;
       const profileId = getSelectedProfileId(command);
+      const rootSelector = getCommandOption(command, 'session');
+      const sessionId = positionalSessionId ?? (typeof rootSelector === 'string' ? rootSelector : undefined);
+      if (!sessionId) {
+        throw new ArgumentError(
+          'Missing Session ID.',
+          `Use \`${CLI_COMMAND} session close <session-id>\` or \`${CLI_COMMAND} --session <session-id> session close\`.`,
+        );
+      }
       requireSessionIdShape(sessionId);
-      const status = await fetchDaemonStatus({ contextId: profileId });
-      if (!status || (status.runtimeConnected && !isDaemonStale(status, PKG_VERSION))) {
-        try {
-          const data = await sendCommand('session-close', {
-            contextId: profileId,
-            session: sessionId,
-            force: opts.force === true,
-          });
+      try {
+        const status = await fetchDaemonStatus({ contextId: profileId });
+        if (!status || (status.runtimeConnected && !isDaemonStale(status, PKG_VERSION))) {
+          try {
+            const data = await sendCommand('session-close', {
+              contextId: profileId,
+              session: sessionId,
+              force: opts.force === true,
+            });
+            await renderOutput(data, { fmt, fmtExplicit: outputFormatIsExplicit(command) });
+            return;
+          } catch (error) {
+            if (status || opts.force === true) throw error;
+          }
+        }
+        if (opts.force === true) {
+          const data = await sendCommand('session-close', { contextId: profileId, session: sessionId, force: true });
           await renderOutput(data, { fmt, fmtExplicit: outputFormatIsExplicit(command) });
           return;
-        } catch (error) {
-          if (status || opts.force === true) throw error;
         }
-      }
-      if (opts.force === true) {
-        const data = await sendCommand('session-close', { contextId: profileId, session: sessionId, force: true });
-        await renderOutput(data, { fmt, fmtExplicit: outputFormatIsExplicit(command) });
+        new LocalBrowserSessionStore().require(profileId, sessionId);
+      } catch (error) {
+        // Closing an already-closed / reaped / never-existed Session is a no-op,
+        // not a failure: cleanup must stay idempotent for unattended agents.
+        if (!isSessionMissingError(error)) throw error;
+        await renderOutput(
+          { ok: true, closed: false, alreadyClosed: true, session: sessionId },
+          { fmt, fmtExplicit: outputFormatIsExplicit(command) },
+        );
         return;
       }
-      new LocalBrowserSessionStore().require(profileId, sessionId);
       await renderOutput({ closed: false, alreadyIdle: true, session: sessionId }, { fmt, fmtExplicit: outputFormatIsExplicit(command) });
     });
 

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -4,6 +4,7 @@ import type { BrowserRuntimeCommand, BrowserRuntimeResult } from '../browser/pro
 import type { BrowserRuntimeProvider } from '../browser/runtime/provider.js';
 import { buildCommandTimeoutFailure, getResponseCorsHeaders } from '../daemon-utils.js';
 import { getSessionLeaseKey, isSessionLeaseCommand, type SessionLease, SessionLeaseRegistry } from '../session-lease.js';
+import { CliError } from '../errors.js';
 import type { BrowserSessionRecord } from '../browser/sessions.js';
 
 const MAX_BODY = 1024 * 1024;
@@ -469,7 +470,13 @@ export function createDaemonServer(provider: BrowserRuntimeProvider, opts: Daemo
         if (!result.ok) pushLog('warn', `Command ${body.id} failed: ${result.error ?? result.errorCode ?? 'unknown error'}`);
         if (!responseAborted) jsonResponse(res, result.ok ? 200 : result.errorCode === 'command_result_unknown' ? 408 : 400, result);
       } catch (err) {
-        jsonResponse(res, 400, { ok: false, error: err instanceof Error ? err.message : 'Invalid request' });
+        // Keep the machine-readable code: clients (e.g. `session close`)
+        // branch on it, and dropping it leaves them only a message to match.
+        jsonResponse(res, 400, {
+          ok: false,
+          errorCode: err instanceof CliError ? err.code : undefined,
+          error: err instanceof Error ? err.message : 'Invalid request',
+        });
       }
       return;
     }

--- a/tests/e2e/management.test.ts
+++ b/tests/e2e/management.test.ts
@@ -133,3 +133,49 @@ describe('management commands E2E', () => {
     expect(code).toBe(2);
   });
 });
+
+describe('session close E2E', () => {
+  const NEVER_EXISTED = 'session_00000000-0000-0000-0000-000000000000';
+
+  it('accepts the root --session selector and the command it used to suggest', async () => {
+    // Old behaviour: this errored with SESSION_SELECTOR_POSITION and suggested
+    // `webcmd --session <id> session close`, which then failed on the missing
+    // positional. Both spellings must now work.
+    const viaFlag = await runManagementCli(['session', 'close', '--session', NEVER_EXISTED]);
+    expect(viaFlag.stderr).not.toMatch(/SESSION_SELECTOR_POSITION|missing required argument/);
+    expect(viaFlag.code).toBe(0);
+
+    const viaRootSelector = await runManagementCli(['--session', NEVER_EXISTED, 'session', 'close']);
+    expect(viaRootSelector.stderr).not.toMatch(/missing required argument/);
+    expect(viaRootSelector.code).toBe(0);
+  });
+
+  it('is idempotent for an unknown Session ID', async () => {
+    const { stdout, code } = await runManagementCli(['session', 'close', NEVER_EXISTED, '-f', 'json']);
+    expect(code).toBe(0);
+    expect(parseJsonOutput(stdout)).toMatchObject({ ok: true, closed: false, alreadyClosed: true, session: NEVER_EXISTED });
+  });
+
+  it('closes a real Session twice without failing', async () => {
+    const created = await runManagementCli(['session', 'create', '-f', 'json']);
+    expect(created.code).toBe(0);
+    const sessionId = parseJsonOutput(created.stdout).id as string;
+    for (const attempt of [1, 2]) {
+      const { code } = await runManagementCli(['session', 'close', sessionId]);
+      expect(code, `close attempt ${attempt}`).toBe(0);
+    }
+  });
+
+  it('still rejects a malformed selector as a usage error', async () => {
+    const { code, stderr, stdout } = await runManagementCli(['session', 'close', 'badid']);
+    expect(code).toBe(2);
+    expect(stdout + stderr).toContain('INVALID_SESSION_SELECTOR');
+  });
+
+  it('names both accepted forms when no Session ID is given', async () => {
+    const { code, stdout, stderr } = await runManagementCli(['session', 'close']);
+    expect(code).toBe(2);
+    expect(stdout + stderr).toContain('session close <session-id>');
+    expect(stdout + stderr).toContain('--session <session-id> session close');
+  });
+});


### PR DESCRIPTION
`webcmd session close --session session_abc` told you to run `webcmd --session session_abc session close` — and that command then failed with `missing required argument 'session-id'`. The suggestion was impossible to satisfy: `--session` is a root selector everywhere in the CLI except `session close`, where the id is a positional. A contestant in a recent eval burned three turns on that loop and never closed its session.

## What changed

1. `session close` takes `[session-id]` (optional) and falls back to the root `--session` selector. With neither, it errors naming both forms.
2. `rejectMisplacedSessionSelectorArgv` is command-aware: for `session close` it rewrites `--session <id>` into the positional instead of throwing a suggestion that cannot work. Every other command keeps the existing SESSION_SELECTOR_POSITION error.
3. `session close` is idempotent — an unknown / already-reaped / already-closed Session returns `{ ok: true, closed: false, alreadyClosed: true, session }` and exit 0. `InvalidSessionSelectorError` (`badid`) still exits 2; every other failure still propagates.
4. `src/daemon/server.ts` kept no error code on unhandled command errors, so `SESSION_NOT_FOUND` arrived at the client as a generic `BROWSER_COMMAND` with only a message. The code is now preserved on the wire, which is what the idempotency check branches on.
5. `--force` is untouched.

## Before / After

Before (on `main`):
```
$ node dist/src/main.js session close --session session_abc
error: SESSION_SELECTOR_POSITION: --session must appear before the command.
       Use: webcmd --session session_abc session close
$ node dist/src/main.js --session session_abc session close
error: missing required argument 'session-id'
```

After (real output, isolated HOME):
```
=== webcmd session close --session session_abc
ok: true
closed: false
alreadyClosed: true
session: session_abc
exit=0

=== webcmd --session session_abc session close
ok: true
closed: false
alreadyClosed: true
session: session_abc
exit=0

=== webcmd session close session_00000000-0000-0000-0000-000000000000
ok: true
closed: false
alreadyClosed: true
session: session_00000000-0000-0000-0000-000000000000
exit=0

=== webcmd session close badid
ok: false
error:
  code: INVALID_SESSION_SELECTOR
  message: 'Session selector must be an opaque Session ID: badid'
  help: Run `webcmd session create` and pass the returned `session_...` ID.
  exitCode: 2
exit=2

=== webcmd session close            (no id at all)
ok: false
error:
  code: ARGUMENT
  message: Missing Session ID.
  help: Use `webcmd session close <session-id>` or `webcmd --session <session-id> session close`.
  exitCode: 2
exit=2
```

Real Session, closed twice, then with `--force` — all exit 0:
```
=== close once  → closed: false / alreadyIdle: true   exit=0
=== close twice → closed: false / alreadyIdle: true   exit=0
=== close --force → closed: false / alreadyIdle: true / displaced: null   exit=0
```

## Tests

- `src/cli-argv-preprocess.test.ts`: `--session`, `--session=`, and `--profile x` prefixed forms all rewrite to `session close <id>`; a valueless `--session` is dropped so the command reports both accepted forms.
- `src/cli.test.ts`: missing Session closes idempotently; root `--session` selector is accepted; `badid` still throws INVALID_SESSION_SELECTOR exit 2.
- `tests/e2e/management.test.ts`: five tests that RUN the CLI — the suggestion round-trip (both spellings, asserting no usage error), unknown id idempotent, real Session closed twice, `badid` exit 2, and the no-id error text.
- `npm run typecheck`, `npx vitest run --project unit` (154 files, 2707 passed), `npm run build` all green. The new e2e tests pass; `management.test.ts > list shows all registered commands` fails in this worktree on `main` too (fixture-plugin install), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
