### PR TITLE
fix(cli): discover adapters authored with registerCommand

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -348,9 +348,9 @@ describe('override reporting surfaces', () => {
     await createProgram('', userClis, pluginsDir)
       .parseAsync(['node', 'webcmd', 'adapter', 'status', '--format', 'json']);
     expect(JSON.parse(stdoutSpy.mock.calls.flat().join('\n'))).toEqual([
-      { command: 'linkedin/search', kind: 'override', plugin: 'linkedin', reconciliationNeeded: true, orphaned: false },
-      { command: 'local/run', kind: 'user', plugin: null, reconciliationNeeded: false, orphaned: false },
-      { command: 'old/search', kind: 'override', plugin: 'old', reconciliationNeeded: false, orphaned: true },
+      { command: 'linkedin/search', kind: 'override', plugin: 'linkedin', reconciliationNeeded: true, orphaned: false, loadError: null },
+      { command: 'local/run', kind: 'user', plugin: null, reconciliationNeeded: false, orphaned: false, loadError: null },
+      { command: 'old/search', kind: 'override', plugin: 'old', reconciliationNeeded: false, orphaned: true, loadError: null },
     ]);
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,7 +55,7 @@ import type { BrowserWindowMode } from './runtime.js';
 import { configureRootCommandSurface } from './root-command-surface.js';
 import { validateRawBrowserSession } from './hosted/browser-args.js';
 import { LocalBrowserSessionStore, requireSessionIdShape, type BrowserSessionListRow } from './browser/sessions.js';
-import { PLUGINS_DIR } from './discovery.js';
+import { getAdapterLoadFailures, PLUGINS_DIR } from './discovery.js';
 import { unknownRootCommandMessage, unknownSubcommandHelp, unknownSubcommandMessage } from './command-suggest.js';
 import { loadBrowserRunSource } from './browser/run/input.js';
 import { BrowserRunError } from './browser/run/types.js';
@@ -1764,18 +1764,21 @@ cli({
 
         const records = readOverrideRecords();
         const reconcile = new Set((await import('./plugin.js')).findOverridesNeedingReconcile().map(({ commandKey }) => commandKey));
+        const failures = new Map(getAdapterLoadFailures().map(failure => [failure.file, failure.error]));
         const adapters: Array<{
           command: string;
           kind: 'user' | 'override';
           plugin: string | null;
           reconciliationNeeded: boolean;
           orphaned: boolean;
+          loadError: string | null;
         }> = [];
         for (const site of userSites) {
           const files = await fs.promises.readdir(path.join(USER_CLIS, site));
           for (const file of files.filter((entry) => entry.endsWith('.js')).sort()) {
             const command = `${site}/${file.slice(0, -3)}`;
             const record = records[command];
+            const loadError = failures.get(path.join(USER_CLIS, site, file)) ?? null;
             adapters.push(record
               ? {
                   command,
@@ -1783,15 +1786,16 @@ cli({
                   plugin: record.plugin,
                   reconciliationNeeded: reconcile.has(command),
                   orphaned: !fs.existsSync(path.join(pluginsDir, record.plugin)),
+                  loadError,
                 }
-              : { command, kind: 'user', plugin: null, reconciliationNeeded: false, orphaned: false });
+              : { command, kind: 'user', plugin: null, reconciliationNeeded: false, orphaned: false, loadError });
           }
         }
         if (fmt !== 'table') {
           renderOutput(adapters, {
             fmt,
             fmtExplicit: outputFormatIsExplicit(adapterStatusCmd),
-            columns: ['command', 'kind', 'plugin', 'reconciliationNeeded', 'orphaned'],
+            columns: ['command', 'kind', 'plugin', 'reconciliationNeeded', 'orphaned', 'loadError'],
             title: `${CLI_COMMAND}/adapter-status`,
             source: `${CLI_COMMAND} adapter status`,
           });
@@ -1801,12 +1805,13 @@ cli({
         for (const site of userSites) {
           console.log(`  ${site}`);
           for (const adapter of adapters.filter((item) => item.command.startsWith(`${site}/`))) {
+            const failure = adapter.loadError ? ` (failed to load: ${adapter.loadError})` : '';
             if (adapter.kind === 'user') {
-              console.log(`    user adapter: ${adapter.command}`);
+              console.log(`    user adapter: ${adapter.command}${failure}`);
             } else if (adapter.orphaned) {
-              console.log(`    orphaned override: ${adapter.command} (plugin ${adapter.plugin} is not installed)`);
+              console.log(`    orphaned override: ${adapter.command} (plugin ${adapter.plugin} is not installed)${failure}`);
             } else {
-              console.log(`    override: ${adapter.command} (plugin ${adapter.plugin}${adapter.reconciliationNeeded ? ', upstream changed since fork' : ''})`);
+              console.log(`    override: ${adapter.command} (plugin ${adapter.plugin}${adapter.reconciliationNeeded ? ', upstream changed since fork' : ''})${failure}`);
             }
           }
         }

--- a/src/command-suggest.ts
+++ b/src/command-suggest.ts
@@ -13,7 +13,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { Command } from 'commander';
 import { CLI_COMMAND } from './brand.js';
-import { missingPluginGuidance, PLUGINS_DIR, USER_CLIS_DIR } from './discovery.js';
+import { getAdapterLoadFailures, missingPluginGuidance, PLUGINS_DIR, USER_CLIS_DIR } from './discovery.js';
 
 /**
  * High-priority overrides: intent that edit distance cannot infer.
@@ -136,6 +136,11 @@ export function unknownRootCommandMessage(
 
   const suggestions = suggestCommands(name, commandCandidates(program));
   if (suggestions.length > 0) return `Unknown command "${name}".\n${formatSuggestions(suggestions)}`;
+
+  // A recorded load failure names the file and the real cause, so it beats the
+  // generic "installed but registered nothing" text below. Only fall back to
+  // that when discovery caught nothing to report.
+  if (getAdapterLoadFailures().some(failure => failure.site === name)) return missingPluginGuidance(name);
 
   const installedDir = installedDirFor(name, installDirs);
   if (installedDir) {

--- a/src/discovery.test.ts
+++ b/src/discovery.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { discoverClis, discoverPlugins } from './discovery.js';
+import { discoverClis, discoverPlugins, getAdapterLoadFailures, missingPluginGuidance } from './discovery.js';
 import { getRegistry } from './registry.js';
 import { classifyCommandOrigin } from './command-origin.js';
 
@@ -118,5 +118,91 @@ describe('discovery attributes source through the real cli() path', () => {
 
     expect(getRegistry().get('base-module/run')).toBeUndefined();
     expect(getRegistry().get('base-source/run')).toBeUndefined();
+  });
+});
+
+describe('adapter load failures are surfaced, not silently swallowed', () => {
+  let tempHome: string;
+  const registryApiUrl = new URL('./registry-api.ts', import.meta.url).href;
+
+  beforeEach(async () => {
+    getRegistry().clear();
+    tempHome = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'webcmd-loadfail-'));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tempHome, { recursive: true, force: true });
+  });
+
+  async function writeAdapter(site: string, source: string): Promise<string> {
+    const siteDir = path.join(tempHome, 'clis', site);
+    await fs.promises.mkdir(siteDir, { recursive: true });
+    const modulePath = path.join(siteDir, 'list.js');
+    await fs.promises.writeFile(modulePath, source);
+    return modulePath;
+  }
+
+  it('registers an adapter that authors with cli() from the public registry export', async () => {
+    await writeAdapter('quotes', `
+      import { cli } from '${registryApiUrl}';
+      cli({ site: 'quotes', name: 'list', description: 'List quotes', access: 'read',
+            browser: false, args: [], func: async () => [] });
+    `);
+
+    await discoverClis(path.join(tempHome, 'clis'));
+
+    expect(getRegistry().get('quotes/list')).toBeDefined();
+    expect(getAdapterLoadFailures().filter(f => f.site === 'quotes')).toEqual([]);
+  });
+
+  it('does not register from a file whose only "cli(" is a comment', async () => {
+    await writeAdapter('inert', '// cli(\nexport const nothing = 1;\n');
+
+    await discoverClis(path.join(tempHome, 'clis'));
+
+    expect([...getRegistry().keys()].filter(key => key.startsWith('inert/'))).toEqual([]);
+    expect(getAdapterLoadFailures().filter(f => f.site === 'inert')).toEqual([]);
+  });
+
+  it('names the real cause when a module throws on load, and leads with it at run time', async () => {
+    const modulePath = await writeAdapter('broken', `
+      import { cli } from '${registryApiUrl}';
+      cli({ site: 'broken', name: 'list', description: 'x', browser: false, args: [], func: async () => [] });
+    `);
+
+    await discoverClis(path.join(tempHome, 'clis'));
+
+    const failure = getAdapterLoadFailures().find(f => f.file === modulePath);
+    expect(failure?.error).toContain('must declare access');
+    const guidance = missingPluginGuidance('broken');
+    expect(guidance.split('\n')[0]).toContain('failed to load');
+    expect(guidance).not.toContain('is not installed');
+    expect(guidance).toContain(modulePath);
+    expect(guidance).toContain('must declare access');
+  });
+
+  it('reports the missing export when an adapter imports registerCommand', async () => {
+    const modulePath = await writeAdapter('legacy', `
+      import { registerCommand } from '${registryApiUrl}';
+      registerCommand({ site: 'legacy', name: 'list', description: 'x', args: [], run: async () => [] });
+    `);
+
+    await discoverClis(path.join(tempHome, 'clis'));
+
+    expect(getRegistry().get('legacy/list')).toBeUndefined();
+    const failure = getAdapterLoadFailures().find(f => f.file === modulePath);
+    expect(failure?.error).toMatch(/registerCommand/);
+  });
+
+  it('agrees with adapter status: every failed file is reported by absolute path', async () => {
+    const modulePath = await writeAdapter('unavailable', `
+      import { cli } from '${registryApiUrl}';
+      cli({ site: 'unavailable', name: 'list', description: 'x', browser: false, args: [], func: async () => [] });
+    `);
+
+    await discoverClis(path.join(tempHome, 'clis'));
+
+    expect(getAdapterLoadFailures().map(f => f.file)).toContain(modulePath);
+    expect(getRegistry().get('unavailable/list')).toBeUndefined();
   });
 });

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -38,8 +38,50 @@ export const USER_WEBCMD_DIR = getUserWebcmdDir();
 export const USER_CLIS_DIR = getUserClisDir();
 /** Plugins directory: ~/.webcmd/plugins/ */
 export const PLUGINS_DIR = getPluginsDir();
-/** Matches files that register commands via cli() or lifecycle hooks */
-const PLUGIN_MODULE_PATTERN = /\b(?:cli|registerSiteAuthCommands|onStartup|onBeforeExecute|onAfterExecute)\s*\(/;
+/**
+ * Adapter files that failed to import, so run-time errors can name the real
+ * cause instead of claiming the site is not installed.
+ */
+const loadFailures: Array<{ site: string; file: string; error: string }> = [];
+
+export function getAdapterLoadFailures(): ReadonlyArray<{ site: string; file: string; error: string }> {
+  return loadFailures;
+}
+
+/**
+ * Gate discovery on the runtime IMPORT, not on call syntax.
+ *
+ * A file can only register anything by importing the runtime, so this catches
+ * every authoring style — cli(), registerSiteAuthCommands(), hooks — instead of
+ * the old `\bcli\s*\(` source regex, which missed real calls it didn't enumerate
+ * and matched comments and strings that were not calls at all. Helper modules
+ * that never import the runtime are still skipped, so their side effects do not
+ * run at startup.
+ */
+const RUNTIME_IMPORT_PATTERN = new RegExp(
+  `${PACKAGE_NAME}/(?:registry|plugin-runtime|hooks)|/(?:registry|registry-api|plugin-runtime|hooks)\\.[jt]s['"\`]`,
+);
+
+async function importsRuntime(filePath: string): Promise<boolean> {
+  try {
+    return RUNTIME_IMPORT_PATTERN.test(await fs.promises.readFile(filePath, 'utf-8'));
+  } catch (err) {
+    log.warn(`Failed to inspect module ${filePath}: ${getErrorMessage(err)}`);
+    return false;
+  }
+}
+
+/** Import an adapter file, recording (and warning about) any load failure. */
+async function loadAdapterModule(site: string, filePath: string): Promise<void> {
+  if (!(await importsRuntime(filePath))) return;
+  try {
+    await runWithDiscoverySource(filePath, () => import(pathToFileURL(filePath).href));
+  } catch (err) {
+    const error = getErrorMessage(err);
+    loadFailures.push({ site, file: filePath, error });
+    log.warn(`Failed to load adapter ${filePath}: ${error}`);
+  }
+}
 
 function parseStrategy(rawStrategy: string | undefined, fallback: Strategy = Strategy.COOKIE): Strategy {
   if (!rawStrategy) return fallback;
@@ -260,10 +302,7 @@ async function discoverClisFromFs(dir: string): Promise<void> {
           return;
         }
         if (file.endsWith('.js') && !file.endsWith('.d.js') && !file.endsWith('.test.js')) {
-          if (!(await isCliModule(filePath))) return;
-          await runWithDiscoverySource(filePath, () => import(pathToFileURL(filePath).href)).catch((err) => {
-            log.warn(`Failed to load module ${filePath}: ${getErrorMessage(err)}`);
-          });
+          await loadAdapterModule(site, filePath);
         }
       }));
     });
@@ -286,6 +325,15 @@ export async function discoverPlugins(pluginsDir: string = PLUGINS_DIR): Promise
 }
 
 export function missingPluginGuidance(site: string): string {
+  const failures = loadFailures.filter(failure => failure.site === site);
+  if (failures.length > 0) {
+    return [
+      `Site "${site}" has adapter files that failed to load:`,
+      ...failures.map(failure => `  ${failure.file}\n    ${failure.error}`),
+      `Fix the file, then re-run. Adapters call cli({ ... }) from '${PACKAGE_NAME}/registry'`,
+      `and must declare access: 'read' | 'write' and func.`,
+    ].join('\n');
+  }
   return [
     `Site "${site}" is not installed.`,
     `Search: ${CLI_COMMAND} plugin search ${site}`,
@@ -306,10 +354,7 @@ async function discoverPluginDir(dir: string, site: string): Promise<void> {
       return;
     }
     if (file.endsWith('.js') && !file.endsWith('.d.js')) {
-      if (!(await isCliModule(filePath))) return;
-      await runWithDiscoverySource(filePath, () => import(pathToFileURL(filePath).href)).catch((err) => {
-        log.warn(`Plugin ${site}/${file}: ${getErrorMessage(err)}`);
-      });
+      await loadAdapterModule(site, filePath);
     } else if (
       file.endsWith('.ts') && !file.endsWith('.d.ts') && !file.endsWith('.test.ts')
     ) {
@@ -324,16 +369,6 @@ async function discoverPluginDir(dir: string, site: string): Promise<void> {
       );
     }
   }));
-}
-
-async function isCliModule(filePath: string): Promise<boolean> {
-  try {
-    const source = await fs.promises.readFile(filePath, 'utf-8');
-    return PLUGIN_MODULE_PATTERN.test(source);
-  } catch (err) {
-    log.warn(`Failed to inspect module ${filePath}: ${getErrorMessage(err)}`);
-    return false;
-  }
 }
 
 async function isDiscoverablePluginDir(entry: fs.Dirent, pluginDir: string): Promise<boolean> {

--- a/src/registry-api.ts
+++ b/src/registry-api.ts
@@ -5,9 +5,13 @@
  * this file. It re-exports ONLY the core registration API — no serialization,
  * no transitive side-effects — to avoid circular dependency deadlocks when
  * plugins are dynamically imported during discoverPlugins().
+ *
+ * cli() is the ONLY authoring entry point. registerCommand() stays internal:
+ * it takes the raw/lazy manifest shape and is not a supported way to author
+ * an adapter.
  */
 
-export { cli, Strategy, getRegistry, fullName, registerCommand } from './registry.js';
+export { cli, Strategy, getRegistry, fullName } from './registry.js';
 export type { CliCommand, Arg, CliOptions, CommandArgs, SiteSessionMode } from './registry.js';
 export type { IPage } from './types.js';
 export { onStartup, onBeforeExecute, onAfterExecute } from './hooks.js';


### PR DESCRIPTION
An adapter in `~/.webcmd/clis/` authored with `registerCommand` — a public export of `@agentrhq/webcmd/registry` — was never imported, so `webcmd quotes list` said the site was not installed while `webcmd adapter status` listed the same command as present.

## The problem

Discovery gated every candidate file through a regex over its **source text**: `/\b(?:cli|registerSiteAuthCommands|onStartup|onBeforeExecute|onAfterExecute)\s*\(/`. Three consequences:

1. `registerCommand(` is not in that list, so a file using the public export was silently never imported.
2. The regex matches comments and strings — appending `// cli(` to the same file flipped it to discoverable.
3. `adapter status` reads the filesystem, so it reported commands discovery had refused to load.

## What changed

1. **Gate on the runtime import, not on call syntax** (`src/discovery.ts`). A file can only register anything by importing the runtime, so discovery now tests for an import of `@agentrhq/webcmd/{registry,plugin-runtime,hooks}`. That covers every authoring style instead of an enumerated list of call names, and a call-shaped comment no longer decides anything. Helper modules that never import the runtime are still skipped, so their side effects still do not run at startup. Chosen over deleting the gate entirely, which would execute every helper module in an adapter directory at startup.
2. **`cli()` is the only authoring API** (`src/registry-api.ts`). `registerCommand` is removed from the public export surface: it takes the raw/lazy manifest shape used by the manifest fast path, not the authoring shape, and adapters written against it died at execution with `has no func or pipeline`. It is undocumented and unused outside the runtime. An adapter importing it now fails loudly at load with the missing-export error, instead of registering a command that cannot run.
3. **Load failures are recorded and lead the error** (`src/discovery.ts`). Every failed import is kept with its site, absolute path, and cause; `missingPluginGuidance` reports those instead of `Site "X" is not installed.` when the site has failing files.
4. **`adapter status` agrees with availability** (`src/cli.ts`). Each row carries `loadError`; the table annotates `(failed to load: …)` and the JSON output gained a `loadError` field.

## Before / After

Before (`node dist/src/main.js`, `HOME` in a temp dir, adapter uses `registerCommand`):

```
$ webcmd quotes list
Site "quotes" is not installed.
Search: webcmd plugin search quotes
Install using the installSource returned by search.

$ webcmd adapter status
Local adapters in ~/.webcmd/clis/ (1 sites):

  quotes
    user adapter: quotes/list
```

After, same adapter:

```
$ webcmd quotes list
⚠  Failed to load adapter /tmp/…/.webcmd/clis/quotes/list.js: The requested module '@agentrhq/webcmd/registry' does not provide an export named 'registerCommand'
Site "quotes" has adapter files that failed to load:
  /tmp/…/.webcmd/clis/quotes/list.js
    The requested module '@agentrhq/webcmd/registry' does not provide an export named 'registerCommand'
Fix the file, then re-run. Adapters call cli({ ... }) from '@agentrhq/webcmd/registry'
and must declare access: 'read' | 'write' and func.

$ webcmd adapter status
Local adapters in ~/.webcmd/clis/ (1 sites):

  quotes
    user adapter: quotes/list (failed to load: The requested module '@agentrhq/webcmd/registry' does not provide an export named 'registerCommand')
```

After, same file rewritten with `cli({ …, access: 'read', func })`:

```
$ webcmd quotes list
- quote: hi
```

## Tests

`src/discovery.test.ts` gains five cases: a `cli()` adapter in a temp `HOME` registers; a file whose only `cli(` is a comment registers nothing and records no failure; a module missing `access` records the real cause and `missingPluginGuidance` leads with it rather than "is not installed"; an adapter importing `registerCommand` does not register and its failure names the export; failed files are recorded by the absolute path `adapter status` keys off. `src/cli.test.ts` covers the new `loadError` JSON field.

`npm run typecheck` clean. `npx vitest run --project unit`: 2708 passed, 1 skipped, 0 failed (the suite needs `npm run build` first — 120 hosted/manifest tests fail without `dist/` on `main` too). `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
