### PR TITLE
fix(cli): name hosted-only mode instead of sending `artifact` to a plugin hunt

### DIFF
--- a/docs/cli-reference.mdx
+++ b/docs/cli-reference.mdx
@@ -142,7 +142,7 @@ Ordinary `curl` is neither required nor automatically authenticated.
 | `setup` | Choose local or hosted mode interactively. |
 | `doctor` | Diagnose browser bridge and daemon connectivity. |
 | `daemon` | Manage the local Webcmd daemon: status, stop, and restart. |
-| `artifact` | Download a hosted execution artifact to `--output`. |
+| `artifact` | Hosted mode only. Download a hosted execution artifact to `--output`. |
 | `browser` | Agent-facing browser runtime for exploration and verification. |
 | `web` | Local URL fetch helpers. |
 | `profile` | List, rename, and select browser runtime profiles. |

--- a/plugin-command-manifest.json
+++ b/plugin-command-manifest.json
@@ -20488,43 +20488,6 @@
   },
   {
     "site": "reddit",
-    "name": "draft-comment",
-    "description": "Draft a comment on a Reddit post without submitting it",
-    "access": "write",
-    "example": "webcmd reddit draft-comment <post-id-or-url> <text> --window foreground",
-    "domain": "reddit.com",
-    "strategy": "ui",
-    "browser": true,
-    "args": [
-      {
-        "name": "post-id",
-        "type": "string",
-        "required": true,
-        "positional": true,
-        "help": "Post ID (e.g. 1abc123), t3 fullname, or Reddit post URL"
-      },
-      {
-        "name": "text",
-        "type": "string",
-        "required": true,
-        "positional": true,
-        "help": "Comment text to leave in the composer"
-      }
-    ],
-    "columns": [
-      "status",
-      "message",
-      "url"
-    ],
-    "type": "js",
-    "modulePath": "plugins/reddit/draft-comment.js",
-    "sourceFile": "plugins/reddit/draft-comment.js",
-    "navigateBefore": false,
-    "siteSession": "persistent",
-    "freshPage": true
-  },
-  {
-    "site": "reddit",
     "name": "frontpage",
     "description": "Reddit Frontpage / r/all",
     "access": "read",

--- a/plugin-command-manifest.json
+++ b/plugin-command-manifest.json
@@ -20488,6 +20488,43 @@
   },
   {
     "site": "reddit",
+    "name": "draft-comment",
+    "description": "Draft a comment on a Reddit post without submitting it",
+    "access": "write",
+    "example": "webcmd reddit draft-comment <post-id-or-url> <text> --window foreground",
+    "domain": "reddit.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "post-id",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Post ID (e.g. 1abc123), t3 fullname, or Reddit post URL"
+      },
+      {
+        "name": "text",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Comment text to leave in the composer"
+      }
+    ],
+    "columns": [
+      "status",
+      "message",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "plugins/reddit/draft-comment.js",
+    "sourceFile": "plugins/reddit/draft-comment.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "freshPage": true
+  },
+  {
+    "site": "reddit",
     "name": "frontpage",
     "description": "Reddit Frontpage / r/all",
     "access": "read",

--- a/src/command-suggest.test.ts
+++ b/src/command-suggest.test.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { handleProgramParseError } from './cli-error-report.js';
 import { createProgram } from './cli.js';
-import { editDistance, isReservedRootCommand, unknownRootCommandMessage, unknownSubcommandMessage } from './command-suggest.js';
+import { editDistance, isHostedOnlyRootCommand, isReservedRootCommand, unknownRootCommandMessage, unknownSubcommandMessage } from './command-suggest.js';
 import { HOSTED_ROOT_HELP } from './completion-shared.js';
 import { WEBCMD_ROOT_COMMANDS } from './hooks.js';
 
@@ -41,6 +41,23 @@ describe('unknown root command', () => {
     expect(message).toContain('Did you mean: webcmd plugin search <query>');
   });
 
+  it('names hosted-only mode instead of sending artifact to a plugin hunt', () => {
+    const message = unknownRootCommandMessage(createProgram('', ''), 'artifact');
+
+    expect(message).toContain('"artifact" is a hosted-mode command');
+    expect(message).toContain('choose hosted mode');
+    // the plugin does not exist, so the old advice could only waste a turn
+    expect(message).not.toContain('plugin search');
+    expect(message).not.toContain('is not installed');
+  });
+
+  it('answers the same way regardless of the case typed', () => {
+    const message = unknownRootCommandMessage(createProgram('', ''), 'Artifact');
+
+    expect(message).toContain('"Artifact" is a hosted-mode command');
+    expect(message).not.toContain('plugin search');
+  });
+
   it('still guides a genuinely unknown token to plugin search', () => {
     const message = unknownRootCommandMessage(createProgram('', ''), 'zzzqqqwww');
 
@@ -74,6 +91,24 @@ describe('reserved roots', () => {
     expect(isReservedRootCommand('setup')).toBe(true);
     expect(isReservedRootCommand('tab')).toBe(false);
     expect(isReservedRootCommand('github')).toBe(false);
+  });
+});
+
+describe('hosted-only roots', () => {
+  it('is exactly the hosted surface local mode does not register', () => {
+    // derived, not listed: a hosted command added later is covered for free
+    for (const name of WEBCMD_ROOT_COMMANDS) expect(isHostedOnlyRootCommand(name)).toBe(false);
+    expect(isHostedOnlyRootCommand('artifact')).toBe(true);
+    expect(isHostedOnlyRootCommand('github')).toBe(false);
+  });
+
+  it('never claims a locally served command is hosted-only', () => {
+    // `web` ships in both surfaces; calling it hosted-only would be a new lie
+    expect(isHostedOnlyRootCommand('web')).toBe(false);
+    expect(isHostedOnlyRootCommand('browser')).toBe(false);
+    expect(isHostedOnlyRootCommand('doctor')).toBe(false);
+    // `setup` is served locally by main.ts before Commander parses argv
+    expect(isHostedOnlyRootCommand('setup')).toBe(false);
   });
 });
 

--- a/src/command-suggest.ts
+++ b/src/command-suggest.ts
@@ -177,9 +177,10 @@ export function isReservedRootCommand(name: string): boolean {
  * A command hosted mode serves that local mode never registers.
  *
  * Derived rather than listed, so a hosted command added later is covered
- * without touching this file. Today that is `artifact`: shell completion offers
- * it in both modes, but locally it resolved to "Site is not installed. Search:
- * webcmd plugin search artifact" — a hunt for a plugin that cannot exist.
+ * without touching this file. Today that is `artifact`, which the CLI reference
+ * lists among the top-level commands: locally it resolved to "Site is not
+ * installed. Search: webcmd plugin search artifact" — a hunt for a plugin that
+ * cannot exist.
  */
 export function isHostedOnlyRootCommand(name: string): boolean {
   if (WEBCMD_ROOT_COMMANDS.has(name)) return false;

--- a/src/command-suggest.ts
+++ b/src/command-suggest.ts
@@ -13,7 +13,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { Command } from 'commander';
 import { CLI_COMMAND } from './brand.js';
-import { HOSTED_ROOT_HELP } from './completion-shared.js';
+import { HOSTED_ONLY_COMMAND_HELP, HOSTED_ROOT_HELP } from './completion-shared.js';
 import { getAdapterLoadFailures, missingPluginGuidance, PLUGINS_DIR, USER_CLIS_DIR } from './discovery.js';
 import { WEBCMD_ROOT_COMMANDS } from './hooks.js';
 
@@ -136,6 +136,15 @@ export function unknownRootCommandMessage(
   const canonical = CANONICAL_ROOT[name.toLowerCase()];
   if (canonical) return `Unknown command "${name}".\nDid you mean: ${canonical}`;
 
+  // An exact hosted-command name is stronger evidence than any edit-distance
+  // guess below it, so this is settled before suggestions run.
+  if (isHostedOnlyRootCommand(name.toLowerCase())) {
+    return [
+      `"${name}" is a hosted-mode command and this installation is in local mode.`,
+      HOSTED_ONLY_COMMAND_HELP,
+    ].join('\n');
+  }
+
   const suggestions = suggestCommands(name, commandCandidates(program));
   if (suggestions.length > 0) return `Unknown command "${name}".\n${formatSuggestions(suggestions)}`;
 
@@ -162,6 +171,23 @@ export function unknownSiteCommandHint(site: string, commandName: string): strin
 export function isReservedRootCommand(name: string): boolean {
   return WEBCMD_ROOT_COMMANDS.has(name)
     || HOSTED_ROOT_HELP.commands.some(command => command.name.split(/\s/, 1)[0] === name);
+}
+
+/**
+ * A command hosted mode serves that local mode never registers.
+ *
+ * Derived rather than listed, so a hosted command added later is covered
+ * without touching this file. Today that is `artifact`: shell completion offers
+ * it in both modes, but locally it resolved to "Site is not installed. Search:
+ * webcmd plugin search artifact" — a hunt for a plugin that cannot exist.
+ */
+export function isHostedOnlyRootCommand(name: string): boolean {
+  if (WEBCMD_ROOT_COMMANDS.has(name)) return false;
+  // `setup` chooses the mode, so both modes serve it. It is absent from
+  // WEBCMD_ROOT_COMMANDS only because main.ts answers it before Commander sees
+  // the argv at all, which would otherwise read here as hosted-only.
+  if (name === 'setup') return false;
+  return HOSTED_ROOT_HELP.commands.some(command => command.name.split(/\s/, 1)[0] === name);
 }
 
 /** Message for an unknown subcommand inside a namespace. Caller writes it to stderr. */

--- a/src/completion-shared.ts
+++ b/src/completion-shared.ts
@@ -26,6 +26,8 @@ export const BUILTIN_COMMANDS = [
 ];
 
 export const LOCAL_ONLY_COMMAND_HELP = 'Run `webcmd setup` and choose local mode to use local-only commands.';
+/** Mirror of {@link LOCAL_ONLY_COMMAND_HELP} for a hosted command reached from local mode. */
+export const HOSTED_ONLY_COMMAND_HELP = 'Run `webcmd setup` and choose hosted mode to use hosted-only commands.';
 
 const HOSTED_CLIENT_ROOT_COMMANDS: readonly RootHelpCommand[] = [
   { name: 'adapter', description: 'Manage hosted adapter sources and overrides' },


### PR DESCRIPTION
## Symptom

In local mode:

```console
$ webcmd artifact download <url> --output ./a.bin
Site "artifact" is not installed.
Search: webcmd plugin search artifact
Install using the installSource returned by search.
```

There is no `artifact` plugin, so that search can only waste a turn — the exact failure mode `command-suggest.ts` was written to end ("telling the caller to search a plugin marketplace for a plugin that cannot exist").

## Cause

`artifact` is a **hosted-mode builtin** (`src/hosted/runner.ts:449`, and in the `builtinCommands` set at `:2134`). It is never registered locally, so the token falls through `unknownRootCommandMessage` to `missingPluginGuidance`.

What points local users at it is `docs/cli-reference.mdx`: the **Top-Level Commands** table listed `artifact` beside `doctor`, `daemon`, and `web` with no mode marker, and the `browser run` section gives the literal `webcmd artifact download <download-url> --output <local-path>`.

Hosted mode already names the mirror-image case with `LOCAL_ONLY_COMMAND_HELP`. Local mode had no equivalent.

## Fix

```console
$ webcmd artifact
"artifact" is a hosted-mode command and this installation is in local mode.
Run `webcmd setup` and choose hosted mode to use hosted-only commands.
```

- `HOSTED_ONLY_COMMAND_HELP` mirrors the existing `LOCAL_ONLY_COMMAND_HELP`.
- `isHostedOnlyRootCommand` is **derived** — hosted root help minus `WEBCMD_ROOT_COMMANDS` — so a hosted command added later is covered without editing this file. Today that set is exactly `{artifact}`.
- `setup` is excluded explicitly. Both modes serve it; it sits outside the local registry only because `main.ts:76` answers it before Commander parses argv, which would otherwise read as hosted-only.
- The check runs **before** the edit-distance suggestions: an exact hosted name is stronger evidence than a fuzzy guess.
- The reference table marks `artifact` "Hosted mode only.", the wording the flag table at `--workspace` already uses.

Unchanged: unknown sites, near misses (`adapters` → `webcmd adapter`), the `CANONICAL_ROOT` intent overrides, the installed-but-failed-to-load path, and the exit code — still `2`, per the envelope contract from #424/#427.

## Correction to an earlier revision of this description

An earlier version of this PR said shell completion advertises `artifact` in both modes. That is wrong, and the code comment repeating it has been fixed. `HOSTED_CLIENT_ROOT_COMMANDS` feeds only `getHostedRootHelp`, which is called from `hosted/runner.ts`; `webcmd completion bash` and `webcmd completion zsh` emit no `artifact` entry in local mode. Completion was already correct — the docs table was not.

## Tests

`src/command-suggest.test.ts`:

- `artifact` names the mode boundary and mentions neither `plugin search` nor `is not installed`;
- the same answer regardless of typed case;
- `isHostedOnlyRootCommand` is false for every member of `WEBCMD_ROOT_COMMANDS`, and specifically for `web`, `browser`, and `doctor` — commands served in both surfaces, where a hosted-only claim would be a new lie;
- `setup` is not reported hosted-only;
- the existing "genuinely unknown token still reaches plugin search" test is untouched and passing.

Verified against a built CLI: `webcmd artifact` and `webcmd artifact download` both print the new message and exit 2; `webcmd bogus` still prints the plugin guidance.

`npx vitest run --project unit` — no new failures against `main` on this machine (25 pre-existing Windows symlink-`EPERM` failures on both). `npm run typecheck` and `npm run check:typed-error-lint` clean.
