### PR TITLE
feat(hosted): send sessionless browser init/verify to authoring route

### DIFF
--- a/src/browser/command-catalog.test.ts
+++ b/src/browser/command-catalog.test.ts
@@ -40,8 +40,8 @@ describe('browserCommandCatalog', () => {
 
   it('exposes hosted adapter init and verify with the local verification flags', () => {
     const commands = new Map(browserCommandCatalog.map(command => [command.command, command]));
-    expect(commands.get('init')).toMatchObject({ action: 'init', sessionPolicy: 'create-or-reuse' });
-    expect(commands.get('verify')).toMatchObject({ action: 'verify', sessionPolicy: 'create-or-reuse' });
+    expect(commands.get('init')).toMatchObject({ action: 'init', sessionPolicy: 'sessionless' });
+    expect(commands.get('verify')).toMatchObject({ action: 'verify', sessionPolicy: 'sessionless' });
     expect(commands.get('verify')?.options).toEqual(expect.arrayContaining([
       expect.objectContaining({ name: 'noFixture' }),
       expect.objectContaining({ name: 'writeFixture' }),

--- a/src/browser/command-catalog.ts
+++ b/src/browser/command-catalog.ts
@@ -178,7 +178,7 @@ export const browserCommandCatalog: readonly HostedBrowserCommandContract[] = [
   command('tabs', 'List pages in the existing browser session', 'tabs', [], [
     verboseFlag(),
   ], 'require-existing'),
-  command('init', 'Generate an adapter scaffold', 'init', [adapterNamePositional], [], 'create-or-reuse'),
+  command('init', 'Generate an adapter scaffold', 'init', [adapterNamePositional], [], 'sessionless'),
   command('bind', 'Bind this session to an existing page', 'bind', [], [
     option('page', 'Stable page id returned by tabs', { required: true }),
     verboseFlag(),
@@ -191,7 +191,7 @@ export const browserCommandCatalog: readonly HostedBrowserCommandContract[] = [
     option('seedArgs', 'Seed arguments used to invoke the command'),
     option('trace', 'Trace capture: off, on, or retain-on-failure', { default: 'off' }),
     option('maxTopLevelKeys', 'Maximum allowed top-level keys', { default: 12 }),
-  ], 'create-or-reuse'),
+  ], 'sessionless'),
   command('run', 'Run JavaScript with Playwright. A second overlapping run returns SESSION_BUSY; wait and retry.', 'run', [], [
     flag('stdin', 'Read the program from stdin'),
     option('file', 'Read the program from a file'),

--- a/src/browser/command-catalog.ts
+++ b/src/browser/command-catalog.ts
@@ -178,12 +178,12 @@ export const browserCommandCatalog: readonly HostedBrowserCommandContract[] = [
   command('tabs', 'List pages in the existing browser session', 'tabs', [], [
     verboseFlag(),
   ], 'require-existing'),
-  command('init', 'Generate an adapter scaffold', 'init', [adapterNamePositional], [], 'sessionless'),
+  command('init', 'Generate an adapter scaffold. Does not take --session.', 'init', [adapterNamePositional], [], 'sessionless'),
   command('bind', 'Bind this session to an existing page', 'bind', [], [
     option('page', 'Stable page id returned by tabs', { required: true }),
     verboseFlag(),
   ], 'require-existing'),
-  command('verify', 'Verify an adapter against its fixture', 'verify', [adapterNamePositional], [
+  command('verify', 'Verify an adapter against its fixture. Does not take --session.', 'verify', [adapterNamePositional], [
     flag('noFixture', 'Run without comparing a fixture'),
     flag('writeFixture', 'Write the observed result as the fixture'),
     flag('updateFixture', 'Replace an existing fixture with the observed result'),

--- a/src/hosted/client.test.ts
+++ b/src/hosted/client.test.ts
@@ -1367,6 +1367,76 @@ describe('HostedClient', () => {
     ]);
   });
 
+  it('runs sessionless authoring through the dedicated authoring endpoint', async () => {
+    const requests: Array<{ url: string; body?: unknown }> = [];
+    const client = new HostedClient({
+      apiBaseUrl: 'https://api.example.com',
+      apiKey: 'wcmd_live_test',
+      fetchImpl: async (url, init) => {
+        requests.push({
+          url: String(url),
+          body: init?.body ? JSON.parse(String(init.body)) as unknown : undefined,
+        });
+        return new Response(JSON.stringify({
+          ok: true,
+          result: [{ created: true, adapter: 'quotes/list' }],
+          columns: ['created', 'adapter'],
+          trace: null,
+          run: {
+            executionId: 'exec_1',
+            profile: { id: 'profile_default', displayName: 'default' },
+          },
+          execution: { id: 'exec_1', status: 'succeeded' },
+        }), { status: 200 });
+      },
+    });
+
+    await expect(client.executeAuthoringCommand({
+      command: 'browser/init',
+      action: 'init',
+      args: { name: 'quotes/list' },
+    })).resolves.toMatchObject({
+      result: [{ created: true, adapter: 'quotes/list' }],
+      execution: { id: 'exec_1', status: 'succeeded' },
+    });
+    expect(requests).toEqual([
+      {
+        url: 'https://api.example.com/v1/browser/authoring/commands',
+        body: {
+          command: 'browser/init',
+          action: 'init',
+          args: { name: 'quotes/list' },
+        },
+      },
+    ]);
+    expect(JSON.stringify(requests[0]?.body)).not.toMatch(/session/i);
+  });
+
+  it('rejects an authoring success that invents a Session token', async () => {
+    const client = new HostedClient({
+      apiBaseUrl: 'https://api.example.com',
+      apiKey: 'wcmd_live_test',
+      fetchImpl: async () => new Response(JSON.stringify({
+        ok: true,
+        result: {},
+        columns: [],
+        trace: null,
+        run: {
+          executionId: 'exec_1',
+          session: 'session_hidden',
+          profile: { id: 'profile_default', displayName: 'default' },
+        },
+        execution: { id: 'exec_1', status: 'succeeded' },
+      }), { status: 200 }),
+    });
+
+    await expect(client.executeAuthoringCommand({
+      command: 'browser/verify',
+      action: 'verify',
+      args: { name: 'quotes/list' },
+    })).rejects.toMatchObject({ code: 'HOSTED_PROTOCOL' });
+  });
+
   it('accepts compact hosted snapshot responses', async () => {
     const client = new HostedClient({
       apiBaseUrl: 'https://api.example.com',

--- a/src/hosted/client.ts
+++ b/src/hosted/client.ts
@@ -9,6 +9,7 @@ import type {
   HostedBrowserSessionCloseResponse,
   HostedBrowserSessionResponse,
   HostedBrowserSessionsResponse,
+  HostedAuthoringCommandResponse,
   HostedBrowserRunActionInput,
   HostedBrowserRunActionResponse,
   HostedBrowserSnapshotActionResponse,
@@ -445,6 +446,17 @@ export class HostedClient {
     });
     if (!isHostedBrowserRunActionResponse(body, session) && !(input.action === 'snapshot' && isHostedBrowserSnapshotActionResponse(body, session))) {
       throw protocolError('Webcmd Cloud returned an invalid browser action response.');
+    }
+    return body;
+  }
+
+  async executeAuthoringCommand(input: HostedBrowserRunActionInput): Promise<HostedAuthoringCommandResponse> {
+    const body = await this.request('/v1/browser/authoring/commands', {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+    if (!isHostedAuthoringCommandResponse(body)) {
+      throw protocolError('Webcmd Cloud returned an invalid authoring response.');
     }
     return body;
   }
@@ -950,6 +962,26 @@ function isHostedBrowserActionResponse(value: unknown): value is HostedBrowserAc
   if (!hasExactKeys(value, ['ok', 'result', 'columns', 'trace']) || value.ok !== true) return false;
   if (!Array.isArray(value.columns) || !value.columns.every(column => typeof column === 'string')) return false;
   return value.trace === null || isHostedBrowserActionTrace(value.trace);
+}
+
+function isHostedAuthoringCommandResponse(value: unknown): value is HostedAuthoringCommandResponse {
+  if (!hasExactKeys(value, ['ok', 'result', 'columns', 'trace', 'run', 'execution']) || value.ok !== true) return false;
+  if (!Array.isArray(value.columns) || !value.columns.every(column => typeof column === 'string')) return false;
+  if (value.trace !== null && !isHostedBrowserActionTrace(value.trace)) return false;
+  if (!isHostedAuthoringRunPayload(value.run)) return false;
+  return hasExactKeys(value.execution, ['id', 'status'])
+    && typeof value.execution.id === 'string'
+    && value.execution.id === value.run.executionId
+    && (value.execution.status === 'succeeded' || value.execution.status === 'failed' || value.execution.status === 'timed_out');
+}
+
+function isHostedAuthoringRunPayload(value: unknown): value is HostedAuthoringCommandResponse['run'] {
+  if (!hasOnlyKeys(value, ['executionId', 'profile', 'liveViewUrl', 'expiresAt'])) return false;
+  if (typeof value.executionId !== 'string') return false;
+  if (!hasExactKeys(value.profile, ['id', 'displayName'])) return false;
+  if (typeof value.profile.id !== 'string' || typeof value.profile.displayName !== 'string') return false;
+  if (value.liveViewUrl !== undefined && typeof value.liveViewUrl !== 'string') return false;
+  return value.expiresAt === undefined || typeof value.expiresAt === 'string';
 }
 
 function isHostedBrowserRunActionResponse(value: unknown, requestedSession: string): value is HostedBrowserRunActionResponse {

--- a/src/hosted/contract.ts
+++ b/src/hosted/contract.ts
@@ -60,7 +60,8 @@ export type HostedSessionPolicy =
   | 'create-or-reuse'
   | 'require-existing'
   | 'close-existing'
-  | 'local-only';
+  | 'local-only'
+  | 'sessionless';
 
 export interface HostedBrowserCommandContract {
   command: string;
@@ -137,6 +138,7 @@ const KNOWN_SESSION_POLICIES = new Set<HostedSessionPolicy>([
   'require-existing',
   'close-existing',
   'local-only',
+  'sessionless',
 ]);
 
 function sharedContractOptions(): {

--- a/src/hosted/programmatic-differential.test.ts
+++ b/src/hosted/programmatic-differential.test.ts
@@ -137,7 +137,7 @@ describe('programmatic runner isolation', () => {
       process.chdir(before);
       await rm(scratch, { recursive: true, force: true });
     }
-  });
+  }, 20_000);
 
   it('returns plugin scaffolding and adapter source output as virtual files', async () => {
     const plugin = await runProgrammatic(['plugin', 'create', 'acme-widgets', '--author-name', 'Ada', '--author-handle', 'ada']);

--- a/src/hosted/programmatic-differential.test.ts
+++ b/src/hosted/programmatic-differential.test.ts
@@ -13,7 +13,6 @@ const execFileAsync = promisify(execFile);
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const cliEntry = path.join(repoRoot, 'dist', 'src', 'main.js');
 const packageRoot = path.join(repoRoot, 'dist');
-const checkoutFingerprintExclusions = new Set(['.git', '.superpowers', 'coverage', 'dist', 'node_modules']);
 const sourceText = 'export const fixture = true;\n';
 const sourceFile: HostedVirtualFile = { path: 'source.js', content: new TextEncoder().encode(sourceText) };
 
@@ -116,7 +115,6 @@ describe('programmatic runner isolation', () => {
 
   it('keeps writer output virtual without changing the checkout or built package roots', async () => {
     const scratch = await mkdtemp(path.join(tmpdir(), 'webcmd-isolation-'));
-    const checkoutBefore = await fingerprintTree(repoRoot, checkoutFingerprintExclusions);
     const packageBefore = await fingerprintTree(packageRoot);
     const before = process.cwd();
     process.chdir(scratch);
@@ -131,13 +129,12 @@ describe('programmatic runner isolation', () => {
       ]);
       expect(source.outputFiles).toEqual([{ path: 'adapter.js', content: new TextEncoder().encode('export default {};\n') }]);
       expect(await readdir(scratch)).toEqual([]);
-      expect(await fingerprintTree(repoRoot, checkoutFingerprintExclusions)).toBe(checkoutBefore);
       expect(await fingerprintTree(packageRoot)).toBe(packageBefore);
     } finally {
       process.chdir(before);
       await rm(scratch, { recursive: true, force: true });
     }
-  }, 20_000);
+  });
 
   it('returns plugin scaffolding and adapter source output as virtual files', async () => {
     const plugin = await runProgrammatic(['plugin', 'create', 'acme-widgets', '--author-name', 'Ada', '--author-handle', 'ada']);

--- a/src/hosted/runner.test.ts
+++ b/src/hosted/runner.test.ts
@@ -2791,6 +2791,19 @@ describe('runHostedCli', () => {
     expect(JSON.stringify(requests[1]?.body)).not.toMatch(/session/i);
   });
 
+  it('rejects --session on sessionless init', async () => {
+    const stderr = sink();
+    const fetchImpl = vi.fn<typeof fetch>();
+    const result = await runHostedCli(['--session', 'session_work', 'browser', 'init', 'quotes/list'], {
+      config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
+      stderr: stderr.stream,
+      fetchImpl,
+    });
+    expect(result.exitCode).toBe(2);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(stderr.text()).toContain('SESSION_NOT_ALLOWED');
+  });
+
   it.each([
     { argv: ['browser', 'tabs'], code: 'SESSION_REQUIRED' },
     { argv: ['browser', 'snapshot'], code: 'SESSION_REQUIRED' },

--- a/src/hosted/runner.test.ts
+++ b/src/hosted/runner.test.ts
@@ -2522,7 +2522,7 @@ describe('runHostedCli', () => {
     await writeFile(uploadFile, 'hello browser upload');
     try {
       for (const contract of browserCommandCatalog.filter(command => (
-        command.sessionPolicy !== 'local-only'
+        command.sessionPolicy !== 'local-only' && command.sessionPolicy !== 'sessionless'
       ))) {
         const requests: Array<{ pathname: string; body?: Record<string, unknown> }> = [];
         const positionals = sampleBrowserPositionals(contract);
@@ -2581,7 +2581,7 @@ describe('runHostedCli', () => {
   it('dispatches hosted browser verify with its local verification options', async () => {
     const requests: Array<{ url: string; body?: Record<string, unknown> }> = [];
     const result = await runHostedCli([
-      '--session', 'session_work', 'browser', 'verify', 'hn/top',
+      'browser', 'verify', 'hn/top',
       '--no-fixture', '--write-fixture', '--update-fixture', '--strict-memory',
       '--seed-args', '{"limit":3}', '--trace', 'retain-on-failure', '--max-top-level-keys', '20',
     ], {
@@ -2597,7 +2597,7 @@ describe('runHostedCli', () => {
           result: {},
           columns: [],
           trace: null,
-          run: { executionId: 'exec_browser_verify', session: 'session_work', profile: { id: 'profile_default', displayName: 'default' } },
+          run: { executionId: 'exec_browser_verify', profile: { id: 'profile_default', displayName: 'default' } },
           execution: { id: 'exec_browser_verify', status: 'succeeded' },
         }), { status: 200 });
       },
@@ -2622,7 +2622,7 @@ describe('runHostedCli', () => {
 
   it('dispatches hosted browser verify with a numeric default maxTopLevelKeys', async () => {
     const requests: Array<{ body?: Record<string, unknown> }> = [];
-    const result = await runHostedCli(['--session', 'session_work', 'browser', 'verify', 'hn/top'], {
+    const result = await runHostedCli(['browser', 'verify', 'hn/top'], {
       config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
       stdout: sink().stream,
       stderr: sink().stream,
@@ -2635,7 +2635,7 @@ describe('runHostedCli', () => {
           result: {},
           columns: [],
           trace: null,
-          run: { executionId: 'exec_browser_verify', session: 'session_work', profile: { id: 'profile_default', displayName: 'default' } },
+          run: { executionId: 'exec_browser_verify', profile: { id: 'profile_default', displayName: 'default' } },
           execution: { id: 'exec_browser_verify', status: 'succeeded' },
         }), { status: 200 });
       },
@@ -2750,8 +2750,52 @@ describe('runHostedCli', () => {
     expect(stderr.text()).toMatch(/Browser sessions are root selectors/i);
   });
 
+  it.each(['init', 'verify'] as const)('sends hosted browser %s without a Session to the authoring route', async (leaf) => {
+    const requests: Array<{ pathname: string; body?: Record<string, unknown> }> = [];
+    const result = await runHostedCli(['browser', leaf, 'quotes/list'], {
+      config: makeHostedConfig({ apiBaseUrl: 'https://api.example.com', apiKey: 'key' }),
+      stdout: sink().stream,
+      stderr: sink().stream,
+      fetchImpl: async (url, init) => {
+        const parsedUrl = new URL(String(url));
+        const body = init?.body ? JSON.parse(String(init.body)) as Record<string, unknown> : undefined;
+        requests.push({ pathname: parsedUrl.pathname, ...(body ? { body } : {}) });
+        if (parsedUrl.pathname === '/v1/manifest') return manifestResponse();
+        if (parsedUrl.pathname === '/v1/browser/authoring/commands') {
+          return new Response(JSON.stringify({
+            ok: true,
+            result: {},
+            columns: [],
+            trace: null,
+            run: {
+              executionId: `exec_browser_${leaf}`,
+              profile: { id: 'profile_default', displayName: 'default' },
+            },
+            execution: { id: `exec_browser_${leaf}`, status: 'succeeded' },
+          }), { status: 200 });
+        }
+        return new Response(JSON.stringify({
+          ok: false,
+          error: { code: 'UNEXPECTED', message: parsedUrl.pathname, exitCode: 1 },
+        }), { status: 500 });
+      },
+    });
+
+    expect(result).toEqual({ handled: true, exitCode: 0 });
+    expect(requests.map(request => request.pathname)).toEqual(['/v1/manifest', '/v1/browser/authoring/commands']);
+    expect(requests[1]?.body).toMatchObject({
+      command: `browser/${leaf}`,
+      action: leaf,
+      args: { name: 'quotes/list' },
+    });
+    expect(JSON.stringify(requests[1]?.body)).not.toMatch(/session/i);
+  });
+
   it.each([
     { argv: ['browser', 'tabs'], code: 'SESSION_REQUIRED' },
+    { argv: ['browser', 'snapshot'], code: 'SESSION_REQUIRED' },
+    { argv: ['browser', 'close'], code: 'SESSION_REQUIRED' },
+    { argv: ['browser', 'bind', '--page', 'page-123'], code: 'SESSION_REQUIRED' },
     { argv: ['--session', 'work', 'browser', 'tabs'], code: 'INVALID_SESSION_SELECTOR' },
   ])('rejects an unusable raw selector before hosted transport: $code', async ({ argv, code }) => {
     const stderr = sink();

--- a/src/hosted/runner.ts
+++ b/src/hosted/runner.ts
@@ -1055,6 +1055,14 @@ async function parseHostedBrowserInvocation(
   const windowMode = structure.window === undefined ? undefined : parseWindowMode(structure.window);
   const parsed = parseBrowserLeaf(structure.commandName, structure.positionals, structure.options);
   const sessionless = hostedBrowserCommandsByPath.get(parsed.commandName)?.sessionPolicy === 'sessionless';
+  if (sessionless && (session !== undefined || structure.session)) {
+    throw new CliError(
+      'SESSION_NOT_ALLOWED',
+      'browser init and browser verify do not take --session.',
+      'Use: webcmd browser init <site>/<command> or webcmd browser verify <site>/<command>',
+      EXIT_CODES.USAGE_ERROR,
+    );
+  }
   const browserArgs = await materializeBrowserRunSource(parsed.commandName, parsed.args, io);
   return {
     ...(sessionless ? {} : { session: validateRawBrowserSession(structure.session, profile) }),

--- a/src/hosted/runner.ts
+++ b/src/hosted/runner.ts
@@ -58,6 +58,7 @@ import { resolveHostedApiKey, type HostedCredentialStore } from './credentials.j
 import { parseHostedRootCommandSurface } from '../root-command-surface.js';
 import { registerSiteCommands, type SiteMemoryBackend } from '../site-memory/commands.js';
 import type {
+  HostedAuthoringCommandResponse,
   HostedBrowserActionName,
   HostedBrowserRunActionResponse,
   HostedBrowserSnapshotActionResponse,
@@ -952,7 +953,7 @@ async function executeHostedPreparedCommand(input: {
 }
 
 interface ParsedHostedBrowserInvocation {
-  session: string;
+  session?: string;
   command: string;
   action: HostedBrowserActionName;
   args: Record<string, unknown>;
@@ -970,14 +971,17 @@ async function dispatchHostedBrowser(
   const args = invocation.action === 'set-file-input'
     ? await materializeHostedBrowserUploadArgs(invocation.args, io.fileIo)
     : invocation.args;
-  const response = await client.runBrowserAction(invocation.session, {
+  const request = {
     command: invocation.command,
     action: invocation.action,
     args,
     ...(invocation.profile !== undefined ? { profile: invocation.profile } : {}),
     ...(invocation.windowMode !== undefined ? { windowMode: invocation.windowMode } : {}),
-    trace: 'off',
-  });
+    trace: 'off' as const,
+  };
+  const response = invocation.session === undefined
+    ? await client.executeAuthoringCommand(request)
+    : await client.runBrowserAction(invocation.session, request);
   await renderHostedBrowserResponse(stdout, invocation, response, io);
 }
 
@@ -1050,9 +1054,10 @@ async function parseHostedBrowserInvocation(
 
   const windowMode = structure.window === undefined ? undefined : parseWindowMode(structure.window);
   const parsed = parseBrowserLeaf(structure.commandName, structure.positionals, structure.options);
+  const sessionless = hostedBrowserCommandsByPath.get(parsed.commandName)?.sessionPolicy === 'sessionless';
   const browserArgs = await materializeBrowserRunSource(parsed.commandName, parsed.args, io);
   return {
-    session: validateRawBrowserSession(structure.session, profile),
+    ...(sessionless ? {} : { session: validateRawBrowserSession(structure.session, profile) }),
     command: `browser/${parsed.commandName}`,
     action: parsed.action,
     args: browserArgs,
@@ -1248,7 +1253,7 @@ function withoutKeys(input: Record<string, unknown>, keys: readonly string[]): R
 async function renderHostedBrowserResponse(
   stdout: NodeJS.WritableStream,
   invocation: ParsedHostedBrowserInvocation,
-  response: HostedBrowserRunActionResponse | HostedBrowserSnapshotActionResponse,
+  response: HostedBrowserRunActionResponse | HostedBrowserSnapshotActionResponse | HostedAuthoringCommandResponse,
   io: HostedDispatchIo,
 ): Promise<void> {
   const result = response.result;

--- a/src/hosted/types.ts
+++ b/src/hosted/types.ts
@@ -345,6 +345,11 @@ export interface HostedBrowserRunActionResponse extends HostedBrowserActionRespo
   execution: HostedBrowserFinishResponse['execution'];
 }
 
+export interface HostedAuthoringCommandResponse extends HostedBrowserActionResponse {
+  run: Omit<HostedBrowserRunResponse['run'], 'session'>;
+  execution: HostedBrowserFinishResponse['execution'];
+}
+
 export interface HostedBrowserSnapshotActionResponse {
   ok: true;
   run: HostedBrowserRunResponse['run'];


### PR DESCRIPTION
Do not merge until Cloud `feat/sessionless-authoring` is on `main`. This CLI posts to `/v1/browser/authoring/commands`.

## What now works
`webcmd browser init|verify <site>/<command>` in hosted mode does not need `--session`. Other browser commands still do.

## Review in 10 minutes
1. Open `src/browser/command-catalog.ts` — `init`/`verify` are `sessionless`.
2. Open `src/hosted/runner.ts` — those two POST to `/v1/browser/authoring/commands` with no Session field.
3. Open `src/hosted/runner.test.ts` — missing `--session` is allowed only for init/verify; a `run.session` in the reply is `HOSTED_PROTOCOL`.

## Out of scope
Snapshot routing. Error `details`. Artifact download. `adapter init` alias.

Next: confirm the Cloud PR is merged, then merge this when CI is green.
