### PR TITLE
fix(observation): redact Basic/Negotiate/NTLM auth credentials in raw text, not just Bearer

### DIFF
--- a/src/observation/redaction.test.ts
+++ b/src/observation/redaction.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, it } from 'vitest';
-import { redactHeaders, redactUrl, redactValue } from './redaction.js';
+import { redactHeaders, redactText, redactUrl, redactValue } from './redaction.js';
 
 describe('observation redaction', () => {
+    it('redacts Basic/Negotiate/NTLM auth credentials in raw text, not just Bearer', () => {
+      expect(redactText('Authorization: Basic dXNlcjpwYXNzd29yZA=='))
+        .toBe('Authorization: Basic [REDACTED]');
+      expect(redactText('curl -H "Authorization: Basic dXNlcjpwYXNzd29yZA==" https://api.example.com'))
+        .toBe('curl -H "Authorization: Basic [REDACTED]" https://api.example.com');
+      expect(redactText('Authorization: Bearer abc.def.ghi'))
+        .toBe('Authorization: Bearer [REDACTED]');
+      expect(redactText('WWW-Authenticate: NTLM TlRMTVNTUAAB'))
+        .toBe('WWW-Authenticate: NTLM [REDACTED]');
+    });
+
   it('redacts sensitive headers by default', () => {
     expect(redactHeaders({
       authorization: 'Bearer secret-token',

--- a/src/observation/redaction.ts
+++ b/src/observation/redaction.ts
@@ -44,7 +44,12 @@ export function redactHeaders(headers: Record<string, unknown> | undefined, opts
 export function redactText(text: string, opts: RedactionOptions = {}): string {
   const max = opts.maxStringLength ?? 50_000;
   let out = text
-    .replace(/Bearer\s+[A-Za-z0-9\-._~+/]+=*/gi, 'Bearer [REDACTED]')
+    // HTTP auth schemes carry an opaque credential as their second token (RFC 7235).
+    // Bearer was the only scheme redacted here; Basic/Negotiate/NTLM leaked their
+    // credential verbatim into observation artifacts whenever it appeared in raw
+    // text (page content, titles, rendered command output) rather than in a
+    // structured headers object routed through redactHeaders.
+    .replace(/\b(Bearer|Basic|Negotiate|NTLM)\s+[A-Za-z0-9\-._~+/]+=*/gi, (_match, scheme: string) => `${scheme} [REDACTED]`)
     .replace(/(["'])(password|passwd|pwd|token|secret|api_key|apikey|access_token|session_id)\1\s*:\s*(["'])(.*?)\3/gi, '$1$2$1:$3[REDACTED]$3')
     .replace(/(token|secret|password|api_key|apikey|access_token|session_id)[=:]\s*['"]?[^'"\s,;}&]+['"]?/gi, '$1=[REDACTED]')
     .replace(/(cookie[=:]\s*)[^\n;]{3,}/gi, '$1[REDACTED]')


### PR DESCRIPTION
## What

`redactText()` in `src/observation/redaction.ts` only stripped the `Bearer`
auth scheme before writing raw text into observation artifacts. Basic,
Negotiate, and NTLM credentials passed through untouched:

    redactText('Authorization: Basic dXNlcjpwYXNzd29yZA==')
    // -> 'Authorization: Basic dXNlcjpwYXNzd29yZA==' (unredacted)

    redactText('Authorization: Bearer abc.def.ghi')
    // -> 'Authorization: Bearer [REDACTED]' (correctly redacted)

## Why it matters

`redactText` is the last line of defense for raw text that ends up in
stored observation artifacts — extracted page content, page titles, and
rendered command output (see `browser/run/runner.ts` and
`browser/runtime/local-cloak/actions.ts`) — as opposed to structured
header objects, which already go through `redactHeaders`. A page
displaying an HTTP Basic Auth header (API docs, a debug/status page, a
network trace echoed into visible content) would have that credential
captured verbatim in stored artifacts.

## Fix

Generalized the Bearer-only regex to cover the standard RFC 7235 auth
schemes (Bearer, Basic, Negotiate, NTLM), preserving the matched scheme
name in the redacted output:

    .replace(/\b(Bearer|Basic|Negotiate|NTLM)\s+[A-Za-z0-9\-._~+/]+=*/gi,
      (_match, scheme) => `${scheme} [REDACTED]`)

## Testing

- Added a regression test covering Basic, Bearer, and NTLM in
  `redaction.test.ts`.
- Ran the full unit suite before and after: 154 files / 2627 tests,
  all green, no regressions.