### PR TITLE
feat(hosted): add authenticated artifact download command

### DIFF
--- a/docs/cli-reference.mdx
+++ b/docs/cli-reference.mdx
@@ -124,6 +124,16 @@ Reusable adapters continue to use the existing `IPage` API. Playwright-style
 programs are for reconnaissance and ad-hoc multi-step work; they are not pasted
 into adapter modules.
 
+Hosted `browser run` receipts keep the `cloud-artifact://` locator and add an
+authenticated `downloadUrl`. Download later with:
+
+```bash
+webcmd artifact download <download-url> --output <local-path>
+```
+
+`--output` is required. Webcmd authenticates to the configured Cloud API.
+Ordinary `curl` is neither required nor automatically authenticated.
+
 ## Top-Level Commands
 
 | Command | Purpose |
@@ -132,6 +142,7 @@ into adapter modules.
 | `setup` | Choose local or hosted mode interactively. |
 | `doctor` | Diagnose browser bridge and daemon connectivity. |
 | `daemon` | Manage the local Webcmd daemon: status, stop, and restart. |
+| `artifact` | Download a hosted execution artifact to `--output`. |
 | `browser` | Agent-facing browser runtime for exploration and verification. |
 | `web` | Local URL fetch helpers. |
 | `profile` | List, rename, and select browser runtime profiles. |

--- a/skill-src/cli/webcmd-browser/references/browser-run-playwright.src.md
+++ b/skill-src/cli/webcmd-browser/references/browser-run-playwright.src.md
@@ -107,9 +107,18 @@ came from `writeArtifact`, `saveAs`, or `screenshot`:
 
 Locally the bytes land at `~/.webcmd/cache/browser-run/<artifactId>/<filename>` (under
 `$WEBCMD_CACHE_DIR/browser-run` when that is set), readable once `run` has returned. Hosted
-runs use the same receipt shape with a `cloud-artifact://` locator backed by the execution's
-trace artifact store. The receipt never carries the bytes themselves, so return the receipt —
+runs use the same receipt shape with a `cloud-artifact://` locator plus an authenticated
+HTTPS `downloadUrl`. The receipt never carries the bytes themselves, so return the receipt —
 or just read it off `artifacts` — rather than trying to return file contents through `result`.
+
+Download a hosted artifact later with:
+
+```text
+webcmd artifact download <download-url> --output <local-path>
+```
+
+`--output` is required. Webcmd supplies hosted authentication. Ordinary `curl` is neither
+required nor automatically authenticated; the URL alone does not grant access.
 
 ## Errors
 

--- a/skills/webcmd-browser/references/browser-run-playwright.md
+++ b/skills/webcmd-browser/references/browser-run-playwright.md
@@ -107,9 +107,18 @@ came from `writeArtifact`, `saveAs`, or `screenshot`:
 
 Locally the bytes land at `~/.webcmd/cache/browser-run/<artifactId>/<filename>` (under
 `$WEBCMD_CACHE_DIR/browser-run` when that is set), readable once `run` has returned. Hosted
-runs use the same receipt shape with a `cloud-artifact://` locator backed by the execution's
-trace artifact store. The receipt never carries the bytes themselves, so return the receipt —
+runs use the same receipt shape with a `cloud-artifact://` locator plus an authenticated
+HTTPS `downloadUrl`. The receipt never carries the bytes themselves, so return the receipt —
 or just read it off `artifacts` — rather than trying to return file contents through `result`.
+
+Download a hosted artifact later with:
+
+```text
+webcmd artifact download <download-url> --output <local-path>
+```
+
+`--output` is required. Webcmd supplies hosted authentication. Ordinary `curl` is neither
+required nor automatically authenticated; the URL alone does not grant access.
 
 ## Errors
 

--- a/src/browser/run/types.ts
+++ b/src/browser/run/types.ts
@@ -25,6 +25,7 @@ export interface BrowserRunArtifactReceipt {
   contentType: string;
   byteSize: number;
   locator: string;
+  downloadUrl?: string;
 }
 
 export interface BrowserRunArtifactSink {

--- a/src/completion-shared.ts
+++ b/src/completion-shared.ts
@@ -40,6 +40,7 @@ export const HOSTED_ROOT_HELP: RootHelpPresentation = {
     { flags: '-h, --help', description: 'Display help for command' },
   ],
   commands: [
+    { name: 'artifact', description: 'Download a hosted execution artifact to a local path' },
     { name: 'browser', description: 'Browser control through a hosted browser session' },
     { name: 'completion <shell>', description: 'Output a shell completion script' },
     { name: 'list', description: 'List all available hosted CLI commands' },

--- a/src/hosted/artifact-download.ts
+++ b/src/hosted/artifact-download.ts
@@ -1,0 +1,75 @@
+import { ArgumentError } from '../errors.js';
+import { CLI_COMMAND } from '../brand.js';
+import { writeToStream } from '../stream-write.js';
+import type { HostedClient } from './client.js';
+import type { HostedFileIo } from './file-io.js';
+
+const HELP = `Usage: ${CLI_COMMAND} artifact download <download-url> --output <local-path>
+
+Download a hosted execution artifact using Webcmd authentication.
+--output is required. Ordinary curl is not authenticated.
+`;
+
+export async function runHostedArtifactDownload(
+  argv: readonly string[],
+  client: HostedClient,
+  stdout: NodeJS.WritableStream,
+  fileIo: HostedFileIo,
+): Promise<void> {
+  const parsed = parseArtifactDownloadArgv(argv);
+  if (parsed.kind === 'help') {
+    await writeToStream(stdout, HELP);
+    return;
+  }
+  const body = await client.downloadArtifactFromUrl(parsed.url);
+  await fileIo.writeFile(parsed.output, body);
+  await writeToStream(stdout, `${parsed.output}\n`);
+}
+
+function parseArtifactDownloadArgv(
+  argv: readonly string[],
+): { kind: 'help' } | { kind: 'run'; url: string; output: string } {
+  if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') return { kind: 'help' };
+  if (argv[0] !== 'download') {
+    throw new ArgumentError(
+      `unknown artifact command '${argv[0]}'`,
+      `Use: ${CLI_COMMAND} artifact download <download-url> --output <local-path>`,
+    );
+  }
+  const rest = argv.slice(1);
+  if (rest.includes('--help') || rest.includes('-h')) return { kind: 'help' };
+  let url: string | undefined;
+  let output: string | undefined;
+  for (let i = 0; i < rest.length; i += 1) {
+    const token = rest[i]!;
+    if (token === '--output' || token === '-o') {
+      const value = rest[i + 1];
+      if (value === undefined) throw new ArgumentError('option \'--output <local-path>\' argument missing');
+      output = value;
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--output=')) {
+      output = token.slice('--output='.length);
+      continue;
+    }
+    if (token.startsWith('-')) {
+      throw new ArgumentError(`unknown option '${token}'`);
+    }
+    if (url !== undefined) throw new ArgumentError(`unexpected argument '${token}'`);
+    url = token;
+  }
+  if (!url) {
+    throw new ArgumentError(
+      'missing required argument \'download-url\'',
+      `Use: ${CLI_COMMAND} artifact download <download-url> --output <local-path>`,
+    );
+  }
+  if (!output) {
+    throw new ArgumentError(
+      '--output is required',
+      `Use: ${CLI_COMMAND} artifact download <download-url> --output <local-path>`,
+    );
+  }
+  return { kind: 'run', url, output };
+}

--- a/src/hosted/artifact-download.ts
+++ b/src/hosted/artifact-download.ts
@@ -1,5 +1,7 @@
 import { ArgumentError } from '../errors.js';
 import { CLI_COMMAND } from '../brand.js';
+import { parseOutputFormat } from '../command-surface.js';
+import { render as renderOutput } from '../output.js';
 import { writeToStream } from '../stream-write.js';
 import type { HostedClient } from './client.js';
 import type { HostedFileIo } from './file-io.js';
@@ -23,12 +25,17 @@ export async function runHostedArtifactDownload(
   }
   const body = await client.downloadArtifactFromUrl(parsed.url);
   await fileIo.writeFile(parsed.output, body);
+  const payload = { output: parsed.output, bytes: body.byteLength };
+  if (parsed.formatExplicit) {
+    await renderOutput(payload, { fmt: parsed.format, fmtExplicit: true, stdout });
+    return;
+  }
   await writeToStream(stdout, `${parsed.output}\n`);
 }
 
 function parseArtifactDownloadArgv(
   argv: readonly string[],
-): { kind: 'help' } | { kind: 'run'; url: string; output: string } {
+): { kind: 'help' } | { kind: 'run'; url: string; output: string; format: string; formatExplicit: boolean } {
   if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') return { kind: 'help' };
   if (argv[0] !== 'download') {
     throw new ArgumentError(
@@ -40,6 +47,7 @@ function parseArtifactDownloadArgv(
   if (rest.includes('--help') || rest.includes('-h')) return { kind: 'help' };
   let url: string | undefined;
   let output: string | undefined;
+  let format: string | undefined;
   for (let i = 0; i < rest.length; i += 1) {
     const token = rest[i]!;
     if (token === '--output' || token === '-o') {
@@ -51,6 +59,21 @@ function parseArtifactDownloadArgv(
     }
     if (token.startsWith('--output=')) {
       output = token.slice('--output='.length);
+      continue;
+    }
+    if (token === '--format' || token === '-f') {
+      const value = rest[i + 1];
+      if (value === undefined) throw new ArgumentError('option \'--format <format>\' argument missing');
+      format = parseOutputFormat(value);
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--format=')) {
+      format = parseOutputFormat(token.slice('--format='.length));
+      continue;
+    }
+    if (token === '--json') {
+      format = 'json';
       continue;
     }
     if (token.startsWith('-')) {
@@ -71,5 +94,5 @@ function parseArtifactDownloadArgv(
       `Use: ${CLI_COMMAND} artifact download <download-url> --output <local-path>`,
     );
   }
-  return { kind: 'run', url, output };
+  return { kind: 'run', url, output, format: format ?? 'table', formatExplicit: format !== undefined };
 }

--- a/src/hosted/artifact-url.test.ts
+++ b/src/hosted/artifact-url.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { parseExecutionArtifactDownloadUrl } from './artifact-url.js';
+
+const apiBaseUrl = 'https://api.example.com';
+
+describe('parseExecutionArtifactDownloadUrl', () => {
+  it('extracts execution and artifact ids from the approved route', () => {
+    expect(parseExecutionArtifactDownloadUrl(
+      'https://api.example.com/v1/executions/exec_1/artifacts/trace_a',
+      apiBaseUrl,
+    )).toEqual({ executionId: 'exec_1', artifactId: 'trace_a' });
+  });
+
+  it('rejects a foreign origin before any request is implied', () => {
+    expect(() => parseExecutionArtifactDownloadUrl(
+      'https://evil.example/v1/executions/exec_1/artifacts/trace_a',
+      apiBaseUrl,
+    )).toThrow(/origin/i);
+  });
+
+  it('rejects a malformed path', () => {
+    expect(() => parseExecutionArtifactDownloadUrl(
+      'https://api.example.com/v1/artifacts/trace_a',
+      apiBaseUrl,
+    )).toThrow(/path/i);
+  });
+});

--- a/src/hosted/artifact-url.test.ts
+++ b/src/hosted/artifact-url.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { ArgumentError } from '../errors.js';
 import { parseExecutionArtifactDownloadUrl } from './artifact-url.js';
 
 const apiBaseUrl = 'https://api.example.com';
@@ -23,5 +24,19 @@ describe('parseExecutionArtifactDownloadUrl', () => {
       'https://api.example.com/v1/artifacts/trace_a',
       apiBaseUrl,
     )).toThrow(/path/i);
+  });
+
+  it('rejects malformed percent-encoding as an argument error', () => {
+    expect(() => parseExecutionArtifactDownloadUrl(
+      'https://api.example.com/v1/executions/exec_%ZZ/artifacts/trace_a',
+      apiBaseUrl,
+    )).toThrow(ArgumentError);
+  });
+
+  it('accepts the configured API pathname prefix', () => {
+    expect(parseExecutionArtifactDownloadUrl(
+      'https://api.example.com/api/v1/executions/exec_1/artifacts/trace_a',
+      'https://api.example.com/api',
+    )).toEqual({ executionId: 'exec_1', artifactId: 'trace_a' });
   });
 });

--- a/src/hosted/artifact-url.ts
+++ b/src/hosted/artifact-url.ts
@@ -19,16 +19,28 @@ export function parseExecutionArtifactDownloadUrl(
     throw new ArgumentError('Download URL origin must exactly match the configured Webcmd Cloud API.');
   }
   if (parsed.search || parsed.hash) {
-    throw new ArgumentError('Download URL path must match /v1/executions/<execution-id>/artifacts/<artifact-id>.');
+    throw new ArgumentError('Download URL path must match the configured execution-artifact download route.');
   }
-  const match = /^\/v1\/executions\/([^/]+)\/artifacts\/([^/]+)$/.exec(parsed.pathname);
+  const prefix = api.pathname.replace(/\/+$/, '');
+  const expected = `${prefix}/v1/executions/`;
+  if (!parsed.pathname.startsWith(expected)) {
+    throw new ArgumentError('Download URL path must match the configured execution-artifact download route.');
+  }
+  const rest = parsed.pathname.slice(prefix.length);
+  const match = /^\/v1\/executions\/([^/]+)\/artifacts\/([^/]+)$/.exec(rest);
   if (!match) {
-    throw new ArgumentError('Download URL path must match /v1/executions/<execution-id>/artifacts/<artifact-id>.');
+    throw new ArgumentError('Download URL path must match the configured execution-artifact download route.');
   }
-  const executionId = decodeURIComponent(match[1]!);
-  const artifactId = decodeURIComponent(match[2]!);
+  let executionId: string;
+  let artifactId: string;
+  try {
+    executionId = decodeURIComponent(match[1]!);
+    artifactId = decodeURIComponent(match[2]!);
+  } catch {
+    throw new ArgumentError('Download URL path must match the configured execution-artifact download route.');
+  }
   if (!executionId || !artifactId || executionId.includes('/') || artifactId.includes('/')) {
-    throw new ArgumentError('Download URL path must match /v1/executions/<execution-id>/artifacts/<artifact-id>.');
+    throw new ArgumentError('Download URL path must match the configured execution-artifact download route.');
   }
   return { executionId, artifactId };
 }

--- a/src/hosted/artifact-url.ts
+++ b/src/hosted/artifact-url.ts
@@ -1,0 +1,34 @@
+import { ArgumentError } from '../errors.js';
+
+export function parseExecutionArtifactDownloadUrl(
+  downloadUrl: string,
+  apiBaseUrl: string,
+): { executionId: string; artifactId: string } {
+  let parsed: URL;
+  let api: URL;
+  try {
+    parsed = new URL(downloadUrl);
+    api = new URL(apiBaseUrl);
+  } catch {
+    throw new ArgumentError('Download URL is not a valid absolute URL.');
+  }
+  if (parsed.username || parsed.password) {
+    throw new ArgumentError('Download URL origin must exactly match the configured Webcmd Cloud API.');
+  }
+  if (parsed.origin !== api.origin) {
+    throw new ArgumentError('Download URL origin must exactly match the configured Webcmd Cloud API.');
+  }
+  if (parsed.search || parsed.hash) {
+    throw new ArgumentError('Download URL path must match /v1/executions/<execution-id>/artifacts/<artifact-id>.');
+  }
+  const match = /^\/v1\/executions\/([^/]+)\/artifacts\/([^/]+)$/.exec(parsed.pathname);
+  if (!match) {
+    throw new ArgumentError('Download URL path must match /v1/executions/<execution-id>/artifacts/<artifact-id>.');
+  }
+  const executionId = decodeURIComponent(match[1]!);
+  const artifactId = decodeURIComponent(match[2]!);
+  if (!executionId || !artifactId || executionId.includes('/') || artifactId.includes('/')) {
+    throw new ArgumentError('Download URL path must match /v1/executions/<execution-id>/artifacts/<artifact-id>.');
+  }
+  return { executionId, artifactId };
+}

--- a/src/hosted/client.ts
+++ b/src/hosted/client.ts
@@ -1,4 +1,5 @@
 import { attachTraceReceipt, CliError, EXIT_CODES, type ExitCode } from '../errors.js';
+import { parseExecutionArtifactDownloadUrl } from './artifact-url.js';
 import { log } from '../logger.js';
 import { HOSTED_SESSION_PROTOCOL_VERSION } from './types.js';
 import type {
@@ -391,6 +392,11 @@ export class HostedClient {
       );
     }
     return new Uint8Array(await response.arrayBuffer());
+  }
+
+  async downloadArtifactFromUrl(downloadUrl: string): Promise<Uint8Array> {
+    const ids = parseExecutionArtifactDownloadUrl(downloadUrl, this.apiBaseUrl);
+    return this.downloadExecutionArtifact(ids);
   }
 
   async startBrowserRun(session: string, input: HostedBrowserRunRequest): Promise<HostedBrowserRunResponse> {

--- a/src/hosted/manifest.test.ts
+++ b/src/hosted/manifest.test.ts
@@ -226,7 +226,7 @@ describe('hosted manifest helpers', () => {
       fetchImpl: async () => new Response(JSON.stringify({ ok: true, manifest }), { status: 200 }),
     });
 
-    expect(stdout.text().trim().split('\n')).toEqual(['browser', 'completion', 'github', 'list', 'profile', 'setup', 'web']);
+    expect(stdout.text().trim().split('\n')).toEqual(['artifact', 'browser', 'completion', 'github', 'list', 'profile', 'setup', 'web']);
 
     const siteHelp = sink();
     await runHostedCli(['web', '--help'], {

--- a/src/hosted/runner.test.ts
+++ b/src/hosted/runner.test.ts
@@ -2971,4 +2971,28 @@ describe('hosted artifact download', () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it('renders structured JSON when -f json is set', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'webcmd-artifact-dl-json-'));
+    const output = path.join(dir, 'saved.csv');
+    const stdout = sink();
+    try {
+      const result = await runHostedCli([
+        'artifact', 'download',
+        'https://api.example.com/v1/executions/exec_1/artifacts/trace_a',
+        '--output', output,
+        '-f', 'json',
+      ], {
+        config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
+        stdout: stdout.stream,
+        stderr: sink().stream,
+        fetchImpl: async () => new Response(Buffer.from('csv-bytes'), { status: 200 }),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(stdout.text())).toEqual({ output, bytes: 9 });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/hosted/runner.test.ts
+++ b/src/hosted/runner.test.ts
@@ -2881,3 +2881,94 @@ describe('runHostedCli injected I/O', () => {
     });
   });
 });
+
+describe('hosted artifact download', () => {
+  it('rejects a foreign origin before sending a request', async () => {
+    const requests: string[] = [];
+    const stderr = sink();
+    const result = await runHostedCli([
+      'artifact', 'download',
+      'https://evil.example/v1/executions/exec_1/artifacts/trace_a',
+      '--output', '/tmp/out.bin',
+    ], {
+      config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
+      stdout: sink().stream,
+      stderr: stderr.stream,
+      fetchImpl: async (url) => {
+        requests.push(String(url));
+        return new Response('nope');
+      },
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(requests).toEqual([]);
+  });
+
+  it('rejects a malformed path before sending a request', async () => {
+    const requests: string[] = [];
+    const result = await runHostedCli([
+      'artifact', 'download',
+      'https://api.example.com/v1/artifacts/trace_a',
+      '--output', '/tmp/out.bin',
+    ], {
+      config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
+      stdout: sink().stream,
+      stderr: sink().stream,
+      fetchImpl: async (url) => {
+        requests.push(String(url));
+        return new Response('nope');
+      },
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(requests).toEqual([]);
+  });
+
+  it('requires --output', async () => {
+    const requests: string[] = [];
+    const result = await runHostedCli([
+      'artifact', 'download',
+      'https://api.example.com/v1/executions/exec_1/artifacts/trace_a',
+    ], {
+      config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
+      stdout: sink().stream,
+      stderr: sink().stream,
+      fetchImpl: async (url) => {
+        requests.push(String(url));
+        return new Response('nope');
+      },
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(requests).toEqual([]);
+  });
+
+  it('downloads bytes to --output and reports the local path', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'webcmd-artifact-dl-'));
+    const output = path.join(dir, 'saved.csv');
+    const stdout = sink();
+    const requests: string[] = [];
+    try {
+      const result = await runHostedCli([
+        'artifact', 'download',
+        'https://api.example.com/v1/executions/exec_1/artifacts/trace_a',
+        '--output', output,
+      ], {
+        config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
+        stdout: stdout.stream,
+        stderr: sink().stream,
+        fetchImpl: async (url) => {
+          requests.push(String(url));
+          return new Response(Buffer.from('csv-bytes'), { status: 200 });
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(requests).toEqual(['https://api.example.com/v1/executions/exec_1/artifacts/trace_a']);
+      await expect(readFile(output, 'utf8')).resolves.toBe('csv-bytes');
+      expect(stdout.text()).toContain(output);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/hosted/runner.ts
+++ b/src/hosted/runner.ts
@@ -36,6 +36,7 @@ import { CLI_COMMAND } from '../brand.js';
 import { formatPluginSearchEmptyCopy, presentPluginSearch } from '../plugin-search-presentation.js';
 import { missingPluginGuidance } from '../discovery.js';
 import { webFetchCommand } from '../fetch/command.js';
+import { runHostedArtifactDownload } from './artifact-download.js';
 import { HostedClient, HostedClientError, resolveWorkspace } from './client.js';
 import { createVirtualHostedFileIo, realHostedFileIo, type HostedFileIo } from './file-io.js';
 import { HOSTED_SESSION_PROTOCOL_VERSION } from './types.js';
@@ -312,6 +313,11 @@ async function dispatchHosted(
     const manifest = await client.getManifest();
     validateManifestContractIdentity(manifest);
     await dispatchHostedBrowser(invocation, client, stdout, io);
+    return;
+  }
+
+  if (args[0] === 'artifact') {
+    await runHostedArtifactDownload(args.slice(1), client, stdout, io.fileIo);
     return;
   }
 
@@ -1701,7 +1707,7 @@ function readInstalledHostedContractIdentity(): InstalledHostedContractIdentity 
 
 function hostedCommandName(argv: readonly string[]): string | undefined {
   const positionals: string[] = [];
-  const builtinCommands = new Set(['adapter', 'browser', 'completion', 'daemon', 'doctor', 'list', 'plugin', 'profile', 'session', 'setup', 'site', 'skills', 'update', 'web']);
+  const builtinCommands = new Set(['adapter', 'artifact', 'browser', 'completion', 'daemon', 'doctor', 'list', 'plugin', 'profile', 'session', 'setup', 'site', 'skills', 'update', 'web']);
   const valueOptions = new Set(['--profile', '-f', '--format', '--trace']);
   for (let i = 0; i < argv.length && positionals.length < 2; i += 1) {
     const token = argv[i]!;


### PR DESCRIPTION
Merge after Cloud `feat/hosted-artifact-download` is on `main`. Until then the command exists but browser-run fallback is missing.

## What now works
`webcmd artifact download <url> --output <path>` authenticates to Cloud and writes the file. Foreign origins never get the token.

## Review in 10 minutes
1. Open `src/hosted/artifact-url.ts` — origin must match the configured API; path must be `/v1/executions/:id/artifacts/:id`.
2. Open `src/hosted/client.ts` — `downloadArtifactFromUrl` calls existing `downloadExecutionArtifact` after parse.
3. Open `src/hosted/runner.test.ts` — `--output` required; foreign origin / bad path send no request; success prints the local path.

## Out of scope
Auto-copy to cwd. Signed URLs. Local-mode `artifact`. Public upload.

Next: confirm the Cloud PR is merged, then merge this when CI is green.
