### PR TITLE
test: update e2e sessions for readable ids

### DIFF
--- a/tests/e2e/browser-run.test.ts
+++ b/tests/e2e/browser-run.test.ts
@@ -95,7 +95,7 @@ describe('browser run local lifecycle', () => {
     tempDirs.push(cacheDir);
     const env = { WEBCMD_CACHE_DIR: cacheDir, WEBCMD_CONFIG_DIR: cacheDir };
 
-    const created = await runCliWithStdin(['session', 'create', '-f', 'json'], '', env);
+    const created = await runCliWithStdin(['session', 'create', 'browser-run-e2e', '-f', 'json'], '', env);
     expect(created.code).toBe(0);
     const session = parseJsonOutput(created.stdout).id as string;
 

--- a/tests/e2e/browser-tabs.test.ts
+++ b/tests/e2e/browser-tabs.test.ts
@@ -118,7 +118,7 @@ describe('browser public command surface e2e', () => {
   it('uses tabs, bind, run, and close through the built CLI', async () => {
     const daemon = await startFakeDaemon();
     daemons.push(daemon);
-    const session = 'session_four-command-surface';
+    const session = 'browser-tabs-k7';
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-browser-tabs-'));
     tempDirs.push(tempDir);
     const sourcePath = path.join(tempDir, 'program.js');

--- a/tests/e2e/cloak-runtime.test.ts
+++ b/tests/e2e/cloak-runtime.test.ts
@@ -33,7 +33,7 @@ function browserRun(session: string, source: string, options: Parameters<typeof 
 }
 
 async function createSession(options: Parameters<typeof runCli>[1] = {}) {
-  const result = await runCli(['session', 'create', '-f', 'json'], isolatedOptions(options));
+  const result = await runCli(['session', 'create', 'cloak-e2e', '-f', 'json'], isolatedOptions(options));
   expect(result.code, `${result.stdout}\n${result.stderr}`).toBe(0);
   return JSON.parse(result.stdout).id as string;
 }

--- a/tests/e2e/management.test.ts
+++ b/tests/e2e/management.test.ts
@@ -135,29 +135,31 @@ describe('management commands E2E', () => {
 });
 
 describe('session close E2E', () => {
-  const NEVER_EXISTED = 'session_00000000-0000-0000-0000-000000000000';
+  const NEVER_EXISTED = 'never-existed-k7';
 
-  it('accepts the root --session selector and the command it used to suggest', async () => {
+  it('accepts both Session selector forms before reporting a missing Session', async () => {
     // Old behaviour: this errored with SESSION_SELECTOR_POSITION and suggested
     // `webcmd --session <id> session close`, which then failed on the missing
     // positional. Both spellings must now work.
     const viaFlag = await runManagementCli(['session', 'close', '--session', NEVER_EXISTED]);
     expect(viaFlag.stderr).not.toMatch(/SESSION_SELECTOR_POSITION|missing required argument/);
-    expect(viaFlag.code).toBe(0);
+    expect(viaFlag.code).not.toBe(0);
+    expect(viaFlag.stdout + viaFlag.stderr).toContain('SESSION_NOT_FOUND');
 
     const viaRootSelector = await runManagementCli(['--session', NEVER_EXISTED, 'session', 'close']);
     expect(viaRootSelector.stderr).not.toMatch(/missing required argument/);
-    expect(viaRootSelector.code).toBe(0);
+    expect(viaRootSelector.code).not.toBe(0);
+    expect(viaRootSelector.stdout + viaRootSelector.stderr).toContain('SESSION_NOT_FOUND');
   });
 
-  it('is idempotent for an unknown Session ID', async () => {
-    const { stdout, code } = await runManagementCli(['session', 'close', NEVER_EXISTED, '-f', 'json']);
-    expect(code).toBe(0);
-    expect(parseJsonOutput(stdout)).toMatchObject({ ok: true, closed: false, alreadyClosed: true, session: NEVER_EXISTED });
+  it('reports an unknown readable Session ID', async () => {
+    const { stdout, stderr, code } = await runManagementCli(['session', 'close', NEVER_EXISTED, '-f', 'json']);
+    expect(code).not.toBe(0);
+    expect(stdout + stderr).toContain('SESSION_NOT_FOUND');
   });
 
   it('closes a real Session twice without failing', async () => {
-    const created = await runManagementCli(['session', 'create', '-f', 'json']);
+    const created = await runManagementCli(['session', 'create', 'management-e2e', '-f', 'json']);
     expect(created.code).toBe(0);
     const sessionId = parseJsonOutput(created.stdout).id as string;
     for (const attempt of [1, 2]) {


### PR DESCRIPTION
## Summary\n\n- pass required readable names to local session-create E2E fixtures\n- replace legacy CLI Session selectors with valid readable IDs\n- align management E2E expectations with the shipped SESSION_NOT_FOUND contract\n\n## Root cause\n\nPR #443 made local session creation require a positional name and restricted public Session selectors to readable base-plus-suffix IDs. Four E2E fixtures still used the old nameless-create or legacy selector forms.\n\n## Verification\n\n- npm test: 460 files passed; 6,148 tests passed; 1 skipped\n- npm run typecheck: passed\n- reported and adjacent E2E: 3 files passed; 5 tests passed\n- management session-close E2E: 5 tests passed