### PR TITLE
fix(cli): do not report a cross-Profile session close as already closed

### DIFF
--- a/src/browser/sessions.test.ts
+++ b/src/browser/sessions.test.ts
@@ -74,6 +74,14 @@ describe('LocalBrowserSessionStore', () => {
     }));
   });
 
+  it('findOwner names the owning profile without scoping to a selected one', () => {
+    const store = new LocalBrowserSessionStore({ baseDir: tempDir(), idFactory: () => 'session_a' });
+    const created = store.create('profile_work');
+
+    expect(store.findOwner(created.id)).toBe('profile_work');
+    expect(store.findOwner('session_missing')).toBeUndefined();
+  });
+
   it('keeps the generic hint when no profile owns the session', () => {
     const store = new LocalBrowserSessionStore({ baseDir: tempDir() });
 

--- a/src/browser/sessions.ts
+++ b/src/browser/sessions.ts
@@ -83,6 +83,11 @@ export class LocalBrowserSessionStore {
     return { ...record };
   }
 
+  /** Profile that owns this Session ID, regardless of which one is selected. */
+  findOwner(sessionId: string): string | undefined {
+    return findOwnerProfileId(this.load(), sessionId);
+  }
+
   find(profileId: string, sessionId: string): BrowserSessionRecord | undefined {
     requireSessionIdShape(sessionId);
     const state = this.load();

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2524,6 +2524,33 @@ describe('browser Session lifecycle commands', () => {
     });
   });
 
+  it('names the owning Profile instead of reporting a cross-Profile close as done', async () => {
+    // Idempotent close must not swallow a Session that plainly exists next
+    // door: reporting alreadyClosed there leaves the Session open while the
+    // agent believes cleanup ran.
+    mockSendCommand.mockRejectedValueOnce(new Error('daemon unavailable'));
+    const baseDir = path.join(isolatedCliTestHome, '.webcmd');
+    fs.mkdirSync(baseDir, { recursive: true });
+    fs.writeFileSync(path.join(baseDir, 'browser-sessions.json'), JSON.stringify({
+      version: 1,
+      sessions: [{
+        id: 'session_owned',
+        profileId: 'work',
+        kind: 'explicit',
+        createdAt: '2026-08-11T00:00:00.000Z',
+        updatedAt: '2026-08-11T00:00:00.000Z',
+        lastUsedAt: '2026-08-11T00:00:00.000Z',
+      }],
+    }), { mode: 0o600 });
+
+    await expect(
+      createProgram('', '').parseAsync(['node', 'webcmd', 'session', 'close', 'session_owned', '-f', 'json']),
+    ).rejects.toMatchObject({
+      code: 'SESSION_NOT_FOUND',
+      ownerProfileId: 'work',
+    });
+  });
+
   it('closes a missing Session idempotently instead of failing', async () => {
     mockSendCommand.mockRejectedValueOnce(new Error('daemon unavailable'));
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,7 +54,7 @@ import type { BrowserDownloadWaitResult, IPage, ScreenshotOptions } from './type
 import type { BrowserWindowMode } from './runtime.js';
 import { configureRootCommandSurface } from './root-command-surface.js';
 import { validateRawBrowserSession } from './hosted/browser-args.js';
-import { LocalBrowserSessionStore, requireSessionIdShape, type BrowserSessionListRow } from './browser/sessions.js';
+import { LocalBrowserSessionStore, SessionNotFoundError, requireSessionIdShape, type BrowserSessionListRow } from './browser/sessions.js';
 import { getAdapterLoadFailures, PLUGINS_DIR } from './discovery.js';
 import { unknownRootCommandMessage, unknownSubcommandHelp, unknownSubcommandMessage } from './command-suggest.js';
 import { loadBrowserRunSource } from './browser/run/input.js';
@@ -988,6 +988,13 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string, pluginsDi
         // Closing an already-closed / reaped / never-existed Session is a no-op,
         // not a failure: cleanup must stay idempotent for unattended agents.
         if (!isSessionMissingError(error)) throw error;
+        // A Session that exists under another Profile is the one case that must
+        // not report success: the Session stays open, so "alreadyClosed" tells
+        // an unattended agent its cleanup ran when nothing was closed.
+        const owner = new LocalBrowserSessionStore().findOwner(sessionId);
+        if (owner !== undefined && owner !== profileId) {
+          throw new SessionNotFoundError(sessionId, profileId, owner);
+        }
         await renderOutput(
           { ok: true, closed: false, alreadyClosed: true, session: sessionId },
           { fmt, fmtExplicit: outputFormatIsExplicit(command) },


### PR DESCRIPTION
Stacked on #406 — it needs the `ownerProfileId` argument that PR adds to `SessionNotFoundError`. The diff below collapses to the last commit once #406 merges.

## Problem

#420 made `session close` idempotent: an unknown Session ID resolves with `{ok: true, closed: false, alreadyClosed: true}` and exit 0, so unattended cleanup does not fail on an already-reaped Session. That is the right behavior for a Session that is genuinely gone.

The swallow is too wide. A Session ID only ever resolves inside the selected Profile, so a cleanup command that omits `--profile` lands on the same `SESSION_NOT_FOUND` path as a missing Session — and is told the work is done:

```
$ webcmd session close session_abc      # created under --profile work
{ "ok": true, "closed": false, "alreadyClosed": true, "session": "session_abc" }
```

The Session is still open. The agent believes cleanup ran. #388's original retry loop is gone, but it was replaced by a silent leak — arguably the worse failure for unattended runs, because nothing surfaces at all.

## Fix

- `LocalBrowserSessionStore.findOwner()` returns the owning Profile for a Session ID without scoping to a selected Profile. Every Profile's Sessions share one `browser-sessions.json`, so this is a local read — no daemon or provider round trip.
- `session close` consults it before rendering `alreadyClosed`. When a different Profile owns the ID, it throws `SESSION_NOT_FOUND` naming the owner and the exact `--profile <owner>` retry (the message #406 adds) instead of claiming success.
- Unknown, reaped, and never-existed IDs are untouched: still idempotent, still exit 0. Malformed selectors still fail as `INVALID_SESSION_SELECTOR` / exit 2.

Closes the remaining gap from #388.

## Test plan

- `npm run typecheck` — clean.
- `npx vitest run --project unit` — 156 files / 2756 tests pass.
- New: `cli.test.ts` covers the cross-Profile close rejecting with `ownerProfileId`; `sessions.test.ts` covers `findOwner` hit and miss. The existing idempotent-close and root-`--session` cases from #420 still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)