### PR TITLE
fix: release standalone plugin compatibility as 0.7.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Webcmd Cloud can run supported commands and browser sessions on hosted infrastru
 
 Site adapters live in [`agentrhq/webcmd-plugins`](https://github.com/agentrhq/webcmd-plugins). Search and install them with:
 
+Use Webcmd 0.7.11 or newer for compatibility with the standalone plugin catalog.
+
 ```bash
 webcmd plugin search <site> -f json
 webcmd plugin install github:agentrhq/webcmd-plugins/<name>


### PR DESCRIPTION
## Summary

- document that the standalone community plugin catalog requires Webcmd 0.7.11 or newer
- publish the compatibility bridge merged in #472 as a patch release
- explicitly select version 0.7.11

Release-As: 0.7.11

## Verification

- `npx --yes -p node@22 -c "npm test"` — 167 files passed, 3,158 tests passed, 1 skipped
- Node 22 typecheck and build passed
- hosted contract, Codex/Claude plugin metadata, and packaged binary checks passed
- Release Please 17.3.0 dry-run generated a `webcmd 0.7.11` candidate

## Release sequence

Merging this trigger PR makes Release Please open the generated Webcmd 0.7.11 release PR. Merging that generated PR creates the tag, GitHub release, and npm publication.