### PR TITLE
fix(cli): route unknown subcommands through the shared error envelope

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -69,6 +69,7 @@ vi.mock('node:child_process', async () => {
   };
 });
 
+import { handleProgramParseError } from './cli-error-report.js';
 import { createProgram, findPackageRoot, loadAntigravityServe, normalizeVerifyRows, renderVerifyPreview, resolveBrowserVerifyInvocation, resolveSitemapAvailabilityForUrl, selectFreshByTimestamp } from './cli.js';
 
 const realHome = process.env.HOME;
@@ -1184,15 +1185,25 @@ name: 'search',
     const errors: string[] = [];
     const spy = vi.spyOn(console, 'error').mockImplementation((msg: unknown) => { errors.push(String(msg)); });
     const previousExitCode = process.exitCode;
+    // A structural failure is thrown now, not printed from inside the parser;
+    // handleProgramParseError turns it into bytes exactly as runCli does.
+    const run = (argv: string[]): string => {
+      let output = '';
+      try {
+        createProgram('', '').parse(argv, { from: 'user' });
+      } catch (err) {
+        handleProgramParseError(err, { write: (value: string) => { output += value; return true; } } as never);
+      }
+      return `${output}${errors.join('\n')}`;
+    };
     try {
-      createProgram('', '').parse(['browser', 'fork', 'hackernews/top'], { from: 'user' });
-      expect(errors.join('\n')).toContain('webcmd adapter override <site>/<command>');
+      expect(run(['browser', 'fork', 'hackernews/top'])).toContain('webcmd adapter override <site>/<command>');
       expect(process.exitCode).toBe(EXIT_CODES.USAGE_ERROR);
 
       errors.length = 0;
-      createProgram('', '').parse(['browser', 'nonsense'], { from: 'user' });
-      expect(errors.join('\n')).toContain("error: unknown command 'nonsense'");
-      expect(errors.join('\n')).toContain('Valid webcmd browser commands:');
+      const nonsense = run(['browser', 'nonsense']);
+      expect(nonsense).toContain("error: unknown command 'nonsense'");
+      expect(nonsense).toContain('help: valid subcommands for `webcmd browser`:');
     } finally {
       spy.mockRestore();
       process.exitCode = previousExitCode;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ import './fetch/command.js';
 import { commandListPresentation, filterCommandsByTag, toPresentableCommand } from './command-presentation.js';
 import { configureCompletionCommandSurface, configureListCommandSurface, configurePluginInstallSurface, configurePluginListSurface, configurePluginSearchSurface } from './builtin-command-surface.js';
 import { formatPluginSearchEmptyCopy, presentPluginSearch } from './plugin-search-presentation.js';
-import { addOutputFormatOption, applyUnknownOptionContract, JSON_FORMAT_ALIAS_HELP, outputFormatIsExplicit, resolveCommandOutputFormat } from './command-surface.js';
+import { addOutputFormatOption, applyUnknownOptionContract, CommanderStructuralError, JSON_FORMAT_ALIAS_HELP, outputFormatIsExplicit, resolveCommandOutputFormat } from './command-surface.js';
 import { render as renderOutput } from './output.js';
 import { handleProgramParseError } from './cli-error-report.js';
 import { PKG_VERSION } from './version.js';
@@ -56,7 +56,7 @@ import { configureRootCommandSurface } from './root-command-surface.js';
 import { validateRawBrowserSession } from './hosted/browser-args.js';
 import { LocalBrowserSessionStore, requireSessionIdShape, type BrowserSessionListRow } from './browser/sessions.js';
 import { PLUGINS_DIR } from './discovery.js';
-import { unknownRootCommandMessage, unknownSubcommandMessage } from './command-suggest.js';
+import { unknownRootCommandMessage, unknownSubcommandHelp, unknownSubcommandMessage } from './command-suggest.js';
 import { loadBrowserRunSource } from './browser/run/input.js';
 import { BrowserRunError } from './browser/run/types.js';
 import { classifyCommandOrigin, formatCommandOrigin } from './command-origin.js';
@@ -2226,8 +2226,21 @@ cli({
   for (const namespace of program.commands) {
     if (namespace.commands.length === 0 || !SUGGEST_NAMESPACES.has(namespace.name())) continue;
     namespace.on('command:*', (operands: string[]) => {
-      console.error(unknownSubcommandMessage(namespace, operands[0]!));
-      process.exitCode = EXIT_CODES.USAGE_ERROR;
+      // Throw rather than print: handleProgramParseError owns the choice between
+      // human bytes and the machine envelope, so `--json` / `-f yaml` reach this
+      // failure the same way they reach every other usage error.
+      const name = operands[0]!;
+      const output = `${unknownSubcommandMessage(namespace, name)}\n`;
+      const help = unknownSubcommandHelp(namespace);
+      throw new CommanderStructuralError(output, EXIT_CODES.USAGE_ERROR, false, {
+        ok: false,
+        error: {
+          code: 'UNKNOWN_COMMAND',
+          message: `unknown command '${name}'`,
+          ...(help ? { help } : {}),
+          exitCode: EXIT_CODES.USAGE_ERROR,
+        },
+      });
     });
   }
 

--- a/src/command-suggest.test.ts
+++ b/src/command-suggest.test.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
+import { handleProgramParseError } from './cli-error-report.js';
 import { createProgram } from './cli.js';
 import { editDistance, unknownRootCommandMessage, unknownSubcommandMessage } from './command-suggest.js';
 
@@ -67,13 +68,13 @@ describe('unknown namespace subcommand', () => {
 
     expect(message).toContain("error: unknown command 'list'");
     expect(message).toContain('Did you mean: webcmd adapter status');
-    expect(message).toContain('Valid webcmd adapter commands: override, path, reset, source, status');
+    expect(message).toContain('help: valid subcommands for `webcmd adapter`: override, path, reset, source, status');
   });
 
   it('lists valid subcommands even when nothing is close enough to suggest', () => {
     const message = unknownSubcommandMessage(namespaceOf(createProgram('', ''), 'plugin'), 'zzzqqqwww');
 
-    expect(message).toContain('Valid webcmd plugin commands: catalog, create, install, list, search, uninstall, update');
+    expect(message).toContain('help: valid subcommands for `webcmd plugin`: catalog, create, install, list, search, uninstall, update');
   });
 
   it('names the replacement for a retired subcommand', () => {
@@ -97,7 +98,9 @@ describe('error paths write nothing to stdout', () => {
     });
     const stderr = vi.spyOn(console, 'error').mockImplementation(() => {});
     try {
-      await program.parseAsync(argv, { from: 'user' });
+      // Mirror runCli: a structural failure is thrown and rendered by
+      // handleProgramParseError, never printed from inside the parser.
+      await program.parseAsync(argv, { from: 'user' }).catch(handleProgramParseError);
       return { stdout, exitCode: process.exitCode };
     } finally {
       process.exitCode = previousExitCode;

--- a/src/command-suggest.ts
+++ b/src/command-suggest.ts
@@ -164,7 +164,21 @@ export function unknownSubcommandMessage(namespace: Command, name: string): stri
       if (suggestions.length > 0) lines.push(formatSuggestions(suggestions));
     }
   }
-  const valid = [...new Set(namespace.commands.map(child => child.name()))].sort();
-  if (valid.length > 0) lines.push(`Valid ${CLI_COMMAND} ${nsPath} commands: ${valid.join(', ')}`);
+  const help = unknownSubcommandHelp(namespace);
+  if (help) lines.push(`help: ${help}`);
   return lines.join('\n');
+}
+
+/**
+ * The `help:` body for an unknown subcommand, in the one wording the rest of the
+ * CLI uses for this failure (see `structuralHelpText` in command-surface.ts).
+ *
+ * Kept identical on purpose: the suggestion handler and Commander's own
+ * structural path both report "unknown subcommand", and an agent should not
+ * have to learn two spellings of the same sentence.
+ */
+export function unknownSubcommandHelp(namespace: Command): string | undefined {
+  const valid = [...new Set(namespace.commands.map(child => child.name()))].sort();
+  if (valid.length === 0) return undefined;
+  return `valid subcommands for \`${CLI_COMMAND} ${namespace.name()}\`: ${valid.join(', ')}`;
 }


### PR DESCRIPTION
## The problem

`main` is red. #421 and #424 each passed on their own branch; neither was run against the other.

```
× 'unknown subcommand' exits 2 with one stderr line and no envelope for humans
× 'unknown subcommand' renders a JSON envelope under --json
× renders a YAML envelope for -f yaml
```

#421 added a suggestion handler for unknown subcommands that calls `console.error` and sets `process.exitCode` directly. #424 built the shared envelope path that decides between human bytes and a machine envelope. Because #421's handler prints from inside the parser, it never reaches that path — so `webcmd adapter list rest --json` got human text instead of JSON, and the two paths spelled the same sentence differently (`Valid webcmd adapter commands:` vs `help: valid subcommands for \`webcmd adapter\`:`).

## What changed

1. The namespace `command:*` handler throws a `CommanderStructuralError` instead of printing. `handleProgramParseError` already owns the human-vs-envelope choice, so `--json` and `-f yaml` now reach this failure like every other usage error.
2. The error carries an `UNKNOWN_COMMAND` envelope with the suggestion's `help` body.
3. New `unknownSubcommandHelp()` is the single source for that sentence, matching `structuralHelpText()` in `command-surface.ts`. One wording, not two.
4. Three tests updated to the new wording, and two updated to render through `handleProgramParseError` rather than expecting the parser to print.

## Before / After

```
# BEFORE (main) — --json ignored
$ webcmd adapter list rest --json
error: unknown command 'list'
Did you mean: webcmd adapter status
Valid webcmd adapter commands: override, path, reset, source, status

# AFTER
$ webcmd adapter list rest
error: unknown command 'list'
Did you mean: webcmd adapter status
help: valid subcommands for `webcmd adapter`: override, path, reset, source, status

$ webcmd adapter list rest --json
{
  "ok": false,
  "error": {
    "code": "UNKNOWN_COMMAND",
    "message": "unknown command 'list'",
    "help": "valid subcommands for `webcmd adapter`: override, path, reset, source, status",
    "exitCode": 2
  }
}
```

Both exit 2. #421's suggestion survives; #424's envelope now fires.

## Tests

`npm run typecheck` clean. `npx vitest run --project unit` — **155 files, 2732 passed, 1 skipped, 0 failed** (was 3 failed on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
