### PR TITLE
fix(hosted): stop duplicating usage errors and align the subcommand list

### DIFF
--- a/src/command-surface.ts
+++ b/src/command-surface.ts
@@ -98,12 +98,23 @@ export function commandInvocationPath(command: Command): string {
   return names.join(' ');
 }
 
+/**
+ * Subcommand names for a `help:` line, in the one shape both modes emit.
+ *
+ * Sorted and without Commander's auto-generated `help` command: hosted mode
+ * builds this list from the manifest and has neither declaration order nor a
+ * `help` entry, so an unsorted local list drifted from the hosted one for no
+ * reason a caller could act on. What legitimately still differs is commands
+ * hosted mode cannot offer at all (LOCAL strategy).
+ */
 function visibleSubcommandNames(command: Command): string[] {
+  let names: string[];
   try {
-    return command.createHelp().visibleCommands(command).map(child => child.name());
+    names = command.createHelp().visibleCommands(command).map(child => child.name());
   } catch {
-    return command.commands.map(child => child.name());
+    names = command.commands.map(child => child.name());
   }
+  return [...new Set(names)].filter(name => name !== 'help').sort();
 }
 
 /** The `help:` body offered alongside a structural `error:` line — no prefix, no newline. */

--- a/src/hosted/root-command-surface.test.ts
+++ b/src/hosted/root-command-surface.test.ts
@@ -545,8 +545,10 @@ describe('hosted root preflight call order', () => {
     if (argv.join(' ') === 'list --help') {
       expect(stderr.text()).toBe(local.stderr);
     } else if (argv.join(' ') === 'list --unknown') {
+      // Hosted used to replay Commander's captured stderr on top of the
+      // formatted line and print `error:` twice. It matches local now.
+      expect(stderr.text()).toBe(local.stderr);
       expect(stderr.text()).toBe([
-        "error: unknown option '--unknown'",
         "error: unknown option '--unknown'",
         'help: valid flags for `webcmd list`: --tag, -f, --format, --json',
         '',
@@ -656,8 +658,8 @@ describe('hosted root preflight call order', () => {
       expect(stderr.text()).toBe(local.stderr);
       expect(local.stdout).toHaveLength(371);
     } else if (name === 'leaf version is unknown') {
+      expect(stderr.text()).toBe(local.stderr);
       expect(stderr.text()).toBe([
-        "error: unknown option '-V'",
         "error: unknown option '-V'",
         'help: valid flags for `webcmd completion`: -f, --format, --json',
         '',
@@ -791,7 +793,7 @@ describe('hosted root preflight call order', () => {
     expect(local).toMatchObject({
       exitCode: 2,
       stdout: '',
-      stderr: "error: unknown command 'bogus'\nhelp: valid subcommands for `webcmd github`: whoami, help\n",
+      stderr: "error: unknown command 'bogus'\nhelp: valid subcommands for `webcmd github`: whoami\n",
     });
     expect(hosted).toEqual({ handled: true, exitCode: local.exitCode });
     expect(stdout.text()).toBe(local.stdout);

--- a/src/hosted/runner.ts
+++ b/src/hosted/runner.ts
@@ -447,7 +447,9 @@ async function dispatchHosted(
     }
     // Same usage-error contract as the local CLI: exit 2 plus the valid
     // subcommands for the site, not a trailing UNKNOWN/exit-1 envelope.
-    const known = hostedCommands(manifest).filter(entry => entry.site === site).map(entry => entry.name);
+    // Same shape as the local `help:` line (see visibleSubcommandNames): sorted,
+    // no `help` entry. Commands hosted mode cannot run are genuinely absent.
+    const known = [...new Set(hostedCommands(manifest).filter(entry => entry.site === site).map(entry => entry.name))].sort();
     const help = known.length > 0 ? `help: valid subcommands for \`webcmd ${site}\`: ${known.join(', ')}\n` : '';
     throw new CommanderCompatibleError(
       `error: unknown command '${commandName}'\n${help}`,
@@ -1185,9 +1187,11 @@ function parseHostedListSurface(argv: readonly string[], literal: boolean): Pars
   } catch (error) {
     if (!(error instanceof CommanderError)) throw error;
     if (error.code === 'commander.helpDisplayed') return { kind: 'help', output: stdout };
+    // No includeCapturedStderrForUnknownOption: structuralErrorFromCommander
+    // now formats the `error:` line itself, so replaying Commander's captured
+    // stderr on top printed the same line twice in hosted mode only.
     throw structuralErrorFromCommander(error, resolveCommandFromArgv(root, ['list', ...argv]), stderr, {
       appendErrorEnvelope: true,
-      includeCapturedStderrForUnknownOption: true,
     });
   }
   if (!actionRan) throw new CommanderStructuralError("error: command 'list' did not run\n", 1);
@@ -1380,7 +1384,6 @@ function parseHostedCompletionSurface(
     if (error.code === 'commander.helpDisplayed') return { kind: 'help', output: stdout };
     throw structuralErrorFromCommander(error, resolveCommandFromArgv(root, ['completion', ...argv]), stderr, {
       appendErrorEnvelope: true,
-      includeCapturedStderrForUnknownOption: true,
     });
   }
   if (shell === undefined) {


### PR DESCRIPTION
## The problem

webcmd-cloud's parity suite, run against this repo's `main`, found two ways hosted mode drifted from local after #424/#427. Both are hosted-only; local was already correct.

**1. Hosted printed every unknown-option error twice.**

```
local                               hosted
error: unknown option '--unknown'   error: unknown option '--unknown'
help: valid flags for ...           error: unknown option '--unknown'   ← twice
                                    help: valid flags for ...
```

`src/hosted/runner.ts` still passed `includeCapturedStderrForUnknownOption: true`. Since #424, `structuralErrorFromCommander` formats the `error:` line itself, so replaying Commander's captured stderr on top printed it a second time — the exact duplicate #424 removed on the local path.

**2. The `help:` subcommand list was spelled differently on each side.**

```
local:  echo, empty, null, scalar, presentation, fail, session-busy, large, local-only, help
hosted: echo, empty, fail, large, null, presentation, scalar, session-busy
```

Local used Commander's declaration order and included the auto-generated `help` entry; hosted built its list from the manifest and had neither. Two implementations of one sentence.

## What changed

1. Dropped `includeCapturedStderrForUnknownOption` at both `src/hosted/runner.ts` call sites (`list`, `completion`).
2. `visibleSubcommandNames` now sorts, de-duplicates, and drops Commander's `help` entry.
3. The hosted list sorts and de-duplicates the same way.
4. Four assertions in `src/hosted/root-command-surface.test.ts` updated — they were pinning the duplicated line and the `help` entry as expected output.

After this, the only difference left between the two lists is commands hosted mode genuinely cannot run (LOCAL strategy) — a real capability boundary, not drift.

## Before / After

```
# BEFORE — hosted
error: unknown option '-V'
error: unknown option '-V'
help: valid flags for `webcmd completion`: -f, --format, --json

# AFTER — hosted, byte-identical to local
error: unknown option '-V'
help: valid flags for `webcmd completion`: -f, --format, --json
```

```
# AFTER — same order, same shape; only `local-only` differs, and legitimately
local:  help: valid subcommands for `webcmd parity`: echo, empty, fail, large, local-only, null, presentation, scalar, session-busy
hosted: help: valid subcommands for `webcmd parity`: echo, empty, fail, large, null, presentation, scalar, session-busy
```

## Tests

`npm run typecheck` clean. `npx vitest run --project unit` — **156 files, 2747 passed, 1 skipped, 0 failed.**

Cross-checked against webcmd-cloud by packing this branch and running its parity suite: the two duplicate-line failures are gone. What remains there is digest re-baselining plus the `local-only` capability delta, handled in the companion cloud PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
