### PR TITLE
fix(cli): resolve installSource from the catalog and name the data: popup block

### DIFF
--- a/src/browser/command-catalog.ts
+++ b/src/browser/command-catalog.ts
@@ -25,10 +25,15 @@ Examples:
     await page.locator('input[type=file]').setInputFiles('/tmp/upload.pdf');
 
   Track popups and new pages:
-    const popupPromise = context.waitForEvent('page');
+    const popupPromise = context.waitForEvent('page', { timeout: 5000 });
     await page.getByRole('link', { name: 'Open' }).click();
     const popup = await popupPromise;
     await popup.waitForLoadState();
+
+  Chrome blocks top-level data: navigation, so window.open('data:...') creates no
+  tab and no popup event ever fires. Open one yourself instead:
+    const receipt = await context.newPage();
+    await receipt.goto(receiptUrl);
 
 Sandbox:
   Node require/fs are not available inside browser run. Return structured data,

--- a/src/browser/run/runner.test.ts
+++ b/src/browser/run/runner.test.ts
@@ -945,6 +945,16 @@ afterAll(async () => {
     });
   });
 
+  it('names the data: URL block in the popup hint', () => {
+    // Chrome refuses top-level data: navigation, so window.open('data:...')
+    // creates no target and no popup event ever fires — while still returning a
+    // Window object, which is why page code looks like it worked. An agent that
+    // is not told this retries the same click.
+    expect(POPUP_WAIT_TIMEOUT_HINT).toContain('data:');
+    expect(POPUP_WAIT_TIMEOUT_HINT).toContain('context.newPage()');
+    expect(POPUP_WAIT_TIMEOUT_HINT).not.toMatch(/page\.goto on the current page/);
+  });
+
   it('cancels an in-flight run through its abort signal', async () => {
     const controller = new AbortController();
     const pending = run(`await page.waitForEvent('popup');`, {

--- a/src/browser/run/runner.ts
+++ b/src/browser/run/runner.ts
@@ -57,7 +57,12 @@ const PLAYWRIGHT_CLIENT_SOURCE = fs.readFileSync(
 
 const GENERIC_TIMEOUT_HINT = 'Split the task into a smaller run or increase --timeout.';
 export const DOWNLOAD_WAIT_TIMEOUT_HINT = 'A timed-out download wait is not a license to invent file contents. If a download event fired, use download.saveAs(suggestedFilename()). If none fired, report that gap. Do not rebuild the file from page logic.';
-export const POPUP_WAIT_TIMEOUT_HINT = 'A missing popup is not recovered with page.goto on the current page. Open a tracked tab with context.newPage(), then goto the destination URL on that new page. Cap waitForEvent(\'popup\') with a short timeout.';
+export const POPUP_WAIT_TIMEOUT_HINT = [
+  'No popup or tab was created.',
+  'Chrome blocks top-level data: navigation, so window.open("data:...") opens nothing — it still returns a Window object, so page code that checks the return value looks like it succeeded.',
+  'Recovery is the same either way: open a tracked tab with context.newPage(), then goto the destination URL on that new page. Do not page.goto on the opener.',
+  "Cap waitForEvent('popup') with a short timeout instead of the default.",
+].join(' ');
 const NO_CAPTURE_HINT = 'The program completed without captured evidence; return structured data, console.log concise evidence, or call writeArtifact(filename, bytes) to save files.';
 const NODE_SANDBOX_HINT = 'Node require/fs are not available inside browser run. Use Playwright page/context/browser APIs, page.request for HTTP, or writeArtifact(filename, bytes) for files.';
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1274,7 +1274,7 @@ name: 'search',
     expect(help).toContain("await page.goto('data:text/html,");
     expect(help).toContain("await download.saveAs(download.suggestedFilename())");
     expect(help).toContain("await page.locator('input[type=file]').setInputFiles('/tmp/upload.pdf')");
-    expect(help).toContain("const popupPromise = context.waitForEvent('page')");
+    expect(help).toContain("const popupPromise = context.waitForEvent('page', { timeout: 5000 })");
     expect(help).toContain('Node require/fs are not available inside browser run');
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1499,6 +1499,8 @@ cli({
         });
       } catch (err) {
         console.error(`Error: ${getErrorMessage(err)}`);
+        const resolved = await installSourceSuggestion(err, source);
+        if (resolved) console.error(resolved);
         process.exitCode = EXIT_CODES.GENERIC_ERROR;
       }
     });
@@ -2424,6 +2426,31 @@ cli({
   }
 
   return program;
+}
+
+/**
+ * Turn "Invalid plugin source" into the command that actually installs it.
+ *
+ * `plugin search` reports a name and an installSource; agents pass the name,
+ * because that is the memorable half. Rather than reprint the format list and
+ * leave them to guess, look the name up and hand back the exact source. A
+ * catalog lookup needs the network, so any failure degrades to the search hint
+ * — never to a worse error than the one already printed.
+ */
+async function installSourceSuggestion(err: unknown, source: string): Promise<string | undefined> {
+  const { InvalidPluginSourceError, looksLikePluginName } = await import('./plugin.js');
+  if (!(err instanceof InvalidPluginSourceError) || !looksLikePluginName(source)) return undefined;
+  try {
+    const { readCatalog, searchCatalogPlugins } = await import('./plugin-catalog.js');
+    const { plugins } = await searchCatalogPlugins(readCatalog(), { query: source });
+    const exact = plugins.filter(plugin => plugin.name.toLowerCase() === source.toLowerCase());
+    if (exact.length === 1 && exact[0]!.installSource) {
+      return `help: "${source}" is in the catalog. Install it with:\n  ${CLI_COMMAND} plugin install ${exact[0]!.installSource}`;
+    }
+  } catch {
+    // Catalog unreachable: fall through to the generic hint.
+  }
+  return `help: "${source}" looks like a plugin name, not a source. Find its installSource with:\n  ${CLI_COMMAND} plugin search ${source}`;
 }
 
 export async function loadAntigravityServe(pluginsDir: string = PLUGINS_DIR): Promise<{

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -2336,3 +2336,24 @@ describe('listPlugins override reporting', () => {
     });
   });
 });
+
+describe('invalid plugin source', () => {
+  it('flags a bare plugin name so the CLI can resolve its installSource', () => {
+    expect(pluginModule.looksLikePluginName('openfda')).toBe(true);
+    expect(pluginModule.looksLikePluginName('rest-countries')).toBe(true);
+    // Anything with a scheme, slash or space is a malformed source, not a name.
+    expect(pluginModule.looksLikePluginName('github:user/repo')).toBe(false);
+    expect(pluginModule.looksLikePluginName('/abs/path')).toBe(false);
+    expect(pluginModule.looksLikePluginName('some junk')).toBe(false);
+  });
+
+  it('raises InvalidPluginSourceError carrying the source', () => {
+    expect(() => pluginModule.installPlugin('openfda')).toThrow(pluginModule.InvalidPluginSourceError);
+    try {
+      pluginModule.installPlugin('openfda');
+    } catch (err) {
+      expect((err as pluginModule.InvalidPluginSourceError).source).toBe('openfda');
+      expect((err as Error).message).toContain('Invalid plugin source: "openfda"');
+    }
+  });
+});

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -871,7 +871,28 @@ function publishMonorepoPlugins(
 export function installPlugin(source: string, options: { all?: boolean } = {}): string | string[] {
   const parsed = parseSource(source);
   if (!parsed) {
-    throw new Error(
+    throw new InvalidPluginSourceError(source);
+  }
+  return installParsedPlugin(parsed, source, options);
+}
+
+/** A bare token like `openfda` — a plugin NAME, not a source. Worth a catalog lookup. */
+export function looksLikePluginName(source: string): boolean {
+  return /^[a-z0-9][a-z0-9-]*$/i.test(source);
+}
+
+/**
+ * Raised when `plugin install` is handed something that is not a source.
+ *
+ * Agents reliably type the plugin name here, because that is what `plugin
+ * search` shows them first. The format list alone left them guessing; the CLI
+ * layer catches this and resolves the real installSource from the catalog.
+ */
+export class InvalidPluginSourceError extends Error {
+  readonly source: string;
+
+  constructor(source: string) {
+    super(
       `Invalid plugin source: "${source}"\n` +
       `Supported formats:\n` +
       `  github:user/repo\n` +
@@ -883,8 +904,16 @@ export function installPlugin(source: string, options: { all?: boolean } = {}): 
       `  file:///absolute/path\n` +
       `  /absolute/path`
     );
+    this.name = 'InvalidPluginSourceError';
+    this.source = source;
   }
+}
 
+function installParsedPlugin(
+  parsed: NonNullable<ReturnType<typeof parseSource>>,
+  source: string,
+  options: { all?: boolean } = {},
+): string | string[] {
   const { name: repoName, subPlugin } = parsed;
 
   if (parsed.type === 'local') {


### PR DESCRIPTION
## The problem

The two friction points that survived the task-eval re-run and cost points in both runs.

**1. `plugin install <name>` is a dead end.**

```
$ webcmd plugin install openfda
Error: Invalid plugin source: "openfda"
Supported formats:
  github:user/repo
  github:user/repo/subplugin
  ... 6 more
```

`plugin search` reports a name and an installSource. The name is the memorable half, so that is what gets typed here. Eight formats and no indication which one applies to `openfda`.

**2. A popup wait after `window.open('data:...')` times out for an unexplained reason.**

Chrome blocks top-level `data:` navigation, so `window.open('data:...')` creates no target and no popup event can ever fire. `window.open` still returns a Window object, so the page's own code looks like it succeeded. The old hint said "a missing popup is not recovered with page.goto" — true, but it never said *why nothing appeared*, so the agent burned 30s and then guessed.

I verified the runtime is not at fault before changing anything:

```
window.open('https://example.com/') → GOT_PAGE:https://example.com/, context.pages() = 2
window.open('data:text/html,...')   → TIMEOUT,                       context.pages() = 1
                                      window.open returned "[object Window]"
```

Popup tracking works. The bug was the diagnostic.

## What changed

1. `installPlugin` throws a typed `InvalidPluginSourceError`; `looksLikePluginName` identifies a bare token like `openfda`.
2. On that error the CLI searches the catalog and prints the exact install command. Network failure or no match degrades to the `plugin search` hint — never to a worse error than the one already shown.
3. `POPUP_WAIT_TIMEOUT_HINT` names the `data:` block, the misleading `Window` return value, and the recovery.
4. `browser run --help` documents the same thing, with a short `timeout` on the example so nobody inherits the 30s default.

Sources that are not bare names keep their existing error exactly.

## Before / After

```
# BEFORE
$ webcmd plugin install openfda
Error: Invalid plugin source: "openfda"
Supported formats:
  ...

# AFTER
$ webcmd plugin install openfda
Error: Invalid plugin source: "openfda"
Supported formats:
  ...
help: "openfda" is in the catalog. Install it with:
  webcmd plugin install github:agentrhq/webcmd/openfda

# AFTER — not in the catalog
$ webcmd plugin install not-a-real-plugin-xyz
help: "not-a-real-plugin-xyz" looks like a plugin name, not a source. Find its installSource with:
  webcmd plugin search not-a-real-plugin-xyz
```

```
# AFTER — real run against a data: page
"code": "BROWSER_RUN_TIMEOUT",
"hint": "No popup or tab was created. Chrome blocks top-level data: navigation, so
         window.open(\"data:...\") opens nothing — it still returns a Window object, so page
         code that checks the return value looks like it succeeded. Recovery is the same
         either way: open a tracked tab with context.newPage(), then goto the destination
         URL on that new page. Do not page.goto on the opener. Cap waitForEvent('popup')
         with a short timeout instead of the default."
```

## Tests

`npm run typecheck` clean. `npx vitest run --project unit` — **156 files, 2750 passed, 1 skipped, 0 failed.**

New: `looksLikePluginName` accepts names and rejects sources; `installPlugin` raises `InvalidPluginSourceError` carrying the source; the popup hint names `data:` and `context.newPage()`. One existing `browser run --help` assertion updated for the `timeout` added to the example.

Both paths were also exercised by hand against a live Cloak session; the output above is real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
