### PR TITLE
fix(hosted): accept object error.details from Cloud

### DIFF
--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -16,6 +16,7 @@ import {
   toEnvelope,
   withAdapterRepairHelp,
 } from './errors.js';
+import { HostedClientError } from './hosted/client.js';
 import type { SessionLeaseHolder } from './session-lease.js';
 
 describe('Error type hierarchy', () => {
@@ -166,6 +167,28 @@ describe('toEnvelope', () => {
     const causeStr = envelope.error.cause ?? '';
     expect(causeStr).toContain('(cause chain truncated)');
     expect(causeStr).not.toContain('root'); // root is beyond depth 10
+  });
+
+  it('preserves hosted object details on the CLI error envelope', () => {
+    const details = { warnings: [{ code: 'PAGE_STALE' }], timings: { program_ms: 12 } };
+    const err = new HostedClientError(
+      'BROWSER_RUN_TIMEOUT',
+      'The browser program timed out.',
+      'Retry with a shorter program.',
+      75,
+      { details },
+    );
+
+    expect(toEnvelope(err)).toEqual({
+      ok: false,
+      error: {
+        code: 'BROWSER_RUN_TIMEOUT',
+        message: 'The browser program timed out.',
+        help: 'Retry with a shorter program.',
+        exitCode: 75,
+        details,
+      },
+    });
   });
 
   it('preserves public hosted trace receipts without inventing local paths', () => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -291,6 +291,7 @@ export interface ErrorEnvelope {
     exitCode: number;
     stack?: string;
     cause?: string;
+    details?: Record<string, unknown>;
   };
   trace?: {
     traceId: string;
@@ -302,6 +303,14 @@ export interface ErrorEnvelope {
 }
 
 // ── Utilities ───────────────────────────────────────────────────────────────
+
+function errorDetails(err: unknown): Record<string, unknown> | undefined {
+  if (!err || typeof err !== 'object') return undefined;
+  const details = (err as { details?: unknown }).details;
+  return details && typeof details === 'object' && !Array.isArray(details)
+    ? details as Record<string, unknown>
+    : undefined;
+}
 
 /** Extract a human-readable message from an unknown caught value. */
 export function getErrorMessage(error: unknown): string {
@@ -335,6 +344,7 @@ export function toEnvelope(err: unknown): ErrorEnvelope {
         }
     : undefined;
   if (err instanceof CliError) {
+    const details = errorDetails(err);
     return {
       ok: false,
       error: {
@@ -343,6 +353,7 @@ export function toEnvelope(err: unknown): ErrorEnvelope {
         ...(err.hint ? { help: err.hint } : {}),
         exitCode: err.exitCode,
         ...(cause ? { cause } : {}),
+        ...(details ? { details } : {}),
       },
       ...(trace ? { trace } : {}),
     };

--- a/src/hosted/client.test.ts
+++ b/src/hosted/client.test.ts
@@ -880,6 +880,80 @@ describe('HostedClient', () => {
     } satisfies Partial<HostedClientError>);
   });
 
+  it('keeps the original hosted error code when failure details are a nested object', async () => {
+    const details = {
+      warnings: [{ code: 'PAGE_STALE', message: 'The assigned page changed.' }],
+      timings: { program_ms: 12 },
+    };
+    const client = new HostedClient({
+      apiBaseUrl: 'https://api.example.com',
+      apiKey: 'key',
+      fetchImpl: async () => new Response(JSON.stringify({
+        ok: false,
+        error: {
+          code: 'BROWSER_RUN_TIMEOUT',
+          message: 'The browser program timed out.',
+          help: 'Retry with a shorter program.',
+          exitCode: 75,
+          details,
+        },
+        execution: { id: 'exec_timeout', command: 'github/whoami', status: 'timed_out' },
+      }), { status: 504 }),
+    });
+
+    await expect(client.execute({ command: 'github/whoami', args: {} })).rejects.toMatchObject({
+      code: 'BROWSER_RUN_TIMEOUT',
+      details,
+    } satisfies Partial<HostedClientError>);
+  });
+
+  it('preserves object details on artifact-download failures', async () => {
+    const details = { artifactId: 'artifact_out', reason: 'expired' };
+    const client = new HostedClient({
+      apiBaseUrl: 'https://api.example.com',
+      apiKey: 'key',
+      fetchImpl: async () => new Response(JSON.stringify({
+        ok: false,
+        error: {
+          code: 'ARTIFACT_NOT_FOUND',
+          message: 'The artifact is gone.',
+          exitCode: 66,
+          details,
+        },
+      }), { status: 404 }),
+    });
+
+    await expect(client.downloadExecutionArtifact({
+      executionId: 'exec_files',
+      artifactId: 'artifact_out',
+    })).rejects.toMatchObject({
+      code: 'ARTIFACT_NOT_FOUND',
+      details,
+    } satisfies Partial<HostedClientError>);
+  });
+
+  it('preserves object details on raw-text request failures', async () => {
+    const details = { site: 'github', path: 'notes.md' };
+    const client = new HostedClient({
+      apiBaseUrl: 'https://api.example.com',
+      apiKey: 'key',
+      fetchImpl: async () => new Response(JSON.stringify({
+        ok: false,
+        error: {
+          code: 'SITE_MEMORY_NOT_FOUND',
+          message: 'Missing notes.',
+          exitCode: 66,
+          details,
+        },
+      }), { status: 404 }),
+    });
+
+    await expect(client.readSiteMemory('github', 'notes.md')).rejects.toMatchObject({
+      code: 'SITE_MEMORY_NOT_FOUND',
+      details,
+    } satisfies Partial<HostedClientError>);
+  });
+
   it.each(['success', 'failure'].flatMap(phase => invalidTraceUrlCases.map(testCase => ({
     phase,
     ...testCase,
@@ -1073,6 +1147,38 @@ describe('HostedClient', () => {
         execution: {
           id: 'exec_good', command: 'github/whoami', status: 'succeeded', internalPath: '/srv/private/token.json',
         },
+      },
+    },
+    {
+      name: 'array error details',
+      status: 500,
+      body: {
+        ok: false,
+        error: { code: 'UNKNOWN', message: 'failed', exitCode: 1, details: ['secret'] },
+      },
+    },
+    {
+      name: 'string error details',
+      status: 500,
+      body: {
+        ok: false,
+        error: { code: 'UNKNOWN', message: 'failed', exitCode: 1, details: 'secret' },
+      },
+    },
+    {
+      name: 'number error details',
+      status: 500,
+      body: {
+        ok: false,
+        error: { code: 'UNKNOWN', message: 'failed', exitCode: 1, details: 12 },
+      },
+    },
+    {
+      name: 'null error details',
+      status: 500,
+      body: {
+        ok: false,
+        error: { code: 'UNKNOWN', message: 'failed', exitCode: 1, details: null },
       },
     },
   ])('rejects malformed $name as HOSTED_PROTOCOL', async ({ status, body }) => {

--- a/src/hosted/client.ts
+++ b/src/hosted/client.ts
@@ -61,17 +61,23 @@ export function resolveWorkspace(argv: readonly string[], env: NodeJS.ProcessEnv
 export class HostedClientError extends CliError {
   readonly execution?: HostedExecution;
   readonly trace?: HostedTraceReceipt;
+  readonly details?: Record<string, unknown>;
 
   constructor(
     code: string,
     message: string,
     help?: string,
     exitCode: ExitCode = EXIT_CODES.GENERIC_ERROR,
-    metadata: { execution?: HostedExecution; trace?: HostedTraceReceipt } = {},
+    metadata: {
+      execution?: HostedExecution;
+      trace?: HostedTraceReceipt;
+      details?: Record<string, unknown>;
+    } = {},
   ) {
     super(code, message, help, exitCode);
     this.execution = metadata.execution;
     this.trace = metadata.trace;
+    this.details = metadata.details;
     if (metadata.trace) attachTraceReceipt(this, metadata.trace);
   }
 }
@@ -378,17 +384,7 @@ export class HostedClient {
       const text = await response.text();
       const body = text ? parseJson(text) : {};
       if (!isHostedError(body)) throw protocolError('Webcmd Cloud returned an invalid artifact download failure.');
-      const error = body.error;
-      throw new HostedClientError(
-        error.code,
-        error.message,
-        error.help,
-        normalizeExitCode(error.exitCode, response.status === 401 ? EXIT_CODES.NOPERM : EXIT_CODES.GENERIC_ERROR),
-        {
-          ...(body.execution ? { execution: body.execution } : {}),
-          ...(body.trace ? { trace: body.trace } : {}),
-        },
-      );
+      throw hostedFailure(body, response.status === 401 ? EXIT_CODES.NOPERM : EXIT_CODES.GENERIC_ERROR);
     }
     return new Uint8Array(await response.arrayBuffer());
   }
@@ -465,20 +461,7 @@ export class HostedClient {
       if (body.execution && !isValidExecutedFailure(body, executionExpectation)) {
         throw protocolError('Webcmd Cloud returned an invalid executed failure response.');
       }
-      const error = body.error;
-      throw new HostedClientError(
-        error.code,
-        error.message,
-        error.help,
-        normalizeExitCode(
-          error.exitCode,
-          response.status === 401 ? EXIT_CODES.NOPERM : EXIT_CODES.GENERIC_ERROR,
-        ),
-        {
-          ...(body.execution ? { execution: body.execution } : {}),
-          ...(body.trace ? { trace: body.trace } : {}),
-        },
-      );
+      throw hostedFailure(body, response.status === 401 ? EXIT_CODES.NOPERM : EXIT_CODES.GENERIC_ERROR);
     }
     if (!response.ok) throw protocolError('Webcmd Cloud returned a success envelope with an HTTP error status.');
     return body;
@@ -523,13 +506,7 @@ export class HostedClient {
     if (response.ok) return text;
     const body = text ? parseJson(text) : {};
     if (!isHostedError(body)) throw protocolError('Webcmd Cloud returned an invalid raw response failure.');
-    throw new HostedClientError(
-      body.error.code,
-      body.error.message,
-      body.error.help,
-      normalizeExitCode(body.error.exitCode, response.status === 401 ? EXIT_CODES.NOPERM : EXIT_CODES.GENERIC_ERROR),
-      { ...(body.execution ? { execution: body.execution } : {}), ...(body.trace ? { trace: body.trace } : {}) },
-    );
+    throw hostedFailure(body, response.status === 401 ? EXIT_CODES.NOPERM : EXIT_CODES.GENERIC_ERROR);
   }
 }
 
@@ -612,11 +589,12 @@ function isHostedAdapterOverrideResponse(value: unknown): value is {
 
 function isHostedError(value: unknown): value is HostedErrorResponse {
   if (!hasOnlyKeys(value, ['ok', 'error', 'execution', 'trace']) || value.ok !== false || !isRecord(value.error)) return false;
-  if (!hasOnlyKeys(value.error, ['code', 'message', 'help', 'exitCode'])) return false;
+  if (!hasOnlyKeys(value.error, ['code', 'message', 'help', 'exitCode', 'details'])) return false;
   if (typeof value.error.code !== 'string' || typeof value.error.message !== 'string') return false;
   if (value.error.exitCode !== undefined
     && (typeof value.error.exitCode !== 'number' || !isAllowedExitCode(value.error.exitCode))) return false;
   if (value.error.help !== undefined && typeof value.error.help !== 'string') return false;
+  if (value.error.details !== undefined && !isRecord(value.error.details)) return false;
   if (value.execution !== undefined && !isHostedExecution(value.execution)) return false;
   if (value.trace !== undefined && !isHostedTraceReceipt(value.trace)) return false;
   if (value.execution?.status === 'succeeded') return false;
@@ -1050,6 +1028,20 @@ function normalizeExitCode(value: number | undefined, fallback: ExitCode): ExitC
 
 function protocolError(message: string): HostedClientError {
   return new HostedClientError('HOSTED_PROTOCOL', message);
+}
+
+function hostedFailure(body: HostedErrorResponse, fallback: ExitCode): HostedClientError {
+  return new HostedClientError(
+    body.error.code,
+    body.error.message,
+    body.error.help,
+    normalizeExitCode(body.error.exitCode, fallback),
+    {
+      ...(body.execution ? { execution: body.execution } : {}),
+      ...(body.trace ? { trace: body.trace } : {}),
+      ...(body.error.details ? { details: body.error.details } : {}),
+    },
+  );
 }
 
 type HostedTraceMode = 'off' | 'on' | 'retain-on-failure';

--- a/src/hosted/types.ts
+++ b/src/hosted/types.ts
@@ -358,6 +358,7 @@ export interface HostedErrorResponse {
     message: string;
     help?: string;
     exitCode?: number;
+    details?: Record<string, unknown>;
   };
   execution?: HostedExecution;
   trace?: HostedTraceReceipt;


### PR DESCRIPTION
Merge after CI is green. Pair with the Cloud twin (`feat/hosted-error-details`). Either repo can land first.

## What now works
A Cloud failure with object `details` keeps the real error code. It no longer becomes `HOSTED_PROTOCOL`.

## Review in 10 minutes
1. Open `src/hosted/client.ts` — `isHostedError` allows object `details`; `hostedFailure` is the one throw path.
2. Open `src/errors.ts` — `toEnvelope` copies object `details` onto the CLI envelope.
3. Skim `src/hosted/client.test.ts` — nested object keeps original code; array/string/number/`null` stay `HOSTED_PROTOCOL`.

## Out of scope
Pin bump. Producer-specific redaction. Snapshot, init/verify, artifact download.

Next: open the Cloud twin and merge both when CI is green.
