### PR TITLE
fix(site-memory): retry transient Windows lock opens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
   schedule:
     - cron: '0 8 * * 1'

--- a/src/site-memory/file-lock.test.ts
+++ b/src/site-memory/file-lock.test.ts
@@ -1,13 +1,19 @@
 import { spawnSync } from 'node:child_process';
-import { mkdtemp, readFile, rm, stat, utimes, writeFile } from 'node:fs/promises';
+import { mkdtemp, open, readFile, rm, stat, utimes, writeFile } from 'node:fs/promises';
 import { hostname, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { lockPathFor, withFileLock } from './file-lock.js';
 
 const tempDirs: string[] = [];
 
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...actual, open: vi.fn(actual.open) };
+});
+
 afterEach(async () => {
+  vi.restoreAllMocks();
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
@@ -25,6 +31,17 @@ describe('site memory file lock', () => {
     })));
 
     expect(overlapped).toBe(false);
+    await expect(exists(lockPathFor(target))).resolves.toBe(false);
+  });
+
+  it('retries a transient Windows EPERM when creating the lock', async () => {
+    const target = await tempTarget();
+    vi.mocked(open).mockRejectedValueOnce(
+      Object.assign(new Error('transient Windows lock'), { code: 'EPERM' }),
+    );
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+
+    await expect(withFileLock(target, async () => 'written')).resolves.toBe('written');
     await expect(exists(lockPathFor(target))).resolves.toBe(false);
   });
 

--- a/src/site-memory/file-lock.ts
+++ b/src/site-memory/file-lock.ts
@@ -77,11 +77,15 @@ async function acquire(lockPath: string, options: FileLockOptions): Promise<stri
 /** Resolves true when this call created the lock, false when someone else holds it. */
 async function create(lockPath: string, body: string): Promise<boolean> {
   let handle;
-  try {
-    handle = await open(lockPath, 'wx');
-  } catch (err) {
-    if (isNodeError(err) && err.code === 'EEXIST') return false;
-    throw err;
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      handle = await open(lockPath, 'wx');
+      break;
+    } catch (err) {
+      if (isNodeError(err) && err.code === 'EEXIST') return false;
+      if (process.platform !== 'win32' || !isNodeError(err) || err.code !== 'EPERM' || attempt >= 2) throw err;
+      await delay(backoffMs(attempt));
+    }
   }
   try {
     await handle.writeFile(body, 'utf8');


### PR DESCRIPTION
## Summary

- retry transient Windows `EPERM` failures while atomically creating site-memory lock files
- preserve immediate failure for non-Windows, non-`EPERM`, and persistent errors
- run branch CI once for pull requests while retaining push CI on `main`

## Verification

- TDD regression: failed before the fix, passed after it
- Node 22 full unit/plugin suite: 459 files, 6,124 passed, 1 skipped
- `npm run typecheck`
- `npm run build`
- `git diff --check`