### PR TITLE
Fix SLAB full-parity session orchestration

### DIFF
--- a/docs/authentication-and-profiles.mdx
+++ b/docs/authentication-and-profiles.mdx
@@ -20,6 +20,13 @@ windows/workspaces within a profile; separate Sessions let multiple agents use
 the same profile in parallel. Use a named profile when work and personal
 accounts, customers, or environments must stay separate.
 
+When SLAB is the local runtime, a Session may create its own browser window or
+explicitly bind an existing human window. `browser tabs` discovers unbound
+windows without changing them, and binding one tab claims the complete
+containing window. Normal Session close detaches an adopted human window rather
+than closing it. Discovery IDs are live-runtime identities; list again after a
+browser or daemon restart.
+
 ## Hosted Profiles
 
 Webcmd Cloud scopes every hosted profile to a workspace. A workspace is an ambient container the CLI resolves once per invocation: the `--workspace <id>` flag if present, otherwise the `WEBCMD_WORKSPACE` environment variable, otherwise an implicit default workspace. Within that workspace, `--profile <name>` selects a persona; an unset or default profile lazily creates that workspace's own `default` profile the first time it is used.

--- a/mcp-skills/webcmd-browser.md
+++ b/mcp-skills/webcmd-browser.md
@@ -9,8 +9,16 @@ action, and close it when finished. IDs are immutable and Profile-scoped. Raw
 browser commands require an explicit readable selector. Each invocation has a
 240-second wall-clock budget.
 
+With SLAB, `session list` includes unbound live windows as `discovered` rows and
+`browser tabs` lists their pages without claiming them. Bind an exact returned
+page with `browser bind --page <page-id>`; this claims its complete window.
+Discovered IDs expire when the browser attachment or daemon restarts, so list
+again after a stale-ID failure. Closing an adopted human Session detaches Webcmd
+and leaves the human window open.
+
     { "argv": ["--profile", "work", "session", "create", "Work Project", "-f", "json"] }
     { "argv": ["--profile", "work", "--session", "work-project-k7", "browser", "tabs", "-f", "json"] }
+    { "argv": ["--profile", "work", "--session", "work-project-k7", "browser", "bind", "--page", "page-123", "-f", "json"] }
     { "argv": ["--profile", "work", "--session", "work-project-k7", "browser", "snapshot", "--snapshot-mode", "act", "-f", "json"] }
     { "argv": ["--profile", "work", "session", "close", "work-project-k7"] }
 

--- a/skill-src/cli/webcmd-browser/SKILL.src.md
+++ b/skill-src/cli/webcmd-browser/SKILL.src.md
@@ -71,7 +71,7 @@ webcmd --profile work session close work-project-k7
 
 ## Command surface
 
-The raw surface is `tabs`, `bind --page`, `snapshot`, `run`, and `close`. Close a whole Session through `webcmd session close`; close one exact agent-owned tab with `browser close --page <page-id>`. A human-adopted tab requires command-local `--force`.
+The raw surface is `tabs`, `bind --page`, `snapshot`, and `run`. Close a whole Session through `webcmd session close`; close one tab with `browser close --page <page-id>`. A human-adopted tab requires `--force`.
 
 Common calls:
 
@@ -174,7 +174,7 @@ when applicable. Do not close that Session during the live handoff.
 2. If the site exposes a login command, run `webcmd <site> login`.
 3. `already_logged_in` is verified; continue.
 4. `in_progress` means no current user action, so do not ask the user, wait for confirmation, or poll.
-5. `action_required` is a hard stop. Give the user its instructions and any returned `action_url` or `view_url`. If Webcmd returned no URL, use the current visible browser.
+5. `action_required` is a hard stop. Give the user its instructions and any returned `action_url` or `view_url`. If Webcmd returned no URL, use the visible browser.
 6. Never ask for or type passwords, OTPs, recovery codes, cookies, credentials, or session secrets. Never echo or store them.
 7. Run the returned `verify_command` or `handoff.verifyCommand` only after the user reports done; verification must succeed before retrying.
 8. Without a verifier, take a fresh snapshot and verify the intended identity check or post-action state before any retry, especially for write commands. The user's report alone is not verification.

--- a/skill-src/cli/webcmd-browser/SKILL.src.md
+++ b/skill-src/cli/webcmd-browser/SKILL.src.md
@@ -37,13 +37,14 @@ Until `doctor` is green, browser commands may fail.
 - Create a named profile first: `webcmd profile create <profile>`. If an explicit profile returns `PROFILE_NOT_FOUND`, create it, then retry session creation.
 - Raw browser commands require the returned readable ID at the root: `webcmd --profile <profile> --session <session-id> browser ...`.
 - Profiles are cookie jars and auth scope; Sessions are browser workspaces/windows within a Profile. Session IDs are immutable and Profile-scoped. Parallel agents use separate Sessions.
-- `webcmd session list` shows sessions and their handoff/runtime state; close finished work with `webcmd session close <session-id>`. Close is blocked while that Session has a live handoff.
+- `webcmd session list` shows durable sessions and, with SLAB, unbound live windows as `discovered` rows. Discovered window/page IDs are temporary; list again after browser or daemon restart.
+- Close finished work with `webcmd session close <session-id>`. It closes an agent-created window but only detaches a human window explicitly bound through SLAB. Close is blocked while that Session has a live handoff.
 - Browser state in the bound page persists between calls, but each `run` gets a fresh JavaScript scope.
-- `webcmd --session <session-id> browser tabs` lists existing pages without creating a new one.
-- `webcmd --session <session-id> browser bind --page <page-id>` explicitly attaches the session to an existing page.
+- `webcmd --session <session-id> browser tabs` lists owned pages and discoverable unowned SLAB tabs without creating, focusing, or claiming a page.
+- `webcmd --session <session-id> browser bind --page <page-id>` explicitly claims the selected tab's complete SLAB window, including sibling tabs.
 - If the user manually signs in or changes the visible tab, re-bind or inspect with a fresh snapshot before continuing.
 
-Raw browser commands require an explicit readable selector. Local browser commands use Cloak; hosted browser commands use Webcmd Cloud and Browser Use.
+Raw browser commands require an explicit readable selector. Local browser commands use the configured browser runtime; hosted browser commands use Webcmd Cloud and Browser Use.
 
 ```bash
 webcmd site memory context https://example.com/ --task-id task-1 -f json
@@ -70,15 +71,16 @@ webcmd --profile work session close work-project-k7
 
 ## Command surface
 
-The raw surface is `tabs`, `bind --page`, `snapshot`, and `run`; close through `webcmd session close`.
+The raw surface is `tabs`, `bind --page`, `snapshot`, `run`, and `close`. Close a whole Session through `webcmd session close`; close one exact agent-owned tab with `browser close --page <page-id>`. A human-adopted tab requires command-local `--force`.
 
 Common calls:
 
-1. `webcmd --session <session-id> browser tabs` lists existing pages and is read-only.
-2. `webcmd --session <session-id> browser bind --page page-123` is an explicit bind that selects one page.
+1. `webcmd --session <session-id> browser tabs` lists existing pages and is read-only. In SLAB, unowned human tabs are discoverable but remain untouched.
+2. `webcmd --session <session-id> browser bind --page page-123` explicitly binds the complete containing window. Re-list if a temporary discovered ID is stale.
 3. `webcmd --session <session-id> browser snapshot --snapshot-mode act` inspects actionable controls. Use `--snapshot-mode tree` for fuller page structure or `--snapshot-mode read` for readable article/content text.
 4. `webcmd --session <session-id> browser run --stdin` runs one JavaScript program with fresh JavaScript scope and persistent browser state in the bound page.
 5. `webcmd session close <session-id>` closes the session when finished.
+6. `webcmd --session <session-id> browser close --page <page-id> --force` destructively closes exactly one adopted human tab; omit `--force` for agent-owned tabs.
 
 | command | use |
 | --- | --- |

--- a/skill-src/mcp/webcmd-browser.src.md
+++ b/skill-src/mcp/webcmd-browser.src.md
@@ -9,8 +9,16 @@ action, and close it when finished. IDs are immutable and Profile-scoped. Raw
 browser commands require an explicit readable selector. Each invocation has a
 240-second wall-clock budget.
 
+With SLAB, `session list` includes unbound live windows as `discovered` rows and
+`browser tabs` lists their pages without claiming them. Bind an exact returned
+page with `browser bind --page <page-id>`; this claims its complete window.
+Discovered IDs expire when the browser attachment or daemon restarts, so list
+again after a stale-ID failure. Closing an adopted human Session detaches Webcmd
+and leaves the human window open.
+
     { "argv": ["--profile", "work", "session", "create", "Work Project", "-f", "json"] }
     { "argv": ["--profile", "work", "--session", "work-project-k7", "browser", "tabs", "-f", "json"] }
+    { "argv": ["--profile", "work", "--session", "work-project-k7", "browser", "bind", "--page", "page-123", "-f", "json"] }
     { "argv": ["--profile", "work", "--session", "work-project-k7", "browser", "snapshot", "--snapshot-mode", "act", "-f", "json"] }
     { "argv": ["--profile", "work", "session", "close", "work-project-k7"] }
 

--- a/skills/webcmd-browser/SKILL.md
+++ b/skills/webcmd-browser/SKILL.md
@@ -71,7 +71,7 @@ webcmd --profile work session close work-project-k7
 
 ## Command surface
 
-The raw surface is `tabs`, `bind --page`, `snapshot`, `run`, and `close`. Close a whole Session through `webcmd session close`; close one exact agent-owned tab with `browser close --page <page-id>`. A human-adopted tab requires command-local `--force`.
+The raw surface is `tabs`, `bind --page`, `snapshot`, and `run`. Close a whole Session through `webcmd session close`; close one tab with `browser close --page <page-id>`. A human-adopted tab requires `--force`.
 
 Common calls:
 
@@ -174,7 +174,7 @@ when applicable. Do not close that Session during the live handoff.
 2. If the site exposes a login command, run `webcmd <site> login`.
 3. `already_logged_in` is verified; continue.
 4. `in_progress` means no current user action, so do not ask the user, wait for confirmation, or poll.
-5. `action_required` is a hard stop. Give the user its instructions and any returned `action_url` or `view_url`. If Webcmd returned no URL, use the current visible browser.
+5. `action_required` is a hard stop. Give the user its instructions and any returned `action_url` or `view_url`. If Webcmd returned no URL, use the visible browser.
 6. Never ask for or type passwords, OTPs, recovery codes, cookies, credentials, or session secrets. Never echo or store them.
 7. Run the returned `verify_command` or `handoff.verifyCommand` only after the user reports done; verification must succeed before retrying.
 8. Without a verifier, take a fresh snapshot and verify the intended identity check or post-action state before any retry, especially for write commands. The user's report alone is not verification.

--- a/skills/webcmd-browser/SKILL.md
+++ b/skills/webcmd-browser/SKILL.md
@@ -37,13 +37,14 @@ Until `doctor` is green, browser commands may fail.
 - Create a named profile first: `webcmd profile create <profile>`. If an explicit profile returns `PROFILE_NOT_FOUND`, create it, then retry session creation.
 - Raw browser commands require the returned readable ID at the root: `webcmd --profile <profile> --session <session-id> browser ...`.
 - Profiles are cookie jars and auth scope; Sessions are browser workspaces/windows within a Profile. Session IDs are immutable and Profile-scoped. Parallel agents use separate Sessions.
-- `webcmd session list` shows sessions and their handoff/runtime state; close finished work with `webcmd session close <session-id>`. Close is blocked while that Session has a live handoff.
+- `webcmd session list` shows durable sessions and, with SLAB, unbound live windows as `discovered` rows. Discovered window/page IDs are temporary; list again after browser or daemon restart.
+- Close finished work with `webcmd session close <session-id>`. It closes an agent-created window but only detaches a human window explicitly bound through SLAB. Close is blocked while that Session has a live handoff.
 - Browser state in the bound page persists between calls, but each `run` gets a fresh JavaScript scope.
-- `webcmd --session <session-id> browser tabs` lists existing pages without creating a new one.
-- `webcmd --session <session-id> browser bind --page <page-id>` explicitly attaches the session to an existing page.
+- `webcmd --session <session-id> browser tabs` lists owned pages and discoverable unowned SLAB tabs without creating, focusing, or claiming a page.
+- `webcmd --session <session-id> browser bind --page <page-id>` explicitly claims the selected tab's complete SLAB window, including sibling tabs.
 - If the user manually signs in or changes the visible tab, re-bind or inspect with a fresh snapshot before continuing.
 
-Raw browser commands require an explicit readable selector. Local browser commands use Cloak; hosted browser commands use Webcmd Cloud and Browser Use.
+Raw browser commands require an explicit readable selector. Local browser commands use the configured browser runtime; hosted browser commands use Webcmd Cloud and Browser Use.
 
 ```bash
 webcmd site memory context https://example.com/ --task-id task-1 -f json
@@ -70,15 +71,16 @@ webcmd --profile work session close work-project-k7
 
 ## Command surface
 
-The raw surface is `tabs`, `bind --page`, `snapshot`, and `run`; close through `webcmd session close`.
+The raw surface is `tabs`, `bind --page`, `snapshot`, `run`, and `close`. Close a whole Session through `webcmd session close`; close one exact agent-owned tab with `browser close --page <page-id>`. A human-adopted tab requires command-local `--force`.
 
 Common calls:
 
-1. `webcmd --session <session-id> browser tabs` lists existing pages and is read-only.
-2. `webcmd --session <session-id> browser bind --page page-123` is an explicit bind that selects one page.
+1. `webcmd --session <session-id> browser tabs` lists existing pages and is read-only. In SLAB, unowned human tabs are discoverable but remain untouched.
+2. `webcmd --session <session-id> browser bind --page page-123` explicitly binds the complete containing window. Re-list if a temporary discovered ID is stale.
 3. `webcmd --session <session-id> browser snapshot --snapshot-mode act` inspects actionable controls. Use `--snapshot-mode tree` for fuller page structure or `--snapshot-mode read` for readable article/content text.
 4. `webcmd --session <session-id> browser run --stdin` runs one JavaScript program with fresh JavaScript scope and persistent browser state in the bound page.
 5. `webcmd session close <session-id>` closes the session when finished.
+6. `webcmd --session <session-id> browser close --page <page-id> --force` destructively closes exactly one adopted human tab; omit `--force` for agent-owned tabs.
 
 | command | use |
 | --- | --- |

--- a/src/browser/command-catalog.ts
+++ b/src/browser/command-catalog.ts
@@ -209,6 +209,8 @@ export const browserCommandCatalog: readonly HostedBrowserCommandContract[] = [
     verboseFlag(),
   ], 'require-existing'),
   command('close', 'Close or detach this browser session', 'close-window', [], [
+    option('page', 'Stable page id to close exactly'),
+    flag('force', 'Allow destructive closure of a human-adopted tab'),
     verboseFlag(),
   ], 'close-existing'),
 ] as const;

--- a/src/browser/daemon-lifecycle.test.ts
+++ b/src/browser/daemon-lifecycle.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const spawnMock = vi.hoisted(() => vi.fn((..._args: unknown[]) => ({ unref: vi.fn() })));
+
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...await importOriginal<typeof import('node:child_process')>(),
+  spawn: spawnMock,
+}));
+
+import { browserConnectErrorFromHealth, spawnDaemonProcess } from './daemon-lifecycle.js';
+
+describe('spawnDaemonProcess', () => {
+  const originalTmpdir = process.env.TMPDIR;
+
+  afterEach(() => {
+    spawnMock.mockClear();
+    if (originalTmpdir === undefined) delete process.env.TMPDIR;
+    else process.env.TMPDIR = originalTmpdir;
+  });
+
+  it('does not inherit a caller-owned temporary directory', () => {
+    process.env.TMPDIR = '/tmp/deleted-eval-attempt/tmp';
+
+    spawnDaemonProcess();
+
+    expect(spawnMock).toHaveBeenCalledOnce();
+    const options = spawnMock.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(options?.env).not.toHaveProperty('TMPDIR');
+    expect(options?.env).not.toHaveProperty('TMP');
+    expect(options?.env).not.toHaveProperty('TEMP');
+  });
+});
+
+describe('provider-specific readiness errors', () => {
+  it('never tells a SLAB user to open Chrome or enable Cloak', () => {
+    for (const state of ['profile-disconnected', 'no-runtime'] as const) {
+      const error = browserConnectErrorFromHealth({ state, status: null } as never, 'work', 'slab');
+      expect(`${error.message}\n${error.hint}`).toContain('SLAB');
+      expect(`${error.message}\n${error.hint}`).not.toMatch(/Chrome|Cloak/);
+    }
+  });
+
+  it('names configured direct and custom runtimes without Cloak instructions', () => {
+    const chrome = browserConnectErrorFromHealth({ state: 'no-runtime', status: null } as never, undefined, 'chrome');
+    const custom = browserConnectErrorFromHealth({ state: 'no-runtime', status: null } as never, undefined, 'custom');
+    expect(chrome.hint).toContain('configured Chrome runtime');
+    expect(custom.hint).toContain('custom browser runtime');
+    expect(`${chrome.hint}${custom.hint}`).not.toContain('Cloak');
+  });
+});

--- a/src/browser/daemon-lifecycle.ts
+++ b/src/browser/daemon-lifecycle.ts
@@ -44,10 +44,14 @@ export function resolveDaemonLaunchSpec(): DaemonLaunchSpec {
 
 export function spawnDaemonProcess(): ChildProcess {
   const launch = resolveDaemonLaunchSpec();
+  const env = { ...process.env };
+  delete env.TMPDIR;
+  delete env.TMP;
+  delete env.TEMP;
   const proc = spawn(launch.binary, launch.args, {
     detached: true,
     stdio: 'ignore',
-    env: { ...process.env },
+    env,
   });
   proc.unref();
   return proc;
@@ -183,8 +187,9 @@ export async function ensureBrowserBridgeReady(
     }
     spawnedProcess = daemonLifecycleHooks.spawnDaemonProcess();
   } else if (verbose && (isVerbose() || process.stderr.isTTY)) {
-    process.stderr.write('⏳ Waiting for Cloak to connect...\n');
-    process.stderr.write('   Make sure Chrome/Chromium is open and Cloak is enabled.\n');
+    const kind = selectedLocalBrowserKind();
+    process.stderr.write(`⏳ Waiting for ${runtimeLabel(kind)} to connect...\n`);
+    process.stderr.write(`   ${runtimeReadinessHint(kind)}\n`);
   }
 
   if (selectedSlab) {
@@ -208,7 +213,24 @@ function selectedLocalBrowserKind(): 'cloak' | 'chrome' | 'slab' | 'custom' {
   return config.mode === 'local' ? config.browser.kind : 'cloak';
 }
 
-function browserConnectErrorFromHealth(health: DaemonHealth, contextId?: string): BrowserConnectError {
+type LocalBrowserKind = 'cloak' | 'chrome' | 'slab' | 'custom';
+
+function runtimeLabel(kind: LocalBrowserKind): string {
+  return kind === 'slab' ? 'SLAB' : kind === 'cloak' ? 'Cloak' : kind === 'chrome' ? 'Chrome' : 'the custom browser runtime';
+}
+
+function runtimeReadinessHint(kind: LocalBrowserKind): string {
+  if (kind === 'slab') return 'Open SLAB and retry the browser command.';
+  if (kind === 'cloak') return 'Make sure Chrome/Chromium is open and Cloak is enabled.';
+  if (kind === 'chrome') return 'Make sure the configured Chrome runtime is open and reachable.';
+  return 'Make sure the configured custom browser runtime is running and reachable.';
+}
+
+export function browserConnectErrorFromHealth(
+  health: DaemonHealth,
+  contextId?: string,
+  kind: LocalBrowserKind = selectedLocalBrowserKind(),
+): BrowserConnectError {
   if (health.state === 'profile-required') {
     return new BrowserConnectError(
       'Multiple browser profiles are connected',
@@ -221,14 +243,14 @@ function browserConnectErrorFromHealth(health: DaemonHealth, contextId?: string)
     const label = contextId ?? health.status.contextId ?? 'unknown';
     return new BrowserConnectError(
       `Browser profile "${label}" is not connected`,
-      'Open the matching Chrome profile and make sure Cloak is enabled, or choose another profile with webcmd profile use <name>.',
+      `${kind === 'slab' ? 'Open SLAB and verify that Profile' : `Open the matching ${runtimeLabel(kind)} profile`} "${label}" is available, or choose another profile with webcmd profile use <name>.`,
       'profile-disconnected',
     );
   }
   if (health.state === 'no-runtime') {
     return new BrowserConnectError(
       'Browser runtime is not ready',
-      'Open Chrome/Chromium with Cloak enabled and retry the browser command. Run `webcmd doctor` for local status.',
+      `${runtimeReadinessHint(kind)} Run \`webcmd doctor\` for local status.`,
       'runtime-not-ready',
     );
   }

--- a/src/browser/humanizer/elementhandle.ts
+++ b/src/browser/humanizer/elementhandle.ts
@@ -27,6 +27,25 @@ import {
   CHECKS_CLICK, CHECKS_HOVER, CHECKS_INPUT, CHECKS_FOCUS, CHECKS_CHECK,
 } from './actionability.js';
 
+const patchedHandles = new WeakMap<Page, Map<ElementHandle, Map<PropertyKey, PropertyDescriptor | undefined>>>();
+const ELEMENT_HANDLE_KEYS = [
+  '$', '$$', 'waitForSelector', 'click', 'dblclick', 'hover', 'type', 'fill',
+  'press', 'selectOption', 'check', 'uncheck', 'setChecked', 'tap', 'focus',
+  'scrollIntoViewIfNeeded', '_humanPatched',
+] as const;
+
+export function restorePatchedElementHandles(page: Page): void {
+  const handles = patchedHandles.get(page);
+  if (!handles) return;
+  for (const [handle, descriptors] of handles) {
+    for (const [key, descriptor] of descriptors) {
+      if (descriptor) Object.defineProperty(handle, key, descriptor);
+      else Reflect.deleteProperty(handle, key);
+    }
+  }
+  patchedHandles.delete(page);
+}
+
 // --- Platform-aware select-all shortcut ---
 const SELECT_ALL = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
 
@@ -92,6 +111,9 @@ export function patchSingleElementHandle(
   stealth: any,
 ): void {
   if ((el as any)._humanPatched) return;
+  const handles = patchedHandles.get(page) ?? new Map();
+  handles.set(el, new Map(ELEMENT_HANDLE_KEYS.map(key => [key, Object.getOwnPropertyDescriptor(el, key)])));
+  patchedHandles.set(page, handles);
   (el as any)._humanPatched = true;
 
   // Save originals

--- a/src/browser/humanizer/index.ts
+++ b/src/browser/humanizer/index.ts
@@ -59,18 +59,29 @@ const SELECT_ALL = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
  */
 class StealthEval {
   private cdp: CDPSession | null = null;
+  private cdpPromise: Promise<CDPSession> | null = null;
   private contextId: number | null = null;
   private page: Page;
+  private disposed = false;
 
   constructor(page: Page) {
     this.page = page;
   }
 
   private async ensureCdp(): Promise<CDPSession> {
-    if (!this.cdp) {
-      this.cdp = await this.page.context().newCDPSession(this.page);
+    if (this.disposed) throw new Error('Humanizer has been disposed.');
+    if (this.cdp) return this.cdp;
+    if (!this.cdpPromise) {
+      this.cdpPromise = this.page.context().newCDPSession(this.page).then(async cdp => {
+        if (this.disposed) {
+          await cdp.detach().catch(() => {});
+          throw new Error('Humanizer has been disposed.');
+        }
+        this.cdp = cdp;
+        return cdp;
+      });
     }
-    return this.cdp;
+    return this.cdpPromise;
   }
 
   private async createWorld(): Promise<number> {
@@ -141,6 +152,17 @@ class StealthEval {
   async getCdpSession(): Promise<CDPSession> {
     return this.ensureCdp();
   }
+
+  async dispose(): Promise<void> {
+    this.disposed = true;
+    const cdp = this.cdp;
+    const pending = this.cdpPromise;
+    this.cdp = null;
+    this.cdpPromise = null;
+    this.contextId = null;
+    if (cdp) await cdp.detach().catch(() => {});
+    else await pending?.catch(() => {});
+  }
 }
 
 
@@ -152,6 +174,20 @@ class CursorState {
   x = 0;
   y = 0;
   initialized = false;
+}
+
+const patchedFrames = new WeakMap<Page, Set<Frame>>();
+
+export function restorePatchedFrames(page: Page): void {
+  for (const frame of patchedFrames.get(page) ?? []) {
+    const descriptors = (frame as any)._humanRestoreDescriptors as Map<PropertyKey, PropertyDescriptor | undefined> | undefined;
+    if (!descriptors) continue;
+    for (const [key, descriptor] of descriptors) {
+      if (descriptor) Object.defineProperty(frame, key, descriptor);
+      else Reflect.deleteProperty(frame, key);
+    }
+  }
+  patchedFrames.delete(page);
 }
 
 export function createCursorState(): CursorState {
@@ -681,6 +717,17 @@ function patchSingleFrame(
   stealth: StealthEval,
 ): void {
   if ((frame as any)._humanPatched) return;
+  const frameKeys = [
+    'click', 'dblclick', 'hover', 'type', 'fill', 'check', 'uncheck',
+    'selectOption', 'press', 'pressSequentially', 'tap', 'clear', 'dragAndDrop',
+    '$', '$$', 'waitForSelector', '_humanPatched', '_humanRestoreDescriptors',
+  ] as const;
+  (frame as any)._humanRestoreDescriptors = new Map(
+    frameKeys.map(key => [key, Object.getOwnPropertyDescriptor(frame, key)]),
+  );
+  const frames = patchedFrames.get(page) ?? new Set<Frame>();
+  frames.add(frame);
+  patchedFrames.set(page, frames);
   (frame as any)._humanPatched = true;
 
   // Save originals for methods that need fallback

--- a/src/browser/humanizer/page.test.ts
+++ b/src/browser/humanizer/page.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { HumanConfig } from './config.js';
 import * as humanizer from './index.js';
-import { humanizePage } from './page.js';
+import { disposeHumanizedPage, humanizePage } from './page.js';
 
 const FAST_HUMAN_CONFIG: Partial<HumanConfig> = {
   initial_cursor_x: [0, 0],
@@ -41,6 +41,7 @@ const FAST_HUMAN_CONFIG: Partial<HumanConfig> = {
 
 function fakeCdpSession() {
   return {
+    detach: vi.fn().mockResolvedValue(undefined),
     send: vi.fn(async (method: string) => {
       if (method === 'Page.getFrameTree') return { frameTree: { frame: { id: 'frame-1' } } };
       if (method === 'Page.createIsolatedWorld') return { executionContextId: 7 };
@@ -201,6 +202,56 @@ afterEach(() => {
 });
 
 describe('humanizePage', () => {
+  it('awaits an exactly-once disposer that restores Page, mouse, keyboard, and Frame wrappers and detaches stealth CDP', async () => {
+    const childFrame = fakeFrame();
+    const mainFrame = fakeFrame();
+    mainFrame.childFrames.mockReturnValue([childFrame]);
+    const owned = fakePage({ mainFrame });
+    const pageClick = owned.page.click;
+    const mouseMove = owned.page.mouse.move;
+    const keyboardType = owned.page.keyboard.type;
+    const pageDollar = owned.page.$;
+    const pageDollars = owned.page.$$;
+    const pageWaitForSelector = owned.page.waitForSelector;
+    const frameClick = childFrame.click;
+    const frameDollar = childFrame.$;
+
+    humanizePage(owned.page as any, FAST_HUMAN_CONFIG);
+    await (owned.page as any)._stealth.getCdpSession();
+
+    await Promise.all([
+      disposeHumanizedPage(owned.page as any),
+      disposeHumanizedPage(owned.page as any),
+    ]);
+
+    expect(owned.page.click).toBe(pageClick);
+    expect(owned.page.mouse.move).toBe(mouseMove);
+    expect(owned.page.keyboard.type).toBe(keyboardType);
+    expect(owned.page.$).toBe(pageDollar);
+    expect(owned.page.$$).toBe(pageDollars);
+    expect(owned.page.waitForSelector).toBe(pageWaitForSelector);
+    expect(childFrame.click).toBe(frameClick);
+    expect(childFrame.$).toBe(frameDollar);
+    expect((childFrame as any)._humanPatched).toBeUndefined();
+    expect(owned.cdp.detach).toHaveBeenCalledOnce();
+  });
+
+  it('restores Frame wrappers added after navigation', async () => {
+    const mainFrame = fakeFrame();
+    const owned = fakePage({ mainFrame });
+    humanizePage(owned.page as any, FAST_HUMAN_CONFIG);
+    const lateFrame = fakeFrame();
+    const lateClick = lateFrame.click;
+    mainFrame.childFrames.mockReturnValue([lateFrame]);
+
+    await owned.page.goto('https://example.test/');
+    expect(lateFrame.click).not.toBe(lateClick);
+    mainFrame.childFrames.mockReturnValue([]);
+    await disposeHumanizedPage(owned.page as any);
+
+    expect(lateFrame.click).toBe(lateClick);
+    expect((lateFrame as any)._humanPatched).toBeUndefined();
+  });
   it('patches only the supplied Page once without touching its context, browser, or other pages', () => {
     const owned = fakePage();
     const human = fakePage();
@@ -363,5 +414,9 @@ describe('humanizePage', () => {
     expect(rawOwnedHandleClick).not.toHaveBeenCalled();
     expect(owned.page.mouse.down).toHaveBeenCalledOnce();
     expect(owned.page.mouse.up).toHaveBeenCalledOnce();
+
+    await disposeHumanizedPage(owned.page as any);
+    expect(patchedHandle.click).toBe(rawOwnedHandleClick);
+    expect((patchedHandle as any)._humanPatched).toBeUndefined();
   });
 });

--- a/src/browser/humanizer/page.ts
+++ b/src/browser/humanizer/page.ts
@@ -3,13 +3,93 @@
  * at git commit 5176971f45d02845d3d1c0adbbda0bc93addf747. See NOTICE.
  */
 import type { Page } from 'playwright-core';
-import { createCursorState, patchPage, resolveConfig, type HumanConfig } from './index.js';
+import { createCursorState, patchPage, resolveConfig, restorePatchedFrames, type HumanConfig } from './index.js';
+import { restorePatchedElementHandles } from './elementhandle.js';
 
 const humanizedPages = new WeakSet<Page>();
+const pageSnapshots = new WeakMap<Page, {
+  page: Map<PropertyKey, PropertyDescriptor | undefined>;
+  mouse: Map<PropertyKey, PropertyDescriptor | undefined>;
+  keyboard: Map<PropertyKey, PropertyDescriptor | undefined>;
+  frames: Array<{ frame: object; descriptors: Map<PropertyKey, PropertyDescriptor | undefined> }>;
+}>();
+const disposalPromises = new WeakMap<Page, Promise<void>>();
+
+const PAGE_KEYS = [
+  'goto', 'click', 'dblclick', 'hover', 'type', 'fill', 'check', 'uncheck',
+  'selectOption', 'press', 'pressSequentially', 'tap', 'clear', '_original',
+  '$', '$$', 'waitForSelector',
+  '_humanCfg', '_stealth', '_humanCursor', '_humanRaw', '_humanRawKb',
+  '_humanOriginals', '_humanClickFn', '_humanHoverFn', '_humanClearFn',
+  '_humanPressFn', '_humanPressSequentiallyFn', '_humanTapFn', '_ensureCursorInit',
+] as const;
+
+const MOUSE_KEYS = ['move', 'click', 'dblclick', 'wheel', 'down', 'up'] as const;
+const KEYBOARD_KEYS = ['type', 'down', 'up', 'press', 'insertText'] as const;
+const FRAME_KEYS = [
+  'click', 'dblclick', 'hover', 'type', 'fill', 'check', 'uncheck',
+  'selectOption', 'press', 'pressSequentially', 'tap', 'clear', 'dragAndDrop',
+  '$', '$$', 'waitForSelector', '_humanPatched',
+] as const;
+
+function currentFrames(page: Page): object[] {
+  try {
+    const main = page.mainFrame();
+    return [main, ...main.childFrames()];
+  } catch {
+    return [];
+  }
+}
 
 export function humanizePage(page: Page, config?: Partial<HumanConfig>): Page {
   if (humanizedPages.has(page)) return page;
+  disposalPromises.delete(page);
+  pageSnapshots.set(page, {
+    page: new Map(PAGE_KEYS.map(key => [key, Object.getOwnPropertyDescriptor(page, key)])),
+    mouse: new Map(MOUSE_KEYS.map(key => [key, Object.getOwnPropertyDescriptor(page.mouse, key)])),
+    keyboard: new Map(KEYBOARD_KEYS.map(key => [key, Object.getOwnPropertyDescriptor(page.keyboard, key)])),
+    frames: currentFrames(page).map(frame => ({
+      frame,
+      descriptors: new Map(FRAME_KEYS.map(key => [key, Object.getOwnPropertyDescriptor(frame, key)])),
+    })),
+  });
   patchPage(page, resolveConfig('default', config), createCursorState());
   humanizedPages.add(page);
   return page;
+}
+
+export function restoreHumanizedPage(page: Page): void {
+  const snapshot = pageSnapshots.get(page);
+  if (!snapshot) return;
+  const restore = (target: object, entries: Map<PropertyKey, PropertyDescriptor | undefined>) => {
+    for (const [key, descriptor] of entries) {
+      if (descriptor) Object.defineProperty(target, key, descriptor);
+      else Reflect.deleteProperty(target, key);
+    }
+  };
+  restore(page, snapshot.page);
+  restore(page.mouse, snapshot.mouse);
+  restore(page.keyboard, snapshot.keyboard);
+  restorePatchedElementHandles(page);
+  restorePatchedFrames(page);
+  const frames = new Map(snapshot.frames.map(frame => [frame.frame, frame.descriptors]));
+  for (const frame of currentFrames(page)) {
+    const dynamic = (frame as { _humanRestoreDescriptors?: Map<PropertyKey, PropertyDescriptor | undefined> })._humanRestoreDescriptors;
+    if (dynamic) frames.set(frame, dynamic);
+  }
+  for (const [frame, descriptors] of frames) restore(frame, descriptors);
+  pageSnapshots.delete(page);
+  humanizedPages.delete(page);
+}
+
+export function disposeHumanizedPage(page: Page): Promise<void> {
+  const existing = disposalPromises.get(page);
+  if (existing) return existing;
+  const dispose = (async () => {
+    const stealth = (page as unknown as { _stealth?: { dispose?: () => Promise<void> } })._stealth;
+    await stealth?.dispose?.();
+    restoreHumanizedPage(page);
+  })();
+  disposalPromises.set(page, dispose);
+  return dispose;
 }

--- a/src/browser/page.test.ts
+++ b/src/browser/page.test.ts
@@ -448,6 +448,19 @@ describe('Page active target tracking', () => {
     }));
   });
 
+  it('passes an explicit destructive force only for the selected tab close', async () => {
+    sendCommandMock.mockResolvedValueOnce({ closed: 'page-2' });
+
+    const page = new Page('default');
+    await page.closeTab?.('page-2', { force: true });
+
+    expect(sendCommandMock).toHaveBeenCalledWith('tabs', expect.objectContaining({
+      op: 'close',
+      page: 'page-2',
+      force: true,
+    }));
+  });
+
   it('clears the active page binding when closing the selected tab by numeric index', async () => {
     sendCommandFullMock.mockResolvedValueOnce({ data: { selected: true }, page: 'page-2' });
     sendCommandMock

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -237,11 +237,12 @@ export class Page extends BasePage {
     return result.page;
   }
 
-  async closeTab(target?: number | string): Promise<void> {
+  async closeTab(target?: number | string, options: { force?: boolean } = {}): Promise<void> {
     const params: Record<string, unknown> = { op: 'close', ...this._sessionOpts() };
     if (typeof target === 'number') params.index = target;
     else if (typeof target === 'string') params.page = target;
     else if (this._page !== undefined) params.page = this._page;
+    if (options.force === true) params.force = true;
 
     const result = await sendCommand('tabs', params) as { closed?: string } | null;
     const closedPage = typeof result?.closed === 'string' ? result.closed : undefined;

--- a/src/browser/profile-concurrency.test.ts
+++ b/src/browser/profile-concurrency.test.ts
@@ -32,8 +32,9 @@ describe('provider Profile config transactions', () => {
   it('serializes mutations made by independent processes', async () => {
     const run = promisify(execFile);
     const moduleUrl = new URL('./profile.ts', import.meta.url).href;
-    const executable = path.resolve('node_modules/.bin/tsx');
-    await Promise.all(Array.from({ length: 6 }, (_, index) => run(executable, [
+    await Promise.all(Array.from({ length: 6 }, (_, index) => run(process.execPath, [
+      '--import',
+      'tsx',
       '--eval',
       `import { createProviderProfile } from ${JSON.stringify(moduleUrl)}; void createProviderProfile('cloak', ${JSON.stringify(`worker-${index}`)});`,
     ], {

--- a/src/browser/profile-concurrency.test.ts
+++ b/src/browser/profile-concurrency.test.ts
@@ -1,0 +1,82 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ENV_PREFIX } from '../brand.js';
+import { ConfigError } from '../errors.js';
+import { createProviderProfile, loadProfileConfig } from './profile.js';
+
+describe('provider Profile config transactions', () => {
+  let configDir: string;
+  beforeEach(() => {
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-profile-lock-'));
+    vi.stubEnv(`${ENV_PREFIX}_CONFIG_DIR`, configDir);
+  });
+  afterEach(() => { vi.unstubAllEnvs(); fs.rmSync(configDir, { recursive: true, force: true }); });
+
+  it('retains concurrent mutations in independent provider namespaces', async () => {
+    await Promise.all([
+      createProviderProfile('cloak', 'work'),
+      createProviderProfile('chrome', 'personal'),
+    ]);
+    expect(loadProfileConfig('cloak').aliases).toEqual({ work: 'work' });
+    expect(loadProfileConfig('chrome').aliases).toEqual({ personal: 'personal' });
+    const target = path.join(configDir, 'browser-profiles-v2.json');
+    expect(() => JSON.parse(fs.readFileSync(target, 'utf8'))).not.toThrow();
+    if (process.platform !== 'win32') expect(fs.statSync(target).mode & 0o777).toBe(0o600);
+    expect(fs.readdirSync(configDir).filter(name => name.includes('.tmp') || name.endsWith('.lock'))).toEqual([]);
+  });
+
+  it('serializes mutations made by independent processes', async () => {
+    const run = promisify(execFile);
+    const moduleUrl = new URL('./profile.ts', import.meta.url).href;
+    const executable = path.resolve('node_modules/.bin/tsx');
+    await Promise.all(Array.from({ length: 6 }, (_, index) => run(executable, [
+      '--eval',
+      `import { createProviderProfile } from ${JSON.stringify(moduleUrl)}; void createProviderProfile('cloak', ${JSON.stringify(`worker-${index}`)});`,
+    ], {
+      env: { ...process.env, [`${ENV_PREFIX}_CONFIG_DIR`]: configDir },
+    })));
+    expect(Object.keys(loadProfileConfig('cloak').aliases).sort()).toEqual(
+      Array.from({ length: 6 }, (_, index) => `worker-${index}`),
+    );
+  });
+
+  it('reclaims a dead-owner lock but fails closed for a malformed crash lock', async () => {
+    const lock = path.join(configDir, 'browser-profiles-v2.json.lock');
+    fs.writeFileSync(lock, JSON.stringify({ pid: 999_999_999, createdAt: 0, token: 'dead' }));
+    await expect(createProviderProfile('cloak', 'after-dead')).resolves.toMatchObject({ created: true });
+
+    fs.writeFileSync(lock, 'truncated-after-crash');
+    const old = new Date(Date.now() - 2_000);
+    fs.utimesSync(lock, old, old);
+    vi.stubEnv(`${ENV_PREFIX}_PROFILE_LOCK_TIMEOUT_MS`, '20');
+    await expect(createProviderProfile('cloak', 'after-malformed')).rejects.toBeInstanceOf(ConfigError);
+    expect(fs.readFileSync(lock, 'utf8')).toBe('truncated-after-crash');
+  });
+
+  it('never steals an old lock from a live owner', async () => {
+    const lock = path.join(configDir, 'browser-profiles-v2.json.lock');
+    const owner = { pid: process.pid, createdAt: 0, token: 'still-live' };
+    fs.writeFileSync(lock, JSON.stringify(owner));
+    const pending = createProviderProfile('cloak', 'after-live-owner');
+    await new Promise(resolve => setTimeout(resolve, 40));
+    expect(JSON.parse(fs.readFileSync(lock, 'utf8'))).toEqual(owner);
+    expect(loadProfileConfig('cloak').aliases).not.toHaveProperty('after-live-owner');
+    fs.unlinkSync(lock);
+    await expect(pending).resolves.toMatchObject({ created: true });
+  });
+
+  it('returns a stable ConfigError when a live owner remains paused past the wait budget', async () => {
+    const lock = path.join(configDir, 'browser-profiles-v2.json.lock');
+    const owner = { pid: process.pid, createdAt: 0, token: 'paused-live-writer' };
+    fs.writeFileSync(lock, JSON.stringify(owner));
+    vi.stubEnv(`${ENV_PREFIX}_PROFILE_LOCK_TIMEOUT_MS`, '20');
+    const blocked = createProviderProfile('cloak', 'blocked');
+    await expect(blocked).rejects.toBeInstanceOf(ConfigError);
+    await expect(blocked).rejects.toMatchObject({ code: 'CONFIG', exitCode: 78 });
+    expect(JSON.parse(fs.readFileSync(lock, 'utf8'))).toEqual(owner);
+  });
+});

--- a/src/browser/profile.test.ts
+++ b/src/browser/profile.test.ts
@@ -3,8 +3,8 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { ENV_PREFIX } from '../brand.js';
-import { ArgumentError } from '../errors.js';
-import { createProfile, loadProfileConfig, profileListRows, profileRouteParams, resolveProfileSelection, setDefaultProfile } from './profile.js';
+import { ArgumentError, ConfigError } from '../errors.js';
+import { commitSlabProfileEnsure, createProfile, loadProfileConfig, prepareSlabProfileEnsure, profileListRows, profileRouteParams, renameProviderProfile, resolveProfileSelection, rotateSlabProfileEnsure, setDefaultProfile } from './profile.js';
 
 describe('profile selection', () => {
   let configDir: string;
@@ -121,6 +121,63 @@ describe('createProfile', () => {
 
   it('rejects an invalid alias', () => {
     expect(() => createProfile('../nope')).toThrow(ArgumentError);
+  });
+
+  it('fails closed instead of erasing a corrupt provider config', () => {
+    const target = path.join(configDir, 'browser-profiles-v2.json');
+    fs.writeFileSync(target, '{not-json');
+    expect(() => loadProfileConfig('slab')).toThrow(ConfigError);
+    expect(fs.readFileSync(target, 'utf8')).toBe('{not-json');
+  });
+
+  it('never exposes legacy cloak aliases through other providers', () => {
+    fs.writeFileSync(path.join(configDir, 'browser-profiles.json'), JSON.stringify({ version: 1, aliases: { work: 'cloak-work' } }));
+    expect(loadProfileConfig('cloak').aliases).toEqual({ work: 'cloak-work' });
+    expect(loadProfileConfig('chrome').aliases).toEqual({});
+    expect(loadProfileConfig('custom').aliases).toEqual({});
+    expect(loadProfileConfig('slab').aliases).toEqual({});
+  });
+
+  it('keeps SLAB aliases separate and repairs with one stable ensure key', async () => {
+    createProfile('work');
+    expect(loadProfileConfig('slab').aliases).toEqual({});
+    const first = await prepareSlabProfileEnsure('work');
+    const retry = await prepareSlabProfileEnsure('work');
+    expect(retry.idempotencyKey).toBe(first.idempotencyKey);
+    expect(loadProfileConfig('slab').aliases).toEqual({});
+    await commitSlabProfileEnsure('work', first.idempotencyKey, 'Profile 7');
+    expect(loadProfileConfig('slab').aliases).toEqual({ work: 'Profile 7' });
+    expect(loadProfileConfig('cloak').aliases).toEqual({ work: 'work' });
+  });
+
+  it('rotates an explicitly repair-required SLAB key and moves it when renamed', async () => {
+    const pending = await prepareSlabProfileEnsure('work');
+    await commitSlabProfileEnsure('work', pending.idempotencyKey, 'Profile 7');
+    const repair = await rotateSlabProfileEnsure('work', pending.idempotencyKey);
+    expect(repair.idempotencyKey).not.toBe(pending.idempotencyKey);
+    expect(loadProfileConfig('slab').aliases).toEqual({});
+    await commitSlabProfileEnsure('work', repair.idempotencyKey, 'Profile 8');
+    await renameProviderProfile('slab', 'Profile 8', 'renamed');
+    expect(loadProfileConfig('slab').aliases).toEqual({ renamed: 'Profile 8' });
+    expect((await prepareSlabProfileEnsure('renamed')).idempotencyKey).toBe(repair.idempotencyKey);
+  });
+
+  it('clears a colliding stale ensure when an unaliased native profile takes its alias', async () => {
+    const stale = await prepareSlabProfileEnsure('work');
+    await commitSlabProfileEnsure('work', stale.idempotencyKey, 'Profile old');
+    await renameProviderProfile('slab', 'Profile new', 'work');
+    expect(loadProfileConfig('slab').aliases).toEqual({ work: 'Profile new' });
+    expect((await prepareSlabProfileEnsure('work')).idempotencyKey).not.toBe(stale.idempotencyKey);
+  });
+
+  it('moves the source ensure over a colliding target alias', async () => {
+    const source = await prepareSlabProfileEnsure('source');
+    await commitSlabProfileEnsure('source', source.idempotencyKey, 'Profile source');
+    const target = await prepareSlabProfileEnsure('target');
+    await commitSlabProfileEnsure('target', target.idempotencyKey, 'Profile target');
+    await renameProviderProfile('slab', 'Profile source', 'target');
+    expect(loadProfileConfig('slab').aliases).toEqual({ target: 'Profile source' });
+    expect((await prepareSlabProfileEnsure('target')).idempotencyKey).toBe(source.idempotencyKey);
   });
 });
 

--- a/src/browser/profile.ts
+++ b/src/browser/profile.ts
@@ -2,8 +2,10 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { CLI_COMMAND, CONFIG_DIR_NAME, ENV_PREFIX } from '../brand.js';
-import { ArgumentError, CliError, EXIT_CODES } from '../errors.js';
+import { ArgumentError, CliError, ConfigError, EXIT_CODES } from '../errors.js';
 import { normalizeProfileId } from './runtime/local-cloak/profiles.js';
+import { randomUUID } from 'node:crypto';
+import { loadWebcmdConfig, type LocalBrowserConfig } from '../hosted/config.js';
 
 export const DEFAULT_CONTEXT_ID = 'default';
 
@@ -13,9 +15,117 @@ export type ProfileConfig = {
   aliases: Record<string, string>;
 };
 
+export type ProfileProvider = LocalBrowserConfig['kind'];
+type ProviderState = { aliases: Record<string, string>; defaultContextId?: string };
+type ProfileConfigV2 = {
+  version: 2;
+  providers: Record<ProfileProvider, ProviderState>;
+  slabEnsures: Record<string, { idempotencyKey: string; nativeProfileId?: string }>;
+};
+
 function profileConfigPath(): string {
   const baseDir = process.env[`${ENV_PREFIX}_CONFIG_DIR`] || path.join(os.homedir(), CONFIG_DIR_NAME);
   return path.join(baseDir, 'browser-profiles.json');
+}
+
+function providerConfigPath(): string { return profileConfigPath().replace(/\.json$/, '-v2.json'); }
+function activeProvider(): ProfileProvider {
+  const config = loadWebcmdConfig();
+  return config.mode === 'local' ? config.browser.kind : 'cloak';
+}
+
+function emptyV2(): ProfileConfigV2 {
+  return { version: 2, providers: { cloak: { aliases: {} }, chrome: { aliases: {} }, custom: { aliases: {} }, slab: { aliases: {} } }, slabEnsures: {} };
+}
+
+function loadV2(): ProfileConfigV2 {
+  try {
+    const value = JSON.parse(fs.readFileSync(providerConfigPath(), 'utf8')) as ProfileConfigV2;
+    if (value.version !== 2 || !value.providers || !value.slabEnsures
+      || !['cloak', 'chrome', 'custom', 'slab'].every(provider => {
+        const state = value.providers[provider as ProfileProvider];
+        return state && typeof state === 'object' && state.aliases && typeof state.aliases === 'object'
+          && Object.entries(state.aliases).every(([alias, id]) => alias.trim() && typeof id === 'string' && id.trim())
+          && (state.defaultContextId === undefined || typeof state.defaultContextId === 'string');
+      })
+      || Object.entries(value.slabEnsures).some(([alias, ensure]) => !alias.trim()
+        || !ensure || typeof ensure !== 'object'
+        || typeof ensure.idempotencyKey !== 'string' || !ensure.idempotencyKey.trim()
+        || (ensure.nativeProfileId !== undefined && typeof ensure.nativeProfileId !== 'string'))
+    ) throw new ConfigError('browser-profiles-v2.json has an unsupported schema.');
+    return value;
+  } catch (error) {
+    if (['ENOENT', 'ENOTDIR'].includes((error as NodeJS.ErrnoException).code ?? '')) return emptyV2();
+    if (error instanceof ConfigError) throw error;
+    throw new ConfigError(`Could not read browser-profiles-v2.json: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function saveV2(value: ProfileConfigV2): void {
+  const target = providerConfigPath();
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  const temporary = `${target}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    const fd = fs.openSync(temporary, 'wx', 0o600);
+    try { fs.writeFileSync(fd, `${JSON.stringify(value, null, 2)}\n`); fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+    fs.renameSync(temporary, target);
+    try { fs.chmodSync(target, 0o600); } catch {}
+    try { const directory = fs.openSync(path.dirname(target), 'r'); try { fs.fsyncSync(directory); } finally { fs.closeSync(directory); } } catch {}
+  } finally { try { fs.unlinkSync(temporary); } catch {} }
+}
+
+async function withConfigLock<T>(mutate: (value: ProfileConfigV2) => T): Promise<T> {
+  const lock = `${providerConfigPath()}.lock`;
+  const token = randomUUID();
+  const startedAt = Date.now();
+  const configuredTimeout = Number(process.env[`${ENV_PREFIX}_PROFILE_LOCK_TIMEOUT_MS`]);
+  const timeoutMs = Number.isFinite(configuredTimeout) && configuredTimeout > 0 ? configuredTimeout : 5_000;
+  fs.mkdirSync(path.dirname(lock), { recursive: true });
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      const fd = fs.openSync(lock, 'wx', 0o600);
+      try {
+        fs.writeFileSync(fd, JSON.stringify({ pid: process.pid, createdAt: Date.now(), token }));
+        const value = loadV2();
+        if (Object.keys(value.providers.cloak.aliases).length === 0 && !value.providers.cloak.defaultContextId) {
+          try {
+            const legacy = JSON.parse(fs.readFileSync(profileConfigPath(), 'utf8')) as Partial<ProfileConfig>;
+            if (legacy.version === 1 && legacy.aliases && typeof legacy.aliases === 'object') {
+              value.providers.cloak.aliases = Object.fromEntries(Object.entries(legacy.aliases).filter((entry): entry is [string, string] => typeof entry[1] === 'string'));
+              if (typeof legacy.defaultContextId === 'string' && legacy.defaultContextId.trim()) value.providers.cloak.defaultContextId = legacy.defaultContextId.trim();
+            }
+          } catch {}
+        }
+        const result = mutate(value);
+        saveV2(value);
+        return result;
+      } finally {
+        fs.closeSync(fd);
+        try {
+          const current = JSON.parse(fs.readFileSync(lock, 'utf8')) as { token?: string };
+          if (current.token === token) fs.unlinkSync(lock);
+        } catch {}
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      try {
+        const owner = JSON.parse(fs.readFileSync(lock, 'utf8')) as { pid?: number; createdAt?: number };
+        let alive = true;
+        if (owner.pid) try { process.kill(owner.pid, 0); } catch { alive = false; }
+        const age = Date.now() - (owner.createdAt ?? 0);
+        // Age is only evidence that a dead owner's lock is stale. A live owner may
+        // legitimately be delayed; stealing its lock would permit concurrent writers.
+        if (!alive && age > 1_000) { fs.unlinkSync(lock); continue; }
+      } catch {
+        // An unreadable or malformed lock has no demonstrably dead recorded PID.
+        // Fail closed after the bounded wait rather than deleting another writer's lock.
+      }
+      if (Date.now() - startedAt >= timeoutMs) {
+        throw new ConfigError('Profile configuration is locked by another live process. Retry after that operation finishes.');
+      }
+      await new Promise(resolve => setTimeout(resolve, Math.min(5 + attempt * 2, 50)));
+    }
+  }
 }
 
 export function normalizeContextId(value: string | undefined | null): string | undefined {
@@ -27,7 +137,13 @@ export function emptyProfileConfig(): ProfileConfig {
   return { version: 1, aliases: {} };
 }
 
-export function loadProfileConfig(): ProfileConfig {
+export function loadProfileConfig(provider: ProfileProvider = activeProvider()): ProfileConfig {
+  const v2 = loadV2();
+  const providerState = v2.providers[provider];
+  if (providerState && (Object.keys(providerState.aliases).length > 0 || providerState.defaultContextId || provider === 'slab')) {
+    return { version: 1, aliases: { ...providerState.aliases }, ...(providerState.defaultContextId ? { defaultContextId: providerState.defaultContextId } : {}) };
+  }
+  if (provider !== 'cloak') return emptyProfileConfig();
   try {
     const raw = fs.readFileSync(profileConfigPath(), 'utf-8');
     const parsed = JSON.parse(raw) as Partial<ProfileConfig>;
@@ -68,6 +184,102 @@ export function resolveProfileSelection(profile?: string): ProfileSelection | un
   const preferred = normalizeContextId(config.defaultContextId);
   if (preferred) return { contextId: config.aliases[preferred] ?? preferred, source: 'preferred' };
   return undefined;
+}
+
+export async function prepareSlabProfileEnsure(alias: string): Promise<{ alias: string; idempotencyKey: string }> {
+  const name = normalizeContextId(alias);
+  if (!name) throw new ArgumentError('profile alias is required');
+  try { normalizeProfileId(name); } catch {
+    throw new ArgumentError(`Invalid profile alias "${name}". Use letters, numbers, ".", "_" or "-".`);
+  }
+  return withConfigLock(value => {
+    const existing = value.slabEnsures[name];
+    const idempotencyKey = existing?.idempotencyKey ?? randomUUID();
+    value.slabEnsures[name] = { ...existing, idempotencyKey };
+    return { alias: name, idempotencyKey };
+  });
+}
+
+export async function commitSlabProfileEnsure(alias: string, idempotencyKey: string, nativeProfileId: string): Promise<void> {
+  await withConfigLock(value => {
+    const existing = value.slabEnsures[alias];
+    if (existing && existing.idempotencyKey !== idempotencyKey) throw new Error('SLAB Profile ensure identity changed concurrently.');
+    value.slabEnsures[alias] = { idempotencyKey, nativeProfileId };
+    value.providers.slab.aliases[alias] = nativeProfileId;
+  });
+}
+
+export async function rotateSlabProfileEnsure(alias: string, expectedIdempotencyKey: string): Promise<{ alias: string; idempotencyKey: string }> {
+  return withConfigLock(value => {
+    const existing = value.slabEnsures[alias];
+    if (!existing || existing.idempotencyKey !== expectedIdempotencyKey) {
+      throw new ConfigError(`SLAB Profile repair identity changed for alias "${alias}".`);
+    }
+    const idempotencyKey = randomUUID();
+    value.slabEnsures[alias] = { idempotencyKey };
+    delete value.providers.slab.aliases[alias];
+    return { alias, idempotencyKey };
+  });
+}
+
+export async function createProviderProfile(provider: Exclude<ProfileProvider, 'slab'>, alias: string): Promise<{ contextId: string; alias: string; created: boolean }> {
+  const name = normalizeContextId(alias);
+  if (!name) throw new ArgumentError('profile alias is required');
+  let contextId: string;
+  try { contextId = normalizeProfileId(name); } catch {
+    throw new ArgumentError(`Invalid profile alias "${name}". Use letters, numbers, ".", "_" or "-".`);
+  }
+  return withConfigLock(value => {
+    const existing = value.providers[provider].aliases[name];
+    if (existing) return { contextId: existing, alias: name, created: false };
+    value.providers[provider].aliases[name] = contextId;
+    return { contextId, alias: name, created: true };
+  });
+}
+
+export async function renameProviderProfile(provider: ProfileProvider, contextId: string, alias: string): Promise<void> {
+  const normalizedContextId = normalizeContextId(contextId);
+  const normalizedAlias = normalizeContextId(alias);
+  if (!normalizedContextId || !normalizedAlias) throw new ArgumentError('profile contextId and alias are required');
+  try { normalizeProfileId(normalizedAlias); } catch {
+    throw new ArgumentError(`Invalid profile alias "${normalizedAlias}". Use letters, numbers, ".", "_" or "-".`);
+  }
+  await withConfigLock(value => {
+    const state = value.providers[provider];
+    let movedEnsure: ProfileConfigV2['slabEnsures'][string] | undefined;
+    for (const [existingAlias, existingId] of Object.entries(state.aliases)) {
+      if (existingId !== normalizedContextId) continue;
+      delete state.aliases[existingAlias];
+      if (provider === 'slab' && existingAlias !== normalizedAlias) {
+        const ensure = value.slabEnsures[existingAlias];
+        if (ensure) {
+          movedEnsure = { ...ensure, nativeProfileId: normalizedContextId };
+          delete value.slabEnsures[existingAlias];
+        }
+      }
+    }
+    if (provider === 'slab') {
+      delete value.slabEnsures[normalizedAlias];
+      if (movedEnsure) value.slabEnsures[normalizedAlias] = movedEnsure;
+    }
+    state.aliases[normalizedAlias] = normalizedContextId;
+  });
+}
+
+export async function setProviderDefaultProfile(provider: ProfileProvider, profile: string, rows: ProfileListRow[]): Promise<string> {
+  const name = normalizeContextId(profile);
+  const match = name ? resolveKnownProfile(name, rows) : undefined;
+  if (!name) throw new ArgumentError('profile is required');
+  if (!match) {
+    const labels = knownProfileLabels(rows);
+    const usage = `usage: ${CLI_COMMAND} profile use <alias|contextId>`;
+    throw new ArgumentError(
+      labels.length ? `No profile matches "${name}". Valid profiles: ${labels.join(', ')}` : `No profile matches "${name}". No browser profiles are available.`,
+      labels.length ? `${usage}\nexample: ${CLI_COMMAND} profile use ${labels[0]}` : `${usage}\nRun ${CLI_COMMAND} profile list, or create one with a browser-backed command.`,
+    );
+  }
+  await withConfigLock(value => { value.providers[provider].defaultContextId = match.contextId; });
+  return match.contextId;
 }
 
 export function profileRouteParams(

--- a/src/browser/protocol.ts
+++ b/src/browser/protocol.ts
@@ -25,7 +25,8 @@ export type BrowserRuntimeAction =
   | 'session-list'
   | 'session-close'
   | 'session-handoff-start'
-  | 'session-handoff-clear';
+  | 'session-handoff-clear'
+  | 'profile-ensure';
 
 export type BrowserSurface = 'browser' | 'adapter';
 export type SiteSessionMode = 'ephemeral' | 'persistent';
@@ -69,7 +70,7 @@ export interface BrowserRuntimeCommand {
   timeout?: number;
   /** Absolute command deadline in epoch milliseconds. Preferred by newer daemons. */
   deadlineAt?: number;
-  /** Force Session lifecycle actions such as close past active work/handoff guards. */
+  /** Force this command's destructive close; Session and exact-page close interpret it independently. */
   force?: boolean;
   /** Remove an explicit Session record after closing it. Internal probes only. */
   discard?: boolean;
@@ -102,6 +103,8 @@ export interface BrowserRuntimeCommand {
   /** Site and expiry payload for internal Session handoff controls. */
   site?: string;
   expiresAt?: string;
+  alias?: string;
+  idempotencyKey?: string;
 }
 
 export interface BrowserRuntimeResult {

--- a/src/browser/runtime/local-cloak/actions.test.ts
+++ b/src/browser/runtime/local-cloak/actions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest';
+import { dispatchCloakAction } from './actions.js';
+
+describe('Cloak public CDP action cleanup', () => {
+  it.each([false, true])('detaches its command-local CDP session when send failure=%s', async (fails) => {
+    const send = fails ? vi.fn().mockRejectedValue(new Error('send failed')) : vi.fn().mockResolvedValue({ enabled: true });
+    const detach = vi.fn().mockResolvedValue(undefined);
+    const manager = {
+      getPage: vi.fn().mockResolvedValue({
+        profileId: 'default', pageId: 'page-1', page: {},
+        context: { newCDPSession: vi.fn().mockResolvedValue({ send, detach }) },
+      }),
+    };
+    const result = await dispatchCloakAction(manager as never, {
+      id: 'cdp-1', action: 'cdp', session: 'agent', surface: 'browser', cdpMethod: 'Runtime.enable',
+    });
+    expect(result.ok).toBe(!fails);
+    expect(detach).toHaveBeenCalledOnce();
+  });
+});

--- a/src/browser/runtime/local-cloak/actions.ts
+++ b/src/browser/runtime/local-cloak/actions.ts
@@ -464,8 +464,12 @@ export async function dispatchCloakAction(manager: CloakSessionManager, command:
         if (!command.cdpMethod) return invalidRequest(command, 'Missing cdpMethod');
         const lease = await resolveLease(manager, command);
         const session = await lease.context.newCDPSession(lease.page);
-        const data = await session.send(command.cdpMethod as any, command.cdpParams ?? {});
-        return { id: command.id, ok: true, data, page: lease.pageId };
+        try {
+          const data = await session.send(command.cdpMethod as any, command.cdpParams ?? {});
+          return { id: command.id, ok: true, data, page: lease.pageId };
+        } finally {
+          await session.detach().catch(() => {});
+        }
       }
       case 'frames': {
         const lease = await resolveLease(manager, command);

--- a/src/browser/runtime/local-cloak/provider.ts
+++ b/src/browser/runtime/local-cloak/provider.ts
@@ -87,7 +87,7 @@ export class LocalCloakRuntimeProvider implements BrowserRuntimeProvider {
     return this.sessions.clearHandoff(this.resolveProfileId(command), command.sessionId!);
   }
 
-  async listSessions(input: { profileId?: string; limit?: number }): Promise<BrowserSessionListRow[]> {
+  async listSessions(input: { profileId?: string; limit?: number; includeDiscovered?: boolean }): Promise<BrowserSessionListRow[]> {
     return this.sessions.list(input.profileId, input.limit).map((session) => ({
       ...session,
       runtimeState: this.manager.hasSession(session.profileId, session.id) ? 'active' : 'idle',

--- a/src/browser/runtime/local-slab/__fixtures__/attach.response.json
+++ b/src/browser/runtime/local-slab/__fixtures__/attach.response.json
@@ -12,7 +12,7 @@
     "ok": true,
     "result": {
       "connectionId": "00000000-0000-4000-8000-000000000000",
-      "profile": { "id": "default", "displayName": "Default" },
+      "profile": { "id": "default", "displayName": "default" },
       "transport": {
         "kind": "cdp-ipc",
         "endpoint": "/Users/test/.slab/run/AAAAAAAAAAA.sock",

--- a/src/browser/runtime/local-slab/__fixtures__/create-profile-v2.response.json
+++ b/src/browser/runtime/local-slab/__fixtures__/create-profile-v2.response.json
@@ -1,0 +1,38 @@
+{
+  "request": {
+    "id": "create-v2-1",
+    "method": "createProfile",
+    "params": {
+      "protocolVersion": { "min": 2, "max": 2 },
+      "idempotencyKey": "webcmd:work",
+      "displayName": "work"
+    }
+  },
+  "response": {
+    "id": "create-v2-1",
+    "ok": true,
+    "result": {
+      "profile": { "id": "Profile 1", "displayName": "work" },
+      "created": true
+    }
+  },
+  "retried": {
+    "request": {
+      "id": "create-v2-2",
+      "method": "createProfile",
+      "params": {
+        "protocolVersion": { "min": 2, "max": 2 },
+        "idempotencyKey": "webcmd:work",
+        "displayName": "renamed-locally"
+      }
+    },
+    "response": {
+      "id": "create-v2-2",
+      "ok": true,
+      "result": {
+        "profile": { "id": "Profile 1", "displayName": "work" },
+        "created": false
+      }
+    }
+  }
+}

--- a/src/browser/runtime/local-slab/__fixtures__/errors-v2.json
+++ b/src/browser/runtime/local-slab/__fixtures__/errors-v2.json
@@ -1,0 +1,38 @@
+{
+  "INVALID_REQUEST": {
+    "request": { "id": "error-invalid-v2", "method": "attach", "params": { "protocolVersion": { "min": 2, "max": 2 }, "profileId": "default" } },
+    "response": { "id": "error-invalid-v2", "ok": false, "error": { "code": "INVALID_REQUEST", "message": "Invalid JSON, framing, shape, size, or params" } }
+  },
+  "INCOMPATIBLE_PROTOCOL": {
+    "request": { "id": "error-protocol-v2", "method": "hello", "params": { "protocolVersion": { "min": 3, "max": 3 }, "clientVersion": "webcmd/0.7.3" } },
+    "response": { "id": "error-protocol-v2", "ok": false, "error": { "code": "INCOMPATIBLE_PROTOCOL", "message": "Client range does not include a supported revision" } }
+  },
+  "PROFILE_NOT_FOUND": {
+    "request": { "id": "error-profile-v2", "method": "attach", "params": { "protocolVersion": { "min": 2, "max": 2 }, "profileId": "missing-profile" } },
+    "response": { "id": "error-profile-v2", "ok": false, "error": { "code": "PROFILE_NOT_FOUND", "message": "Requested profile is unavailable" } }
+  },
+  "ATTACH_FAILED": {
+    "request": { "id": "error-attach-v2", "method": "attach", "params": { "protocolVersion": { "min": 2, "max": 2 }, "profileId": "default" } },
+    "response": { "id": "error-attach-v2", "ok": false, "error": { "code": "ATTACH_FAILED", "message": "Browser could not create the attachment" } }
+  },
+  "AUTHENTICATION_FAILED": {
+    "request": { "id": "error-auth-v2", "method": "attach", "params": { "protocolVersion": { "min": 2, "max": 2 }, "profileId": "default" } },
+    "response": { "id": "error-auth-v2", "ok": false, "error": { "code": "AUTHENTICATION_FAILED", "message": "CDP IPC credential was missing or wrong" } }
+  },
+  "CONNECTION_NOT_FOUND": {
+    "request": { "id": "error-connection-v2", "method": "attach", "params": { "protocolVersion": { "min": 2, "max": 2 }, "profileId": "default" } },
+    "response": { "id": "error-connection-v2", "ok": false, "error": { "code": "CONNECTION_NOT_FOUND", "message": "A non-release operation referenced an unknown lease" } }
+  },
+  "PROFILE_CREATE_FAILED": {
+    "request": { "id": "error-create-v2", "method": "createProfile", "params": { "protocolVersion": { "min": 2, "max": 2 }, "idempotencyKey": "webcmd:failed", "displayName": "failed" } },
+    "response": { "id": "error-create-v2", "ok": false, "error": { "code": "PROFILE_CREATE_FAILED", "message": "Chromium could not initialize the profile" } }
+  },
+  "PROFILE_GONE": {
+    "request": { "id": "error-gone-v2", "method": "attach", "params": { "protocolVersion": { "min": 2, "max": 2 }, "profileId": "Profile 1" } },
+    "response": { "id": "error-gone-v2", "ok": false, "error": { "code": "PROFILE_GONE", "message": "Profile was removed during attachment" } }
+  },
+  "PROFILE_REPAIR_REQUIRED": {
+    "request": { "id": "error-repair-v2", "method": "createProfile", "params": { "protocolVersion": { "min": 2, "max": 2 }, "idempotencyKey": "webcmd:repair", "displayName": "repair" } },
+    "response": { "id": "error-repair-v2", "ok": false, "error": { "code": "PROFILE_REPAIR_REQUIRED", "message": "Saved profile mapping conflicts with native state" } }
+  }
+}

--- a/src/browser/runtime/local-slab/__fixtures__/errors.json
+++ b/src/browser/runtime/local-slab/__fixtures__/errors.json
@@ -22,7 +22,7 @@
       "id": "error-protocol-1",
       "method": "hello",
       "params": {
-        "protocolVersion": { "min": 2, "max": 2 },
+        "protocolVersion": { "min": 3, "max": 3 },
         "clientVersion": "webcmd/0.7.3"
       }
     },
@@ -31,7 +31,7 @@
       "ok": false,
       "error": {
         "code": "INCOMPATIBLE_PROTOCOL",
-        "message": "Client range does not include v1"
+        "message": "Client range does not include a supported revision"
       }
     }
   },

--- a/src/browser/runtime/local-slab/__fixtures__/hello-v2.response.json
+++ b/src/browser/runtime/local-slab/__fixtures__/hello-v2.response.json
@@ -1,20 +1,20 @@
 {
   "request": {
-    "id": "hello-1",
+    "id": "hello-v2-1",
     "method": "hello",
     "params": {
-      "protocolVersion": { "min": 1, "max": 1 },
+      "protocolVersion": { "min": 1, "max": 2 },
       "clientVersion": "webcmd/0.7.3"
     }
   },
   "response": {
-    "id": "hello-1",
+    "id": "hello-v2-1",
     "ok": true,
     "result": {
-      "protocolVersion": 1,
+      "protocolVersion": 2,
       "browserVersion": "152.0.7977.65",
       "browserPid": 1234,
-      "profiles": [{ "id": "default", "displayName": "default" }]
+      "profiles": [{ "id": "Profile 1", "displayName": "work" }]
     }
   }
 }

--- a/src/browser/runtime/local-slab/actions.test.ts
+++ b/src/browser/runtime/local-slab/actions.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import { dispatchSlabAction } from './actions.js';
+
+function fixture(send: ReturnType<typeof vi.fn>) {
+  const detach = vi.fn().mockResolvedValue(undefined);
+  const manager = {
+    getPage: vi.fn().mockResolvedValue({
+      profileId: 'default',
+      pageId: 'page-1',
+      page: {},
+      context: { newCDPSession: vi.fn().mockResolvedValue({ send, detach }) },
+    }),
+  };
+  const command = { id: 'cdp-1', action: 'cdp' as const, session: 'agent', surface: 'browser' as const, cdpMethod: 'Runtime.enable' };
+  return { manager, command, detach };
+}
+
+describe('SLAB public CDP action cleanup', () => {
+  it('detaches its command-local CDP session after success', async () => {
+    const { manager, command, detach } = fixture(vi.fn().mockResolvedValue({ enabled: true }));
+    await expect(dispatchSlabAction(manager as never, command)).resolves.toMatchObject({ ok: true });
+    expect(detach).toHaveBeenCalledOnce();
+  });
+
+  it('detaches its command-local CDP session after send failure', async () => {
+    const { manager, command, detach } = fixture(vi.fn().mockRejectedValue(new Error('send failed')));
+    await expect(dispatchSlabAction(manager as never, command)).resolves.toMatchObject({ ok: false, error: 'send failed' });
+    expect(detach).toHaveBeenCalledOnce();
+  });
+});

--- a/src/browser/runtime/local-slab/actions.ts
+++ b/src/browser/runtime/local-slab/actions.ts
@@ -363,6 +363,7 @@ export async function dispatchSlabAction(manager: SlabSessionManager, command: B
             session: command.session,
             surface: command.surface,
             pageId: command.page,
+            force: command.force,
           });
           return { id: command.id, ok: true, data: { closed: Boolean(closed), page: closed ?? command.page, session: command.session } };
         } else {
@@ -425,6 +426,7 @@ export async function dispatchSlabAction(manager: SlabSessionManager, command: B
               surface: command.surface,
               pageId: command.page,
               index: command.index,
+              force: command.force,
             });
             if (!closed) return { id: command.id, ok: false, errorCode: 'runtime_command_failed', error: 'Tab not found' };
             return { id: command.id, ok: true, data: { closed } };
@@ -464,8 +466,12 @@ export async function dispatchSlabAction(manager: SlabSessionManager, command: B
         if (!command.cdpMethod) return invalidRequest(command, 'Missing cdpMethod');
         const lease = await resolveLease(manager, command);
         const session = await lease.context.newCDPSession(lease.page);
-        const data = await session.send(command.cdpMethod as any, command.cdpParams ?? {});
-        return { id: command.id, ok: true, data, page: lease.pageId };
+        try {
+          const data = await session.send(command.cdpMethod as any, command.cdpParams ?? {});
+          return { id: command.id, ok: true, data, page: lease.pageId };
+        } finally {
+          await session.detach().catch(() => {});
+        }
       }
       case 'frames': {
         const lease = await resolveLease(manager, command);
@@ -539,7 +545,7 @@ export async function dispatchSlabAction(manager: SlabSessionManager, command: B
       err instanceof Error
       && 'code' in err
       && typeof err.code === 'string'
-      && (err.code.startsWith('BROWSER_RUN_') || err.code === 'SESSION_WINDOW_CONFLICT')
+      && (err.code.startsWith('BROWSER_RUN_') || err.code === 'SESSION_WINDOW_CONFLICT' || err.code === 'ADOPTED_TAB_FORCE_REQUIRED')
     ) {
       const hint = 'hint' in err && typeof err.hint === 'string'
         ? err.hint

--- a/src/browser/runtime/local-slab/attachment.test.ts
+++ b/src/browser/runtime/local-slab/attachment.test.ts
@@ -72,6 +72,7 @@ describe('attachSlabProfile', () => {
     await expect(attachSlabProfile('default', { bridge, connectTransport, connectOverCDP })).rejects.toThrow('Playwright refused');
     expect(cdpTransport.close).toHaveBeenCalledOnce();
     expect(bridge.release).toHaveBeenCalledWith('connection-1');
+    expect(bridge.close).toHaveBeenCalledOnce();
   });
 
   it('closes the bridge when native attach fails before a lease exists', async () => {
@@ -102,6 +103,7 @@ describe('attachSlabProfile', () => {
 
     expect(cdpTransport.close).toHaveBeenCalledOnce();
     expect(bridge.release).toHaveBeenCalledWith('connection-1');
+    expect(bridge.close).toHaveBeenCalledOnce();
     expect(vi.mocked(cdpTransport.close).mock.invocationCallOrder[0]).toBeLessThan(bridge.release.mock.invocationCallOrder[0]!);
   });
 });

--- a/src/browser/runtime/local-slab/attachment.ts
+++ b/src/browser/runtime/local-slab/attachment.ts
@@ -41,20 +41,37 @@ export async function attachSlabProfile(profileId: string, options: AttachSlabPr
     const context = browser.contexts()[0];
     if (!context) throw new Error('SLAB attachment returned no persistent browser context.');
     const connectedTransport = transport;
+    let closed = false;
+    const closeLocal = async () => {
+      if (closed) return;
+      closed = true;
+      connectedTransport.close();
+      await bridge.close().catch(() => {});
+    };
     return {
       profileId: attachment.profile.id,
       browserVersion: browser.version(),
       context,
       browser,
-      closeTransport: () => connectedTransport.close(),
+      closeTransport: () => { void closeLocal(); },
       release: async () => {
+        if (closed) return;
         connectedTransport.close();
-        await bridge.release(attachment.connectionId);
+        try {
+          await bridge.release(attachment.connectionId);
+        } finally {
+          closed = true;
+          await bridge.close().catch(() => {});
+        }
       },
     };
   } catch (error) {
     transport?.close();
-    await bridge.release(attachment.connectionId).catch(() => {});
+    try {
+      await bridge.release(attachment.connectionId).catch(() => {});
+    } finally {
+      await bridge.close().catch(() => {});
+    }
     throw error;
   }
 }

--- a/src/browser/runtime/local-slab/profiles.test.ts
+++ b/src/browser/runtime/local-slab/profiles.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { normalizeProfileId, resolveSlabProfileDir } from './profiles.js';
 
@@ -5,7 +6,7 @@ describe('local SLAB profile ids', () => {
   it('accepts native Chromium profile ids with spaces', () => {
     expect(normalizeProfileId('Profile 1')).toBe('Profile 1');
     expect(resolveSlabProfileDir('Profile 1', { baseDir: '/tmp/webcmd-test' }))
-      .toBe('/tmp/webcmd-test/slab/profiles/Profile 1');
+      .toBe(path.join('/tmp/webcmd-test', 'slab', 'profiles', 'Profile 1'));
   });
 
   it('still rejects path traversal and path separators', () => {

--- a/src/browser/runtime/local-slab/profiles.test.ts
+++ b/src/browser/runtime/local-slab/profiles.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeProfileId, resolveSlabProfileDir } from './profiles.js';
+
+describe('local SLAB profile ids', () => {
+  it('accepts native Chromium profile ids with spaces', () => {
+    expect(normalizeProfileId('Profile 1')).toBe('Profile 1');
+    expect(resolveSlabProfileDir('Profile 1', { baseDir: '/tmp/webcmd-test' }))
+      .toBe('/tmp/webcmd-test/slab/profiles/Profile 1');
+  });
+
+  it('still rejects path traversal and path separators', () => {
+    expect(() => normalizeProfileId('../x')).toThrow(/Invalid profile id/);
+    expect(() => normalizeProfileId('a/b')).toThrow(/Invalid profile id/);
+    expect(() => normalizeProfileId('a\\b')).toThrow(/Invalid profile id/);
+    expect(() => normalizeProfileId('line\nbreak')).toThrow(/Invalid profile id/);
+  });
+});

--- a/src/browser/runtime/local-slab/profiles.ts
+++ b/src/browser/runtime/local-slab/profiles.ts
@@ -8,7 +8,7 @@ export interface SlabProfileDirOptions {
 
 export function normalizeProfileId(value: string | undefined | null): string {
   const id = value?.trim() || 'default';
-  if (!/^[A-Za-z0-9._-]+$/.test(id) || id === '.' || id === '..') {
+  if (/[/\\\0-\x1F\x7F]/.test(id) || id === '.' || id === '..') {
     throw new Error(`Invalid profile id: ${value ?? ''}`);
   }
   return id;

--- a/src/browser/runtime/local-slab/provider.test.ts
+++ b/src/browser/runtime/local-slab/provider.test.ts
@@ -1,0 +1,47 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createLocalBrowserRuntimeProvider } from './provider.js';
+
+describe('LocalSlabRuntimeProvider Session lifecycle', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('removes explicit Session records when user close requests discard', async () => {
+    const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-slab-provider-'));
+    tempDirs.push(baseDir);
+    const provider = createLocalBrowserRuntimeProvider({
+      baseDir,
+      statusBridge: vi.fn().mockResolvedValue({
+        close: vi.fn().mockResolvedValue(undefined),
+        hello: vi.fn().mockResolvedValue({
+          protocolVersion: 2,
+          browserVersion: '152.0.7977.65',
+          browserPid: 1234,
+          profiles: [{ id: 'default', displayName: 'Default' }],
+        }),
+      }),
+    });
+
+    const session = await provider.createSession({
+      id: 'create',
+      action: 'session-create',
+      contextId: 'default',
+      sessionName: 'Smoke',
+    });
+
+    await expect(provider.listSessions({ profileId: 'default', includeDiscovered: false })).resolves.toHaveLength(1);
+    await expect(provider.closeSession({
+      id: 'close',
+      action: 'session-close',
+      contextId: 'default',
+      session: session.id,
+      discard: true,
+    })).resolves.toMatchObject({ session: session.id });
+    await expect(provider.listSessions({ profileId: 'default', includeDiscovered: false })).resolves.toEqual([]);
+  });
+});

--- a/src/browser/runtime/local-slab/provider.ts
+++ b/src/browser/runtime/local-slab/provider.ts
@@ -136,7 +136,7 @@ export class LocalSlabRuntimeProvider implements BrowserRuntimeProvider {
   async closeSession(command: BrowserRuntimeCommand): Promise<{ closed: boolean; alreadyIdle: boolean; session: string }> {
     const record = this.sessions.require(this.resolveProfileId(command), command.session);
     const closedCount = await this.manager.closeSession(record.profileId, record.id);
-    if (command.force && command.discard === true && record.kind === 'explicit' && !record.handoff) this.sessions.remove(record.profileId, record.id);
+    if (command.discard === true && record.kind === 'explicit' && !record.handoff) this.sessions.remove(record.profileId, record.id);
     else if (command.force && record.handoff) this.sessions.clearHandoff(record.profileId, record.id);
     else this.sessions.touch(record.profileId, record.id);
     return { closed: closedCount > 0, alreadyIdle: closedCount === 0, session: record.id };

--- a/src/browser/runtime/local-slab/provider.ts
+++ b/src/browser/runtime/local-slab/provider.ts
@@ -8,11 +8,13 @@ import type { SlabHelloResult } from '../../../slab/protocol.js';
 import { dispatchSlabAction, resolveSlabCommandProfileId } from './actions.js';
 import type { AttachSlabProfile } from './session-manager.js';
 import { SlabSessionManager } from './session-manager.js';
+import { ensureSlabProfile } from '../../../slab/control-bridge.js';
 
 export interface LocalSlabRuntimeProviderOptions {
   baseDir?: string;
   attachProfile?: AttachSlabProfile;
   statusBridge?: () => Promise<Pick<SlabBridgeClient, 'close' | 'hello'>>;
+  ensureProfile?: typeof ensureSlabProfile;
 }
 
 export function createLocalBrowserRuntimeProvider(opts: LocalSlabRuntimeProviderOptions = {}): LocalSlabRuntimeProvider {
@@ -73,7 +75,7 @@ export class LocalSlabRuntimeProvider implements BrowserRuntimeProvider {
       ...(requestedProfile && !selectedProfile?.runtimeConnected ? { profileDisconnected: true } : {}),
       pending: 0,
       commandResultUnknown: 0,
-      sessions: await this.listSessions({ profileId: opts.contextId }),
+      sessions: await this.listSessions({ profileId: opts.contextId, includeDiscovered: false }),
     };
   }
 
@@ -82,7 +84,19 @@ export class LocalSlabRuntimeProvider implements BrowserRuntimeProvider {
   }
 
   async createSession(command: BrowserRuntimeCommand): Promise<BrowserSessionRecord> {
-    return this.sessions.create(this.resolveProfileId(command), command.sessionName ?? '');
+    const profileId = this.resolveProfileId(command);
+    const hello = await this.nativeStatus();
+    if (hello.protocolVersion >= 2 && !hello.profiles.some(profile => profile.id === profileId)) {
+      throw Object.assign(
+        new Error(`SLAB Profile "${profileId}" no longer exists. Run webcmd profile create to repair it explicitly.`),
+        { code: 'PROFILE_GONE' },
+      );
+    }
+    return this.sessions.create(profileId, command.sessionName ?? '');
+  }
+
+  async ensureProfile(input: { alias: string; idempotencyKey: string }) {
+    return (this.opts.ensureProfile ?? ensureSlabProfile)(input);
   }
 
   async requireSession(command: BrowserRuntimeCommand): Promise<BrowserSessionRecord> {
@@ -108,11 +122,15 @@ export class LocalSlabRuntimeProvider implements BrowserRuntimeProvider {
     return this.sessions.clearHandoff(this.resolveProfileId(command), command.sessionId!);
   }
 
-  async listSessions(input: { profileId?: string; limit?: number }): Promise<BrowserSessionListRow[]> {
-    return this.sessions.list(input.profileId, input.limit).map((session) => ({
+  async listSessions(input: { profileId?: string; limit?: number; includeDiscovered?: boolean }): Promise<BrowserSessionListRow[]> {
+    const managed: BrowserSessionListRow[] = this.sessions.list(input.profileId, input.limit).map((session) => ({
       ...session,
+      rowKind: 'session' as const,
       runtimeState: this.manager.hasSession(session.profileId, session.id) ? 'active' : 'idle',
     }));
+    if (input.includeDiscovered === false || !input.profileId || managed.length >= (input.limit ?? 20)) return managed;
+    const discovered = await this.manager.discoveredWindows(input.profileId);
+    return [...managed, ...discovered].slice(0, input.limit ?? 20);
   }
 
   async closeSession(command: BrowserRuntimeCommand): Promise<{ closed: boolean; alreadyIdle: boolean; session: string }> {

--- a/src/browser/runtime/local-slab/runtime-selection.test.ts
+++ b/src/browser/runtime/local-slab/runtime-selection.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 function fakeAttachedProfile() {
   const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
@@ -165,5 +168,35 @@ describe('local browser runtime selection', () => {
       profileDisconnected: true,
       profiles: [],
     });
+  });
+
+  it('allows an unloaded Profile Session record and provisions only through explicit ensure', async () => {
+    const { createLocalBrowserRuntimeProvider } = await import('./provider.js');
+    const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-slab-profile-'));
+    const close = vi.fn().mockResolvedValue(undefined);
+    try {
+      const provider = createLocalBrowserRuntimeProvider({
+        baseDir,
+        statusBridge: vi.fn().mockResolvedValue({
+          close,
+          hello: vi.fn().mockResolvedValue({
+            protocolVersion: 1,
+            browserVersion: '152.0.7977.65',
+            browserPid: 1234,
+            profiles: [{ id: 'default', displayName: 'Default' }],
+          }),
+        }),
+      });
+
+      await expect(provider.createSession({
+        id: 'create-work',
+        action: 'session-create',
+        contextId: 'work',
+        sessionName: 'Work',
+      })).resolves.toMatchObject({ profileId: 'work' });
+      expect(close).toHaveBeenCalledOnce();
+    } finally {
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/browser/runtime/local-slab/session-manager.test.ts
+++ b/src/browser/runtime/local-slab/session-manager.test.ts
@@ -13,6 +13,7 @@ function fakeAttachedProfile() {
   let targetCounter = 0;
   let windowCounter = 0;
   let beforeTargetCreate: (() => void) | undefined;
+  let emitCreatedPageEvents = true;
   const pageCdpSessions = new WeakMap<object, any[]>();
   let context: any;
 
@@ -115,7 +116,7 @@ function fakeAttachedProfile() {
         if (!(params as any)?.hidden) beforeTargetCreate?.();
         const page = makePage();
         pages.push(page);
-        queueMicrotask(() => emit('page', page));
+        if (emitCreatedPageEvents) queueMicrotask(() => emit('page', page));
         return { targetId: targetIds.get(page) };
       }
       if (method === 'Browser.getWindowForTarget') return { windowId: windowIds.get(params?.targetId ?? '') };
@@ -193,6 +194,7 @@ function fakeAttachedProfile() {
       return page;
     },
     setBeforeTargetCreate: (listener: (() => void) | undefined) => { beforeTargetCreate = listener; },
+    setEmitCreatedPageEvents: (value: boolean) => { emitCreatedPageEvents = value; },
     cdpSessionsFor: (page: object) => pageCdpSessions.get(page) ?? [],
     emitPageOnly: (page: object) => emit('page', page),
     emitPage: (page: object) => {
@@ -298,6 +300,38 @@ describe('SlabSessionManager ownership', () => {
     expect(second.page.close).not.toHaveBeenCalled();
     expect(await manager.listPages(b)).toEqual(expect.arrayContaining([
       expect.objectContaining({ page: second.pageId, ownership: 'session' }),
+    ]));
+  });
+
+  it('claims a sole blank startup page for the first agent Session and closes it cleanly', async () => {
+    const attached = fakeAttachedProfile();
+    await attached.humanPage.close();
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
+
+    const lease = await manager.getPage(input);
+
+    expect(lease.page).toBe(attached.humanBlank);
+    expect(await manager.listPages(input)).toEqual([
+      expect.objectContaining({ page: lease.pageId, ownership: 'session', provenance: 'agent-created' }),
+    ]);
+
+    await manager.closeSession('default', 'agent');
+    expect(attached.humanBlank.close).toHaveBeenCalledOnce();
+    expect(await manager.listPages(input)).toEqual([]);
+  });
+
+  it('claims a created target that appears in context pages without a page event', async () => {
+    const attached = fakeAttachedProfile();
+    attached.setEmitCreatedPageEvents(false);
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
+
+    const lease = await manager.getPage(input);
+
+    expect(manager.pageIdFor(lease.page)).toBe(lease.pageId);
+    expect(await manager.listPages(input)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ page: lease.pageId, ownership: 'session' }),
     ]));
   });
 

--- a/src/browser/runtime/local-slab/session-manager.test.ts
+++ b/src/browser/runtime/local-slab/session-manager.test.ts
@@ -1,14 +1,19 @@
 import { describe, expect, it, vi } from 'vitest';
 import { dispatchSlabAction } from './actions.js';
 import { SlabSessionManager } from './session-manager.js';
+import { humanizePage } from '../../humanizer/page.js';
 
 function fakeAttachedProfile() {
   const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  const cdpListeners = new Map<string, Set<(...args: any[]) => void>>();
   const pageListeners = new WeakMap<object, Map<string, Set<(...args: unknown[]) => void>>>();
   const targetIds = new WeakMap<object, string>();
+  const openerTargetIds = new WeakMap<object, string>();
   const windowIds = new Map<string, number>();
   let targetCounter = 0;
   let windowCounter = 0;
+  let beforeTargetCreate: (() => void) | undefined;
+  const pageCdpSessions = new WeakMap<object, any[]>();
   let context: any;
 
   const emit = (event: string, ...args: unknown[]) => {
@@ -69,6 +74,16 @@ function fakeAttachedProfile() {
         bucket.set(event, handlers);
         pageListeners.set(page, bucket);
       },
+      on(event: string, listener: (...args: unknown[]) => void) {
+        const bucket = pageListeners.get(page) ?? new Map();
+        const handlers = bucket.get(event) ?? new Set();
+        handlers.add(listener);
+        bucket.set(event, handlers);
+        pageListeners.set(page, bucket);
+      },
+      off(event: string, listener: (...args: unknown[]) => void) {
+        pageListeners.get(page)?.get(event)?.delete(listener);
+      },
     };
     const targetId = `target-${++targetCounter}`;
     targetIds.set(page, targetId);
@@ -81,7 +96,23 @@ function fakeAttachedProfile() {
   const pages = [humanBlank, humanPage];
   const cdp = {
     send: vi.fn(async (method: string, params?: { targetId?: string }) => {
+      if (method === 'Target.getTargets') {
+        return {
+          targetInfos: pages.filter(page => !page.isClosed()).map(page => ({
+            targetId: targetIds.get(page),
+            type: 'page',
+            title: 'Page',
+            url: page.url(),
+            openerId: openerTargetIds.get(page),
+          })),
+        };
+      }
+      if (method === 'Target.getTargetInfo') {
+        const page = pages.find(candidate => targetIds.get(candidate) === params?.targetId);
+        return { targetInfo: { targetId: params?.targetId, openerId: page ? openerTargetIds.get(page) : undefined } };
+      }
       if (method === 'Target.createTarget') {
+        if (!(params as any)?.hidden) beforeTargetCreate?.();
         const page = makePage();
         pages.push(page);
         queueMicrotask(() => emit('page', page));
@@ -91,7 +122,11 @@ function fakeAttachedProfile() {
       if (method === 'Target.closeTarget') return { success: true };
       return {};
     }),
-    on: vi.fn(),
+    on: vi.fn((event: string, listener: (...args: any[]) => void) => {
+      const bucket = cdpListeners.get(event) ?? new Set();
+      bucket.add(listener);
+      cdpListeners.set(event, bucket);
+    }),
     detach: vi.fn().mockResolvedValue(undefined),
   };
   const browser = {
@@ -105,14 +140,20 @@ function fakeAttachedProfile() {
       pages.push(page);
       return page;
     }),
-    newCDPSession: vi.fn(async (page: object) => ({
+    newCDPSession: vi.fn(async (page: object) => {
+      const session = {
       send: vi.fn(async (method: string, params?: { targetId?: string }) => {
-        if (method === 'Target.getTargetInfo') return { targetInfo: { targetId: targetIds.get(page) } };
+        if (method === 'Target.getTargetInfo') {
+          return { targetInfo: { targetId: targetIds.get(page), openerId: openerTargetIds.get(page) } };
+        }
         if (method === 'Browser.getWindowForTarget') return { windowId: windowIds.get(params?.targetId ?? '') };
         return {};
       }),
       detach: vi.fn().mockResolvedValue(undefined),
-    })),
+      };
+      pageCdpSessions.set(page, [...(pageCdpSessions.get(page) ?? []), session]);
+      return session;
+    }),
     browser: vi.fn(() => browser),
     on(event: string, listener: (...args: unknown[]) => void) {
       const bucket = listeners.get(event) ?? new Set();
@@ -137,7 +178,33 @@ function fakeAttachedProfile() {
     humanBlank,
     humanPage,
     targetIdFor: (page: object) => targetIds.get(page),
-    emitPage: (page: object) => emit('page', page),
+    moveToWindow: (page: object, windowId: number) => windowIds.set(targetIds.get(page)!, windowId),
+    windowIdFor: (page: object) => windowIds.get(targetIds.get(page)!),
+    makeCdpOnlyPopup: (opener: object) => {
+      const page = makePage();
+      pages.push(page);
+      openerTargetIds.set(page, targetIds.get(opener)!);
+      windowIds.set(targetIds.get(page)!, windowIds.get(targetIds.get(opener)!)!);
+      return page;
+    },
+    makeOpenerlessPage: (url = 'https://new.example/') => {
+      const page = makePage(url);
+      pages.push(page);
+      return page;
+    },
+    setBeforeTargetCreate: (listener: (() => void) | undefined) => { beforeTargetCreate = listener; },
+    cdpSessionsFor: (page: object) => pageCdpSessions.get(page) ?? [],
+    emitPageOnly: (page: object) => emit('page', page),
+    emitPage: (page: object) => {
+      const targetInfo = {
+        targetId: targetIds.get(page),
+        type: 'page',
+        url: (page as any).url(),
+        openerId: openerTargetIds.get(page),
+      };
+      for (const listener of cdpListeners.get('Target.targetCreated') ?? []) listener({ targetInfo });
+      emit('page', page);
+    },
     emitClose: () => emit('close'),
   };
 }
@@ -147,6 +214,184 @@ async function flushPageEvent(): Promise<void> {
 }
 
 describe('SlabSessionManager ownership', () => {
+  it('discovers unowned human tabs without creating, owning, or humanizing a page', async () => {
+    const attached = fakeAttachedProfile();
+    attached.moveToWindow(attached.humanBlank, attached.windowIdFor(attached.humanPage)!);
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
+
+    const tabs = await manager.listPages(input);
+
+    expect(tabs).toHaveLength(2);
+    expect(tabs.every(tab => tab.ownership === 'unowned')).toBe(true);
+    expect(new Set(tabs.map(tab => tab.window))).toHaveLength(1);
+    expect(attached.context.newPage).not.toHaveBeenCalled();
+    expect(manager.pageIdFor(attached.humanBlank)).toBeUndefined();
+    expect((attached.humanBlank as any)._original).toBeUndefined();
+  });
+
+  it('atomically binds every sibling in a human window and detaches without closing it', async () => {
+    const attached = fakeAttachedProfile();
+    attached.moveToWindow(attached.humanBlank, attached.windowIdFor(attached.humanPage)!);
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
+    const discovered = await manager.listPages(input);
+
+    const lease = await manager.bindPage({ ...input, pageId: discovered[1]!.page });
+
+    expect(lease?.page).toBe(attached.humanPage);
+    const bound = await manager.listPages(input);
+    expect(bound).toHaveLength(2);
+    expect(bound.every(tab => tab.ownership === 'session' && tab.provenance === 'human-adopted')).toBe(true);
+
+    await manager.closeSession('default', 'agent');
+    expect(attached.humanBlank.close).not.toHaveBeenCalled();
+    expect(attached.humanPage.close).not.toHaveBeenCalled();
+    expect((attached.humanBlank as any)._original).toBeUndefined();
+    expect((attached.humanPage as any)._original).toBeUndefined();
+  });
+
+  it('keeps an adopted window claimed on ordinary lease release and foregrounds only when requested', async () => {
+    const attached = fakeAttachedProfile();
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
+    const [human] = await manager.listPages(input);
+    const lease = await manager.bindPage({ ...input, pageId: human!.page });
+    expect(attached.humanBlank.bringToFront).not.toHaveBeenCalled();
+
+    await manager.release(input);
+    expect(await manager.listPages(input)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ page: lease!.pageId, ownership: 'session', provenance: 'human-adopted' }),
+    ]));
+
+    await manager.bindPage({ ...input, pageId: lease!.pageId, windowMode: 'foreground' });
+    expect(attached.humanBlank.bringToFront).toHaveBeenCalledOnce();
+  });
+
+  it('requires force to destructively close an adopted human tab', async () => {
+    const attached = fakeAttachedProfile();
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
+    const [human] = await manager.listPages(input);
+    const lease = await manager.bindPage({ ...input, pageId: human!.page });
+
+    await expect(manager.closePage({ ...input, pageId: lease!.pageId })).rejects.toMatchObject({
+      code: 'ADOPTED_TAB_FORCE_REQUIRED',
+    });
+    expect(attached.humanBlank.close).not.toHaveBeenCalled();
+
+    await manager.closePage({ ...input, pageId: lease!.pageId, force: true });
+    expect(attached.humanBlank.close).toHaveBeenCalledOnce();
+  });
+
+  it('runs parallel Sessions in distinct windows and closes only the selected Session', async () => {
+    const attached = fakeAttachedProfile();
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
+    const a = { profileId: 'default', session: 'agent-a', sessionId: 'agent-a', surface: 'browser' as const };
+    const b = { profileId: 'default', session: 'agent-b', sessionId: 'agent-b', surface: 'browser' as const };
+
+    const [first, second] = await Promise.all([manager.getPage(a), manager.getPage(b)]);
+    expect(attached.windowIdFor(first.page)).not.toBe(attached.windowIdFor(second.page));
+
+    await manager.closeSession('default', 'agent-a');
+    expect(first.page.close).toHaveBeenCalledOnce();
+    expect(second.page.close).not.toHaveBeenCalled();
+    expect(await manager.listPages(b)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ page: second.pageId, ownership: 'session' }),
+    ]));
+  });
+
+  it('returns one discovered Session row per unowned human window', async () => {
+    const attached = fakeAttachedProfile();
+    attached.moveToWindow(attached.humanBlank, attached.windowIdFor(attached.humanPage)!);
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
+
+    await expect(manager.discoveredWindows('default')).resolves.toEqual([
+      expect.objectContaining({
+        rowKind: 'discovered',
+        profileId: 'default',
+        ownership: 'unowned',
+        tabCount: 2,
+      }),
+    ]);
+  });
+
+  it('daemon shutdown detaches an adopted window without closing human tabs', async () => {
+    const attached = fakeAttachedProfile();
+    attached.moveToWindow(attached.humanBlank, attached.windowIdFor(attached.humanPage)!);
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
+    const [, selected] = await manager.listPages(input);
+    await manager.bindPage({ ...input, pageId: selected!.page });
+
+    await manager.shutdown();
+
+    expect(attached.humanBlank.close).not.toHaveBeenCalled();
+    expect(attached.humanPage.close).not.toHaveBeenCalled();
+    expect(attached.attachment.release).toHaveBeenCalledOnce();
+  });
+
+  it('rolls back every sibling and humanizer mutation when whole-window bind instrumentation fails', async () => {
+    const attached = fakeAttachedProfile();
+    attached.moveToWindow(attached.humanBlank, attached.windowIdFor(attached.humanPage)!);
+    let calls = 0;
+    const manager = new SlabSessionManager({
+      attachProfile: vi.fn().mockResolvedValue(attached.attachment),
+      humanize: page => {
+        calls += 1;
+        if (calls === 2) throw new Error('injected sibling instrumentation failure');
+        return humanizePage(page);
+      },
+    });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
+    const [, selected] = await manager.listPages(input);
+
+    await expect(manager.bindPage({ ...input, pageId: selected!.page }))
+      .rejects.toThrow('injected sibling instrumentation failure');
+
+    expect(manager.pageIdFor(attached.humanBlank)).toBeUndefined();
+    expect(manager.pageIdFor(attached.humanPage)).toBeUndefined();
+    expect((attached.humanBlank as any)._original).toBeUndefined();
+    expect((attached.humanPage as any)._original).toBeUndefined();
+    expect(attached.humanBlank.close).not.toHaveBeenCalled();
+    expect(attached.humanPage.close).not.toHaveBeenCalled();
+  });
+
+  it('rejects an already-owned window without creating a session, claim, or humanizer work', async () => {
+    const attached = fakeAttachedProfile();
+    const humanize = vi.fn(humanizePage);
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment), humanize });
+    const a = { profileId: 'default', session: 'a', sessionId: 'a', surface: 'browser' as const };
+    const b = { profileId: 'default', session: 'b', sessionId: 'b', surface: 'browser' as const };
+    const [human] = await manager.listPages(a);
+    await manager.bindPage({ ...a, pageId: human!.page });
+    const calls = humanize.mock.calls.length;
+    await expect(manager.bindPage({ ...b, targetId: attached.targetIdFor(attached.humanBlank) }))
+      .rejects.toMatchObject({ code: 'SESSION_WINDOW_CONFLICT' });
+    expect(humanize).toHaveBeenCalledTimes(calls);
+    expect(manager.hasSession('default', 'b')).toBe(false);
+    expect((await manager.listPages(a)).filter(row => row.ownership === 'session').every(row => row.sessionId === 'a')).toBe(true);
+  });
+
+  it('rolls back registered siblings when the selected tab disappears during adoption', async () => {
+    const attached = fakeAttachedProfile();
+    attached.moveToWindow(attached.humanBlank, attached.windowIdFor(attached.humanPage)!);
+    const manager = new SlabSessionManager({
+      attachProfile: vi.fn().mockResolvedValue(attached.attachment),
+      humanize: page => {
+        const humanized = humanizePage(page);
+        if (page === attached.humanPage) void attached.humanPage.close();
+        return humanized;
+      },
+    });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
+    const discovered = await manager.listPages(input);
+    await expect(manager.bindPage({ ...input, pageId: discovered.find(row => row.targetId === attached.targetIdFor(attached.humanPage))!.page }))
+      .rejects.toThrow(/disappeared/);
+    expect(manager.hasSession('default', 'agent')).toBe(false);
+    expect((attached.humanBlank as any)._original).toBeUndefined();
+    expect((await manager.listPages(input)).every(row => row.ownership === 'unowned')).toBe(true);
+  });
   it('creates and releases only an agent-owned page', async () => {
     const attached = fakeAttachedProfile();
     const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
@@ -176,7 +421,7 @@ describe('SlabSessionManager ownership', () => {
     const attached = fakeAttachedProfile();
     const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
     const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
-    await manager.getPage(input);
+    await manager.listPages(input);
 
     const lease = await manager.bindPage({ ...input, targetId: attached.targetIdFor(attached.humanPage) });
 
@@ -185,6 +430,209 @@ describe('SlabSessionManager ownership', () => {
     expect(manager.pageIdFor(attached.humanPage)).toBe(lease?.pageId);
     expect((attached.humanPage as any)._original).toEqual(expect.any(Object));
     expect((attached.humanBlank as any)._original).toBeUndefined();
+  });
+
+  it('registers a popup from CDP opener identity when Playwright opener is unavailable', async () => {
+    const attached = fakeAttachedProfile();
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
+    const lease = await manager.getPage(input);
+    const scope = await manager.browserRunScope(input, lease.page);
+    const seen: object[] = [];
+    scope.onPage(page => seen.push(page));
+
+    const popup = attached.makeCdpOnlyPopup(lease.page);
+    attached.emitPage(popup);
+    await flushPageEvent();
+
+    expect(seen).toEqual([popup]);
+    expect(manager.pageIdFor(popup)).toEqual(expect.any(String));
+    expect(await manager.listPages(input)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ page: manager.pageIdFor(popup), provenance: 'agent-created' }),
+    ]));
+  });
+
+  it('preserves agent-created provenance when rebinding an already-owned page', async () => {
+    const attached = fakeAttachedProfile();
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
+    const lease = await manager.getPage(input);
+
+    await manager.bindPage({ ...input, targetId: attached.targetIdFor(lease.page) });
+
+    expect(await manager.listPages(input)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ page: lease.pageId, provenance: 'agent-created' }),
+    ]));
+  });
+
+  it('restores the canonical lease mapping when whole-window bind fails after moving it', async () => {
+    const attached = fakeAttachedProfile();
+    let failurePage: any;
+    const manager = new SlabSessionManager({
+      attachProfile: vi.fn().mockResolvedValue(attached.attachment),
+      humanize: page => {
+        if (page === failurePage) throw new Error('injected rebind failure');
+        return humanizePage(page);
+      },
+    });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const, idleTimeout: 60_000 };
+    const original = await manager.getPage(input);
+    await (original.page as any)._stealth.getCdpSession();
+    const runtime = (manager as any).profiles.get('default');
+    const originalEntry = [...runtime.targetPages.values()].find((entry: any) => entry.page === original.page);
+    const originalTimer = originalEntry.idleTimer;
+    const stealthSession = attached.cdpSessionsFor(original.page).at(-1);
+    const sibling = attached.makeOpenerlessPage('https://rebind.example/');
+    attached.moveToWindow(sibling, attached.windowIdFor(original.page)!);
+    failurePage = sibling;
+
+    await expect(manager.bindPage({ ...input, targetId: attached.targetIdFor(sibling) }))
+      .rejects.toThrow('injected rebind failure');
+
+    await expect(manager.findPage(input)).resolves.toMatchObject({ page: original.page, pageId: original.pageId });
+    expect(originalEntry.idleTimer).toBeDefined();
+    expect(originalEntry.idleTimer).not.toBe(originalTimer);
+    expect(stealthSession.detach).not.toHaveBeenCalled();
+    expect(manager.pageIdFor(sibling)).toBeUndefined();
+    expect((sibling as any)._original).toBeUndefined();
+  });
+
+  it('rolls back automatic popup inheritance when instrumentation fails', async () => {
+    const attached = fakeAttachedProfile();
+    let failurePage: any;
+    const manager = new SlabSessionManager({
+      attachProfile: vi.fn().mockResolvedValue(attached.attachment),
+      humanize: page => {
+        if (page === failurePage) throw new Error('popup instrumentation failed');
+        return humanizePage(page);
+      },
+    });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
+    const original = await manager.getPage(input);
+    const popup = attached.makeCdpOnlyPopup(original.page);
+    failurePage = popup;
+
+    attached.emitPage(popup);
+    await flushPageEvent();
+
+    expect(manager.pageIdFor(popup)).toBeUndefined();
+    expect((popup as any)._original).toBeUndefined();
+    await expect(manager.findPage(input)).resolves.toMatchObject({ page: original.page, pageId: original.pageId });
+    await popup.close();
+    await expect(manager.findPage(input)).resolves.toMatchObject({ page: original.page, pageId: original.pageId });
+  });
+
+  it('inherits adopted Session provenance for an openerless tab in the owned window without observational page CDP', async () => {
+    const attached = fakeAttachedProfile();
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
+    const [human] = await manager.listPages(input);
+    await manager.bindPage({ ...input, pageId: human!.page });
+    attached.context.newCDPSession.mockClear();
+
+    const tab = attached.makeOpenerlessPage();
+    attached.moveToWindow(tab, attached.windowIdFor(attached.humanBlank)!);
+    attached.emitPage(tab);
+    await flushPageEvent();
+
+    expect(manager.pageIdFor(tab)).toEqual(expect.any(String));
+    expect(await manager.listPages(input)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ page: manager.pageIdFor(tab), provenance: 'human-adopted', sessionId: 'agent' }),
+    ]));
+    expect(attached.cdpSessionsFor(tab)[0].detach).toHaveBeenCalledOnce();
+  });
+
+  it('does not attach page CDP while observing an openerless tab in an unowned window', async () => {
+    const attached = fakeAttachedProfile();
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
+    await manager.listPages({ profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' });
+    attached.context.newCDPSession.mockClear();
+
+    const tab = attached.makeOpenerlessPage('https://unowned.example/');
+    attached.emitPage(tab);
+    await flushPageEvent();
+
+    expect(manager.pageIdFor(tab)).toBeUndefined();
+    expect(attached.cdpSessionsFor(tab)[0].detach).toHaveBeenCalledOnce();
+  });
+
+  it('releases pending target page references after correlation and immediately on page close', async () => {
+    const attached = fakeAttachedProfile();
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
+    await manager.listPages({ profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' });
+    const runtime = (manager as any).profiles.get('default');
+    const pending = (manager as any).pendingTargetPages.get(runtime) as Map<string, unknown>;
+
+    const closed = attached.makeOpenerlessPage('https://closed.example/');
+    attached.emitPageOnly(closed);
+    for (let index = 0; index < 10 && !pending.has(attached.targetIdFor(closed)!); index += 1) {
+      await Promise.resolve();
+    }
+    expect(pending.get(attached.targetIdFor(closed)!)).toBe(closed);
+    await closed.close();
+    expect(pending.has(attached.targetIdFor(closed)!)).toBe(false);
+
+    const unclaimed = attached.makeOpenerlessPage('https://unclaimed.example/');
+    attached.emitPageOnly(unclaimed);
+    await flushPageEvent();
+    await flushPageEvent();
+    expect(pending.has(attached.targetIdFor(unclaimed)!)).toBe(false);
+  });
+
+  it('never registers an opener-derived page that opens in a second window for the Session', async () => {
+    const attached = fakeAttachedProfile();
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
+    const lease = await manager.getPage(input);
+    const popup = attached.makeOpenerlessPage();
+    popup.opener.mockResolvedValue(lease.page);
+
+    attached.emitPage(popup);
+    await flushPageEvent();
+
+    expect(manager.pageIdFor(popup)).toBeUndefined();
+    expect((popup as any)._original).toBeUndefined();
+    expect((await manager.listPages(input)).filter(row => row.ownership === 'session')).toHaveLength(1);
+  });
+
+  it('uses direct target identity to distinguish reversed same-URL openerless page events by window ownership', async () => {
+    const attached = fakeAttachedProfile();
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
+    const [human] = await manager.listPages(input);
+    await manager.bindPage({ ...input, pageId: human!.page });
+    attached.context.newCDPSession.mockClear();
+    const owned = attached.makeOpenerlessPage('https://same.example/');
+    const unowned = attached.makeOpenerlessPage('https://same.example/');
+    attached.moveToWindow(owned, attached.windowIdFor(attached.humanBlank)!);
+
+    attached.emitPageOnly(unowned);
+    await Promise.resolve();
+    attached.emitPageOnly(owned);
+    await flushPageEvent();
+
+    expect(manager.pageIdFor(owned)).toEqual(expect.any(String));
+    expect(manager.pageIdFor(unowned)).toBeUndefined();
+    expect(attached.cdpSessionsFor(owned)[0].detach).toHaveBeenCalledOnce();
+    expect(attached.cdpSessionsFor(unowned)[0].detach).toHaveBeenCalledOnce();
+  });
+
+  it('detaches an unrelated human-page probe that arrives during agent target creation without losing its identity', async () => {
+    const attached = fakeAttachedProfile();
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
+    let unrelated: any;
+    attached.setBeforeTargetCreate(() => {
+      unrelated = attached.makeOpenerlessPage('https://during-create.example/');
+      attached.emitPageOnly(unrelated);
+      attached.setBeforeTargetCreate(undefined);
+    });
+
+    await manager.getPage({ profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' });
+    await flushPageEvent();
+
+    expect(manager.pageIdFor(unrelated)).toBeUndefined();
+    expect(attached.cdpSessionsFor(unrelated)).toHaveLength(1);
+    expect(attached.cdpSessionsFor(unrelated)[0].detach).toHaveBeenCalledOnce();
   });
 
   it('reports every detached session operation without reopening or closing SLAB', async () => {

--- a/src/browser/runtime/local-slab/session-manager.ts
+++ b/src/browser/runtime/local-slab/session-manager.ts
@@ -197,6 +197,10 @@ function daemonShuttingDownError(): Error & { code: 'DAEMON_SHUTTING_DOWN' } {
   return Object.assign(new Error('The browser daemon is shutting down.'), { code: 'DAEMON_SHUTTING_DOWN' as const });
 }
 
+function isBlankStartupUrl(url: string): boolean {
+  return url === 'about:blank' || url === 'chrome://newtab/' || url === 'chrome://new-tab-page/';
+}
+
 export class SlabSessionManager {
   readonly networkCapture = new SlabNetworkCapture();
 
@@ -1122,7 +1126,7 @@ export class SlabSessionManager {
     windowMode?: BrowserWindowMode,
   ): Promise<PlaywrightPage> {
     const openerEntry = this.openEntries(session)[0]?.[1];
-    if (!openerEntry) return this.createWindowPage(runtime, windowMode);
+    if (!openerEntry) return await this.claimSoleBlankStartupPage(runtime) ?? this.createWindowPage(runtime, windowMode);
     await this.assertOwnedWindow(runtime, session.id, openerEntry);
     const opener = openerEntry.page;
     const openerWindowId = await this.windowIdForTarget(runtime, openerEntry.targetId, opener);
@@ -1137,6 +1141,16 @@ export class SlabSessionManager {
     const page = await openedPage;
     if (page) return page;
     throw new Error(`SLAB could not create another tab in Session ${session.id} without opening a second window.`);
+  }
+
+  private async claimSoleBlankStartupPage(runtime: ProfileRuntime): Promise<PlaywrightPage | undefined> {
+    if (runtime.targetPages.size > 0 || [...runtime.sessions.values()].some(session => session.windowIds.size > 0)) {
+      return undefined;
+    }
+    const unowned = (await this.discoverPages(runtime))
+      .filter(candidate => runtime.windowOwners.get(candidate.windowId) === undefined);
+    if (unowned.length !== 1 || !isBlankStartupUrl(unowned[0]!.url)) return undefined;
+    return await this.findPageByTargetId(runtime, unowned[0]!.targetId);
   }
 
   private async waitForContextPageForSession(
@@ -1217,11 +1231,37 @@ export class SlabSessionManager {
       return page;
     }
     return new Promise<PlaywrightPage>((resolve, reject) => {
-      const timer = setTimeout(() => {
+      let settled = false;
+      let interval: ReturnType<typeof setInterval> | undefined;
+      const finish = (page: PlaywrightPage) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (interval) clearInterval(interval);
         this.targetPageWaiters.get(runtime)?.delete(targetId);
-        reject(new Error(`Timed out waiting for SLAB target ${targetId}`));
+        resolve(page);
+      };
+      const fail = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        if (interval) clearInterval(interval);
+        this.targetPageWaiters.get(runtime)?.delete(targetId);
+        reject(error);
+      };
+      const poll = () => {
+        void this.findPageByTargetId(runtime, targetId)
+          .then(found => {
+            if (found && !pageIsClosed(found)) finish(found);
+          })
+          .catch(() => {});
+      };
+      const timer = setTimeout(() => {
+        fail(new Error(`Timed out waiting for SLAB target ${targetId}`));
       }, TARGET_PAGE_MATCH_TIMEOUT_MS);
-      this.targetPageWaiters.get(runtime)!.set(targetId, { resolve, reject, timer });
+      interval = setInterval(poll, 50);
+      interval.unref?.();
+      this.targetPageWaiters.get(runtime)!.set(targetId, { resolve: finish, reject: fail, timer });
+      poll();
     });
   }
 
@@ -1233,6 +1273,9 @@ export class SlabSessionManager {
     // owned unless bindPage subsequently registers the exact matching target.
     for (const page of runtime.context.pages()) {
       if (pageIsClosed(page)) continue;
+      const cachedTargetId = this.pageTargetIds.get(page);
+      if (cachedTargetId === targetId) return page;
+      if (cachedTargetId) continue;
       const probe = await runtime.context.newCDPSession(page).catch(() => undefined);
       if (!probe) continue;
       try {

--- a/src/browser/runtime/local-slab/session-manager.ts
+++ b/src/browser/runtime/local-slab/session-manager.ts
@@ -5,8 +5,9 @@ import { SlabNetworkCapture } from './network.js';
 import { log } from '../../../logger.js';
 import { CliError, EXIT_CODES } from '../../../errors.js';
 import { isClosedContextError } from '../../run/types.js';
-import { humanizePage } from '../../humanizer/page.js';
+import { disposeHumanizedPage, humanizePage } from '../../humanizer/page.js';
 import { attachSlabProfile, type AttachedSlabProfile } from './attachment.js';
+import type { DiscoveredBrowserWindowListRow } from '../../sessions.js';
 
 const TARGET_PAGE_MATCH_TIMEOUT_MS = 1_000;
 export const PROFILE_IDLE_TIMEOUT_MS = 60_000;
@@ -52,6 +53,9 @@ type PageEntry = {
   adapterSite?: string;
   idleTimeout?: number;
   idleTimer?: ReturnType<typeof setTimeout>;
+  windowId: number;
+  provenance: 'agent-created' | 'human-adopted';
+  closeListener?: () => void;
 };
 
 export interface SlabPageLease {
@@ -69,10 +73,22 @@ export interface SlabTabInfo {
   title: string;
   url: string;
   profileId: string;
-  session: string;
-  sessionId: string;
+  session?: string;
+  sessionId?: string;
   surface: BrowserSurface;
   selected: boolean;
+  window: string;
+  ownership: 'session' | 'unowned';
+  provenance?: 'agent-created' | 'human-adopted';
+  targetId?: string;
+}
+
+interface DiscoveredPage {
+  pageId: string;
+  windowId: number;
+  targetId: string;
+  title: string;
+  url: string;
 }
 
 interface ProfileRuntime {
@@ -94,6 +110,8 @@ interface ProfileRuntime {
   disposed: boolean;
   releasePromise?: Promise<void>;
   lastSeenAt: number;
+  generation: number;
+  discoveredPages: Map<string, DiscoveredPage>;
 }
 
 interface SessionRuntime {
@@ -123,6 +141,17 @@ export class SessionWindowConflictError extends CliError {
   }
 }
 
+export class AdoptedTabForceRequiredError extends CliError {
+  constructor(pageId: string) {
+    super(
+      'ADOPTED_TAB_FORCE_REQUIRED',
+      `Closing adopted human tab ${pageId} is destructive and requires --force.`,
+      'Detach the Session normally to leave the human window open.',
+      EXIT_CODES.USAGE_ERROR,
+    );
+  }
+}
+
 export class SlabAttachmentLostError extends Error {
   readonly code = 'SLAB_ATTACHMENT_LOST';
 
@@ -136,9 +165,11 @@ export interface SlabSessionManagerOptions {
   baseDir?: string;
   attachProfile?: AttachSlabProfile;
   hasActiveHandoff?: (profileId: string) => boolean;
+  humanize?: typeof humanizePage;
 }
 
 let pageCounter = 0;
+let attachmentGeneration = 0;
 
 export function resolveLeaseKey(input: SessionKeyInput): string {
   const surface = input.surface === 'adapter' ? 'adapter' : 'browser';
@@ -171,6 +202,7 @@ export class SlabSessionManager {
 
   private readonly attachProfile: AttachSlabProfile;
   private readonly hasActiveHandoff: (profileId: string) => boolean;
+  private readonly humanize: typeof humanizePage;
   private readonly profiles = new Map<string, ProfileRuntime>();
   private readonly detachedSessions = new Map<string, Set<string>>();
   private readonly profileLaunches = new Map<string, Promise<ProfileRuntime>>();
@@ -179,9 +211,8 @@ export class SlabSessionManager {
   private readonly pageCreationQueues = new Map<string, Promise<void>>();
   private readonly pageTargetIds = new WeakMap<PlaywrightPage, string>();
   private readonly pageTargetIdPromises = new WeakMap<PlaywrightPage, Promise<string>>();
-  private readonly pageCdpSessions = new WeakMap<PlaywrightPage, CDPSession>();
-  private readonly pageCdpDetaches = new WeakMap<PlaywrightPage, Promise<void>>();
   private readonly pendingTargetPages = new WeakMap<ProfileRuntime, Map<string, PlaywrightPage>>();
+  private readonly pendingTargetCloseListeners = new WeakMap<ProfileRuntime, Map<string, { page: PlaywrightPage; listener: () => void }>>();
   private readonly targetPageWaiters = new WeakMap<ProfileRuntime, Map<string, {
     resolve(page: PlaywrightPage): void;
     reject(error: Error): void;
@@ -193,6 +224,7 @@ export class SlabSessionManager {
   constructor(private readonly opts: SlabSessionManagerOptions = {}) {
     this.attachProfile = opts.attachProfile ?? attachSlabProfile;
     this.hasActiveHandoff = opts.hasActiveHandoff ?? (() => false);
+    this.humanize = opts.humanize ?? humanizePage;
   }
 
   profileStatuses() {
@@ -207,6 +239,28 @@ export class SlabSessionManager {
 
   activeProfileIds(): string[] {
     return [...this.profiles.keys()];
+  }
+
+  async discoveredWindows(profileIdInput: string | undefined): Promise<DiscoveredBrowserWindowListRow[]> {
+    const profileId = normalizeProfileId(profileIdInput);
+    const runtime = await this.getProfileRuntime(profileId);
+    const pages = (await this.discoverPages(runtime))
+      .filter(page => runtime.windowOwners.get(page.windowId) === undefined);
+    const byWindow = new Map<number, DiscoveredPage[]>();
+    for (const page of pages) byWindow.set(page.windowId, [...(byWindow.get(page.windowId) ?? []), page]);
+    const rows: DiscoveredBrowserWindowListRow[] = [...byWindow.entries()].map(([windowId, tabs]) => ({
+      rowKind: 'discovered',
+      profileId,
+      runtimeState: 'available',
+      window: this.windowIdentity(runtime, windowId),
+      page: tabs[0]!.pageId,
+      tabCount: tabs.length,
+      title: tabs[0]!.title,
+      url: tabs[0]!.url,
+      ownership: 'unowned',
+    }));
+    this.scheduleProfileIdle(profileId, runtime);
+    return rows;
   }
 
   async runWithProfileActivity<T>(profileIdInput: string | undefined, task: () => Promise<T>): Promise<T> {
@@ -267,15 +321,21 @@ export class SlabSessionManager {
         }
       }
       const acquired = await this.acquireSessionPage(profileId, sessionId, input.windowMode);
-      const entry = await this.registerOwnedPage(acquired.runtime, acquired.session, acquired.page, {
-        leaseKey,
-        session,
-        surface,
-        siteSession: input.siteSession,
-        sessionKind: input.sessionKind,
-        adapterSite: input.adapterSite,
-        idleTimeout: input.idleTimeout,
-      });
+      let entry: PageEntry;
+      try {
+        entry = await this.registerOwnedPage(acquired.runtime, acquired.session, acquired.page, {
+          leaseKey,
+          session,
+          surface,
+          siteSession: input.siteSession,
+          sessionKind: input.sessionKind,
+          adapterSite: input.adapterSite,
+          idleTimeout: input.idleTimeout,
+        });
+      } catch (error) {
+        if (!pageIsClosed(acquired.page)) await acquired.page.close().catch(() => {});
+        throw error;
+      }
       if (existing && freshPage && existing !== entry) await this.removeEntry(acquired.runtime, sessionRuntime, existing, true);
       this.selectEntry(acquired.session, entry);
       acquired.runtime.lastSeenAt = Date.now();
@@ -385,14 +445,12 @@ export class SlabSessionManager {
     const sessionId = requireSessionId(input);
     this.assertSessionAttached(profileId, sessionId);
     const surface = input.surface ? normalizeSurface(input.surface) : undefined;
-    const runtime = this.profiles.get(profileId);
-    if (!runtime) return [];
+    const runtime = await this.getProfileRuntime(profileId);
     const sessionRuntime = runtime.sessions.get(sessionId);
-    if (!sessionRuntime) return [];
-    const entries = this.openEntries(sessionRuntime)
+    const entries = (sessionRuntime ? this.openEntries(sessionRuntime) : [])
       .filter(([, entry]) => !surface || entry.surface === surface);
     await Promise.all(entries.map(([, entry]) => this.assertOwnedWindow(runtime, sessionId, entry)));
-    return Promise.all(entries.map(async ([, entry], index) => ({
+    const owned = await Promise.all(entries.map(async ([, entry], index) => ({
       id: entry.pageId,
       page: entry.pageId,
       index,
@@ -402,8 +460,29 @@ export class SlabSessionManager {
       session: entry.session,
       sessionId,
       surface: entry.surface,
-      selected: sessionRuntime.selectedPageId === entry.pageId,
+      selected: sessionRuntime?.selectedPageId === entry.pageId,
+      window: this.windowIdentity(runtime, entry.windowId),
+      ownership: 'session' as const,
+      provenance: entry.provenance,
+      targetId: entry.targetId,
     })));
+    const discovered = await this.discoverPages(runtime);
+    const unowned = discovered
+      .filter(candidate => runtime.windowOwners.get(candidate.windowId) === undefined)
+      .map((candidate, index) => ({
+        id: candidate.pageId,
+        page: candidate.pageId,
+        index: owned.length + index,
+        title: candidate.title,
+        url: candidate.url,
+        profileId,
+        surface: 'browser' as const,
+        selected: false,
+        window: this.windowIdentity(runtime, candidate.windowId),
+        ownership: 'unowned' as const,
+        targetId: candidate.targetId,
+      }));
+    return [...owned, ...unowned];
   }
 
   async newPage(input: NewPageInput): Promise<SlabPageLease> {
@@ -440,14 +519,20 @@ export class SlabSessionManager {
       if (!pageIsClosed(acquired.page)) await acquired.page.close().catch(() => {});
       throw new Error('Target page, context or browser has been closed');
     }
-    const entry = await this.registerOwnedPage(acquired.runtime, acquired.sessionRuntime, acquired.page, {
-      session,
-      surface,
-      siteSession: input.siteSession,
-      sessionKind: input.sessionKind,
-      adapterSite: input.adapterSite,
-      idleTimeout: input.idleTimeout,
-    });
+    let entry: PageEntry;
+    try {
+      entry = await this.registerOwnedPage(acquired.runtime, acquired.sessionRuntime, acquired.page, {
+        session,
+        surface,
+        siteSession: input.siteSession,
+        sessionKind: input.sessionKind,
+        adapterSite: input.adapterSite,
+        idleTimeout: input.idleTimeout,
+      });
+    } catch (error) {
+      if (!pageIsClosed(acquired.page)) await acquired.page.close().catch(() => {});
+      throw error;
+    }
     const leaseKey = entry.leaseKey;
     this.refreshIdleTimer(acquired.runtime, acquired.sessionRuntime, leaseKey, entry);
     this.selectEntry(acquired.sessionRuntime, entry);
@@ -513,11 +598,14 @@ export class SlabSessionManager {
     const sessionId = requireSessionId(input);
     this.assertSessionAttached(profileId, sessionId);
     const surface = normalizeSurface(input.surface);
-    const runtime = this.profiles.get(profileId);
-    if (!runtime) return null;
+    const runtime = await this.getProfileRuntime(profileId);
+    return this.withPageCreationLock(profileId, async () => {
+      if (runtime.disposed || this.profiles.get(profileId) !== runtime) {
+        throw new SlabAttachmentLostError();
+      }
     const existingSession = runtime.sessions.get(sessionId);
-    const sessionRuntime = existingSession ?? this.getSessionRuntime(runtime, sessionId);
-    const targetId = input.targetId?.trim();
+    const discovered = input.pageId ? runtime.discoveredPages.get(input.pageId) : undefined;
+    const targetId = input.targetId?.trim() ?? discovered?.targetId;
     const existingEntry = input.pageId
       ? this.findEntryByPageId(runtime, input.pageId)?.[1]
       : targetId
@@ -525,10 +613,47 @@ export class SlabSessionManager {
         : existingSession && this.openEntries(existingSession)[input.index ?? -1]?.[1];
     const page = existingEntry?.page ?? (targetId ? await this.findPageByTargetId(runtime, targetId) : undefined);
     if (!page || pageIsClosed(page)) return null;
+    const selectedTargetId = await this.targetIdForPage(runtime, page);
+    const windowId = await this.windowIdForTarget(runtime, selectedTargetId, page);
+    if (discovered && discovered.windowId !== windowId) return null;
+    const owner = runtime.windowOwners.get(windowId);
+    if (owner !== undefined && owner !== sessionId) {
+      throw new SessionWindowConflictError(input.pageId ?? targetId ?? 'unknown', sessionId, owner);
+    }
+    if (existingSession && existingSession.windowIds.size > 0 && !existingSession.windowIds.has(windowId)) {
+      throw new SessionWindowConflictError(input.pageId ?? targetId ?? 'unknown', sessionId, sessionId);
+    }
+    const sessionRuntime = existingSession ?? this.getSessionRuntime(runtime, sessionId);
     const canonicalKey = resolveLeaseKey(input);
     const currentCanonical = sessionRuntime.pages.get(canonicalKey);
+    const sessionPagesSnapshot = new Map(sessionRuntime.pages);
+    const windowIdsSnapshot = new Set(sessionRuntime.windowIds);
+    const windowOwnersSnapshot = new Map(runtime.windowOwners);
+    const targetPagesSnapshot = new Map(runtime.targetPages);
+    const entrySnapshots = new Map([...runtime.targetPages.values()].map(entry => [entry, {
+      value: { ...entry, idleTimer: undefined },
+      hadIdleTimer: entry.idleTimer !== undefined,
+    }]));
+    const selectedPageIdSnapshot = sessionRuntime.selectedPageId;
+    const restoreTransaction = () => {
+      sessionRuntime.pages.clear();
+      for (const [key, value] of sessionPagesSnapshot) sessionRuntime.pages.set(key, value);
+      sessionRuntime.windowIds.clear();
+      for (const id of windowIdsSnapshot) sessionRuntime.windowIds.add(id);
+      runtime.windowOwners.clear();
+      for (const [id, value] of windowOwnersSnapshot) runtime.windowOwners.set(id, value);
+      runtime.targetPages.clear();
+      for (const [id, value] of targetPagesSnapshot) runtime.targetPages.set(id, value);
+      sessionRuntime.selectedPageId = selectedPageIdSnapshot;
+      for (const [entry, snapshot] of entrySnapshots) {
+        this.clearIdleTimer(entry);
+        Object.assign(entry, snapshot.value);
+        if (snapshot.hadIdleTimer) this.refreshIdleTimer(runtime, sessionRuntime, entry.leaseKey, entry);
+      }
+      if (!existingSession && sessionPagesSnapshot.size === 0) runtime.sessions.delete(sessionId);
+    };
 
-    if (input.windowMode !== 'background') {
+    if (input.windowMode === 'foreground') {
       await page.bringToFront?.().catch(() => {});
     }
 
@@ -540,21 +665,72 @@ export class SlabSessionManager {
       this.refreshIdleTimer(runtime, sessionRuntime, preservedKey, currentCanonical);
     }
 
-    const owned = await this.registerOwnedPage(runtime, sessionRuntime, page, {
-      leaseKey: canonicalKey,
-      session,
-      surface,
-      siteSession: input.siteSession,
-      sessionKind: input.sessionKind,
-      adapterSite: input.adapterSite,
-      idleTimeout: input.idleTimeout,
-    });
+    const siblings: PlaywrightPage[] = [];
+    for (const candidate of runtime.context.pages()) {
+      if (pageIsClosed(candidate)) continue;
+      const candidateTargetId = await this.targetIdForPageInWindow(runtime, candidate, windowId);
+      if (!candidateTargetId) continue;
+      if (candidateTargetId === runtime.anchorTargetId) continue;
+      siblings.push(candidate);
+    }
+    const newlyHumanized: PlaywrightPage[] = [];
+    try {
+      for (const sibling of siblings) {
+        if (!(sibling as unknown as { _original?: unknown })._original) {
+          this.humanize(sibling);
+          newlyHumanized.push(sibling);
+        }
+      }
+    } catch (error) {
+      await Promise.all(newlyHumanized.map(sibling => disposeHumanizedPage(sibling)));
+      await Promise.all(siblings.map(sibling => this.detachPageCdp(sibling)));
+      restoreTransaction();
+      throw error;
+    }
+    let owned: PageEntry | undefined;
+    const registered: PageEntry[] = [];
+    try {
+      for (const sibling of siblings) {
+        if (pageIsClosed(sibling)) throw new Error('SLAB bind target disappeared during window adoption.');
+        const entry = await this.registerOwnedPage(runtime, sessionRuntime, sibling, {
+        ...(sibling === page ? { leaseKey: canonicalKey } : {}),
+        session,
+        surface,
+        siteSession: input.siteSession,
+        sessionKind: input.sessionKind,
+        adapterSite: input.adapterSite,
+        idleTimeout: input.idleTimeout,
+        provenance: [...runtime.targetPages.values()].find(candidate => candidate.page === sibling)?.provenance ?? 'human-adopted',
+        humanize: false,
+      });
+        registered.push(entry);
+        if (sibling === page) owned = entry;
+      }
+    } catch (error) {
+      for (const entry of registered) {
+        if (!entrySnapshots.has(entry)) await this.removeEntry(runtime, sessionRuntime, entry, false);
+      }
+      await Promise.all(newlyHumanized.map(sibling => disposeHumanizedPage(sibling)));
+      await Promise.all(siblings.map(sibling => this.detachPageCdp(sibling)));
+      restoreTransaction();
+      throw error;
+    }
+    if (!owned) {
+      for (const entry of registered) {
+        if (!entrySnapshots.has(entry)) await this.removeEntry(runtime, sessionRuntime, entry, false);
+      }
+      await Promise.all(newlyHumanized.map(sibling => disposeHumanizedPage(sibling)));
+      await Promise.all(siblings.map(sibling => this.detachPageCdp(sibling)));
+      restoreTransaction();
+      return null;
+    }
     this.selectEntry(sessionRuntime, owned);
     runtime.lastSeenAt = Date.now();
     return { profileId, leaseKey: canonicalKey, context: runtime.context, page: owned.page, pageId: owned.pageId };
+    });
   }
 
-  async closePage(input: Pick<SessionKeyInput, 'profileId' | 'session' | 'sessionId' | 'surface'> & { pageId?: string; index?: number }): Promise<string | null> {
+  async closePage(input: Pick<SessionKeyInput, 'profileId' | 'session' | 'sessionId' | 'surface'> & { pageId?: string; index?: number; force?: boolean }): Promise<string | null> {
     const profileId = normalizeProfileId(input.profileId);
     const sessionId = requireSessionId(input);
     this.assertSessionAttached(profileId, sessionId);
@@ -567,7 +743,10 @@ export class SlabSessionManager {
     if (!match) return null;
     const [, entry] = match;
     await this.assertOwnedWindow(runtime, sessionId, entry);
-    await this.removeEntry(runtime, sessionRuntime, entry, true);
+    if (entry.provenance === 'human-adopted' && input.force !== true) {
+      throw new AdoptedTabForceRequiredError(entry.pageId);
+    }
+    await this.removeEntry(runtime, sessionRuntime, entry, true, input.force === true);
     runtime.lastSeenAt = Date.now();
     return entry.pageId;
   }
@@ -589,7 +768,7 @@ export class SlabSessionManager {
     ));
     await Promise.all(entries.map(([, entry]) => this.assertOwnedWindow(runtime, sessionId, entry)));
     for (const [, entry] of entries) {
-      if (entry.siteSession === 'persistent') continue;
+      if (entry.siteSession === 'persistent' || entry.provenance === 'human-adopted') continue;
       await this.removeEntry(runtime, sessionRuntime, entry, true);
     }
   }
@@ -694,21 +873,14 @@ export class SlabSessionManager {
       closing: false,
       disposed: false,
       lastSeenAt: Date.now(),
+      generation: ++attachmentGeneration,
+      discoveredPages: new Map(),
     };
     this.pendingTargetPages.set(runtime, new Map());
+    this.pendingTargetCloseListeners.set(runtime, new Map());
     this.targetPageWaiters.set(runtime, new Map());
     this.attachRuntimeLifecycle(profileId, runtime);
-    if (cdp) {
-      try {
-        runtime.anchorTargetId = (await cdp.send('Target.createTarget', {
-          url: 'about:blank',
-          hidden: true,
-          background: true,
-        }) as { targetId: string }).targetId;
-      } catch (error) {
-        this.warnKeeperFallback(profileId, runtime, error);
-      }
-    } else {
+    if (!cdp) {
       this.warnKeeperFallback(profileId, runtime, keeperError ?? new Error('browser connection unavailable'));
     }
     if (this.shuttingDown) {
@@ -725,28 +897,34 @@ export class SlabSessionManager {
     const detached = this.detachedSessions.get(profileId) ?? new Set<string>();
     for (const sessionId of runtime.sessions.keys()) detached.add(sessionId);
     if (detached.size > 0) this.detachedSessions.set(profileId, detached);
-    void this.releaseRuntime(runtime, false).catch(error => {
+    void this.releaseRuntime(runtime, false, true).catch(error => {
       log.warn(`SLAB Profile ${profileId} release failed: ${errorMessage(error)}`);
     });
-    this.cleanupRuntime(runtime);
   }
 
-  private cleanupRuntime(runtime: ProfileRuntime): void {
+  private async cleanupRuntime(runtime: ProfileRuntime): Promise<void> {
     if (runtime.disposed) return;
     runtime.disposed = true;
     this.cancelProfileIdle(runtime);
+    const humanizerDisposals: Promise<void>[] = [];
     for (const entry of runtime.targetPages.values()) {
       if (entry.idleTimer) clearTimeout(entry.idleTimer);
       this.networkCapture.stop(entry.page);
+      humanizerDisposals.push(disposeHumanizedPage(entry.page));
     }
     runtime.targetPages.clear();
+    runtime.discoveredPages.clear();
     runtime.sessions.clear();
     runtime.windowOwners.clear();
+    this.pendingTargetPages.get(runtime)?.clear();
+    for (const { page, listener } of this.pendingTargetCloseListeners.get(runtime)?.values() ?? []) page.off('close', listener);
+    this.pendingTargetCloseListeners.get(runtime)?.clear();
     for (const waiter of this.targetPageWaiters.get(runtime)?.values() ?? []) {
       clearTimeout(waiter.timer);
       waiter.reject(new Error('Target page, context or browser has been closed'));
     }
     this.targetPageWaiters.get(runtime)?.clear();
+    await Promise.all(humanizerDisposals);
   }
 
   private attachRuntimeLifecycle(profileId: string, runtime: ProfileRuntime): void {
@@ -755,7 +933,7 @@ export class SlabSessionManager {
       void this.handleContextPage(runtime, page).catch(() => {});
     });
     const onCdpEvent = (runtime.cdp as (CDPSession & {
-      on?: (event: string, listener: (payload: { targetId: string }) => void) => void;
+      on?: (event: string, listener: (payload: any) => void) => void;
     }) | undefined)?.on;
     onCdpEvent?.call(runtime.cdp, 'Target.targetDestroyed', ({ targetId }: { targetId: string }) => {
       this.queueAnchorRepair(profileId, runtime, targetId);
@@ -782,6 +960,19 @@ export class SlabSessionManager {
       }) as { targetId: string }).targetId;
     } catch (error) {
       this.warnKeeperFallback(profileId, runtime, error);
+    }
+  }
+
+  private async ensureKeeper(runtime: ProfileRuntime): Promise<void> {
+    if (runtime.anchorTargetId || runtime.useParkingKeeper || !runtime.cdp) return;
+    try {
+      runtime.anchorTargetId = (await runtime.cdp.send('Target.createTarget', {
+        url: 'about:blank',
+        hidden: true,
+        background: true,
+      }) as { targetId: string }).targetId;
+    } catch (error) {
+      this.warnKeeperFallback(runtime.profileId, runtime, error);
     }
   }
 
@@ -851,7 +1042,9 @@ export class SlabSessionManager {
       try {
         if (closePages) {
           await Promise.all([...runtime.targetPages.values()].map(entry => (
-            pageIsClosed(entry.page) ? undefined : entry.page.close().catch(() => {})
+            pageIsClosed(entry.page) || entry.provenance === 'human-adopted'
+              ? undefined
+              : entry.page.close().catch(() => {})
           )));
         }
         await this.closeParkingPage(runtime);
@@ -866,7 +1059,7 @@ export class SlabSessionManager {
         if (releaseNative) await runtime.attachment.release();
         else runtime.attachment.closeTransport();
       } finally {
-        this.cleanupRuntime(runtime);
+        await this.cleanupRuntime(runtime);
       }
     })();
     return runtime.releasePromise;
@@ -943,7 +1136,7 @@ export class SlabSessionManager {
     }
     const page = await openedPage;
     if (page) return page;
-    return this.createWindowPage(runtime, windowMode);
+    throw new Error(`SLAB could not create another tab in Session ${session.id} without opening a second window.`);
   }
 
   private async waitForContextPageForSession(
@@ -1005,6 +1198,7 @@ export class SlabSessionManager {
   }
 
   private async createWindowPage(runtime: ProfileRuntime, windowMode?: BrowserWindowMode, newWindow = true): Promise<PlaywrightPage> {
+    await this.ensureKeeper(runtime);
     if (!runtime.cdp) return runtime.context.newPage();
     const result = await runtime.cdp.send('Target.createTarget', {
       url: 'about:blank',
@@ -1019,8 +1213,7 @@ export class SlabSessionManager {
     const pending = this.pendingTargetPages.get(runtime)!;
     const page = pending.get(targetId);
     if (page) {
-      pending.delete(targetId);
-      pending.clear();
+      this.clearPendingTargetPage(runtime, targetId, page);
       return page;
     }
     return new Promise<PlaywrightPage>((resolve, reject) => {
@@ -1040,13 +1233,67 @@ export class SlabSessionManager {
     // owned unless bindPage subsequently registers the exact matching target.
     for (const page of runtime.context.pages()) {
       if (pageIsClosed(page)) continue;
-      if (await this.targetIdForPage(runtime, page).catch(() => undefined) === targetId) return page;
+      const probe = await runtime.context.newCDPSession(page).catch(() => undefined);
+      if (!probe) continue;
+      try {
+        const { targetInfo } = await probe.send('Target.getTargetInfo') as { targetInfo: { targetId: string } };
+        if (targetInfo.targetId === targetId) {
+          this.pageTargetIds.set(page, targetId);
+          page.once('close', () => this.pageTargetIds.delete(page));
+          return page;
+        }
+      } finally {
+        await probe.detach().catch(() => {});
+      }
     }
     return undefined;
   }
 
+  private windowIdentity(runtime: ProfileRuntime, windowId: number): string {
+    return `slab-window-${runtime.generation}-${windowId}`;
+  }
+
+  private async discoverPages(runtime: ProfileRuntime): Promise<DiscoveredPage[]> {
+    if (!runtime.cdp) return [];
+    const { targetInfos = [] } = await runtime.cdp.send('Target.getTargets') as {
+      targetInfos: Array<{ targetId: string; type: string; title?: string; url?: string }>;
+    };
+    const live = new Set(targetInfos.map(target => target.targetId));
+    for (const [pageId, page] of runtime.discoveredPages) {
+      if (!live.has(page.targetId)) runtime.discoveredPages.delete(pageId);
+    }
+    const result: DiscoveredPage[] = [];
+    for (const target of targetInfos) {
+      if (target.type !== 'page' || target.targetId === runtime.anchorTargetId) continue;
+      if (target.url?.startsWith('devtools://') || target.url?.startsWith('chrome-extension://')) continue;
+      const windowId = await this.windowIdForTarget(runtime, target.targetId).catch(() => undefined);
+      if (windowId === undefined) continue;
+      let page = [...runtime.discoveredPages.values()].find(candidate => candidate.targetId === target.targetId);
+      if (!page) {
+        page = {
+          pageId: `slab-page-${runtime.generation}-${++pageCounter}`,
+          windowId,
+          targetId: target.targetId,
+          title: target.title ?? '',
+          url: target.url ?? '',
+        };
+        runtime.discoveredPages.set(page.pageId, page);
+      } else {
+        page.windowId = windowId;
+        page.title = target.title ?? '';
+        page.url = target.url ?? '';
+      }
+      result.push(page);
+    }
+    return result;
+  }
+
   private async handleContextPage(runtime: ProfileRuntime, page: PlaywrightPage): Promise<void> {
-    const targetId = await this.targetIdForPage(runtime, page);
+    // Context `page` events include pre-existing human tabs. Resolve the exact
+    // target with a short-lived page probe, which targetIdForPage always
+    // detaches; an unowned observation must not leave a debugger attached.
+    const targetId = await this.targetIdForPage(runtime, page).catch(() => undefined);
+    if (!targetId) return;
     if (targetId === runtime.anchorTargetId) {
       page.once('close', () => {
         this.queueAnchorRepair(runtime.profileId, runtime, targetId);
@@ -1056,50 +1303,79 @@ export class SlabSessionManager {
     const waiter = this.targetPageWaiters.get(runtime)?.get(targetId);
     if (waiter) {
       this.targetPageWaiters.get(runtime)!.delete(targetId);
-      this.pendingTargetPages.get(runtime)?.clear();
+      this.clearPendingTargetPage(runtime, targetId);
       clearTimeout(waiter.timer);
       waiter.resolve(page);
     } else {
-      this.pendingTargetPages.get(runtime)?.set(targetId, page);
+      this.rememberPendingTargetPage(runtime, targetId, page);
     }
 
-    const opener = await page.opener().catch(() => null);
-    const openerEntry = opener && [...runtime.targetPages.values()].find(entry => entry.page === opener);
-    if (!openerEntry?.sessionId) return;
-    const session = runtime.sessions.get(openerEntry.sessionId);
-    if (!session) return;
-    this.pendingTargetPages.get(runtime)?.delete(targetId);
-    await this.registerOwnedPage(runtime, session, page, {
-      session: openerEntry.session,
-      surface: openerEntry.surface,
-      siteSession: openerEntry.siteSession,
-      sessionKind: openerEntry.sessionKind,
-      adapterSite: openerEntry.adapterSite,
-      idleTimeout: openerEntry.idleTimeout,
-    });
+    try {
+      await this.withPageCreationLock(runtime.profileId, async () => {
+        if (runtime.disposed || this.profiles.get(runtime.profileId) !== runtime) return;
+        const windowId = await this.windowIdForTarget(runtime, targetId);
+        const windowOwner = runtime.windowOwners.get(windowId);
+        const ownedSession = windowOwner ? runtime.sessions.get(windowOwner) : undefined;
+        const ownedTemplate = ownedSession ? this.openEntries(ownedSession)[0]?.[1] : undefined;
+        const opener = await page.opener().catch(() => null);
+        const openerTargetId = opener
+          ? undefined
+          : await this.openerTargetIdForTarget(runtime, targetId).catch(() => undefined);
+        const openerEntry = ownedTemplate ?? (opener
+          ? [...runtime.targetPages.values()].find(entry => entry.page === opener)
+          : openerTargetId ? runtime.targetPages.get(openerTargetId) : undefined);
+        if (!openerEntry?.sessionId) return;
+        const session = runtime.sessions.get(openerEntry.sessionId);
+        if (!session) return;
+        this.clearPendingTargetPage(runtime, targetId, page);
+        await this.registerOwnedPage(runtime, session, page, {
+          session: openerEntry.session,
+          surface: openerEntry.surface,
+          siteSession: openerEntry.siteSession,
+          sessionKind: openerEntry.sessionKind,
+          adapterSite: openerEntry.adapterSite,
+          idleTimeout: openerEntry.idleTimeout,
+          provenance: openerEntry.provenance,
+        });
+      });
+    } finally {
+      this.clearPendingTargetPage(runtime, targetId, page);
+    }
   }
 
   private async registerOwnedPage(
     runtime: ProfileRuntime,
     session: SessionRuntime,
     page: PlaywrightPage,
-    input: Pick<PageEntry, 'session' | 'surface' | 'siteSession' | 'sessionKind' | 'adapterSite' | 'idleTimeout'> & { leaseKey?: string },
+    input: Pick<PageEntry, 'session' | 'surface' | 'siteSession' | 'sessionKind' | 'adapterSite' | 'idleTimeout'> & {
+      leaseKey?: string;
+      provenance?: 'agent-created' | 'human-adopted';
+      humanize?: boolean;
+    },
   ): Promise<PageEntry> {
     const targetId = await this.targetIdForPage(runtime, page);
-    this.pendingTargetPages.get(runtime)?.delete(targetId);
+    this.clearPendingTargetPage(runtime, targetId, page);
     const windowId = await this.windowIdForTarget(runtime, targetId, page);
     const owner = runtime.windowOwners.get(windowId);
     if (owner !== undefined && owner !== session.id) {
       throw new SessionWindowConflictError(runtime.targetPages.get(targetId)?.pageId ?? 'unknown', session.id, owner);
     }
-    runtime.windowOwners.set(windowId, session.id);
-    session.windowIds.add(windowId);
-
+    if (session.windowIds.size > 0 && !session.windowIds.has(windowId)) {
+      throw new SessionWindowConflictError(runtime.targetPages.get(targetId)?.pageId ?? 'unknown', session.id, session.id);
+    }
     let entry = runtime.targetPages.get(targetId);
+    const priorEntry = entry ? { ...entry, idleTimer: undefined } : undefined;
+    const priorHadIdleTimer = entry?.idleTimer !== undefined;
+    const priorSessionPages = new Map(session.pages);
+    const priorWindowIds = new Set(session.windowIds);
+    const priorOwner = runtime.windowOwners.get(windowId);
     const wasOwned = Boolean(entry?.sessionId);
     if (entry?.sessionId && entry.sessionId !== session.id) {
       throw new SessionWindowConflictError(entry.pageId, session.id, entry.sessionId);
     }
+    try {
+    runtime.windowOwners.set(windowId, session.id);
+    session.windowIds.add(windowId);
     if (!entry) {
       const pageId = nextPageId();
       entry = {
@@ -1114,6 +1390,8 @@ export class SlabSessionManager {
         sessionKind: input.sessionKind,
         adapterSite: input.adapterSite,
         idleTimeout: input.idleTimeout,
+        windowId,
+        provenance: input.provenance ?? this.openEntries(session)[0]?.[1].provenance ?? 'agent-created',
       };
       runtime.targetPages.set(targetId, entry);
       this.attachPageLifecycle(runtime, entry);
@@ -1129,28 +1407,52 @@ export class SlabSessionManager {
       entry.sessionKind = input.sessionKind;
       entry.adapterSite = input.adapterSite;
       entry.idleTimeout = input.idleTimeout;
+      entry.windowId = windowId;
+      entry.provenance = input.provenance ?? entry.provenance;
       entry.leaseKey = input.leaseKey ?? (entry.leaseKey.startsWith('unowned\u0000') ? `page\u0000${entry.pageId}` : entry.leaseKey);
     }
     session.pages.set(entry.leaseKey, entry);
-    humanizePage(page);
+    if (input.humanize !== false) this.humanize(page);
     this.cancelProfileIdle(runtime);
     this.refreshIdleTimer(runtime, session, entry.leaseKey, entry);
     if (!wasOwned) for (const listener of this.sessionPageListeners.get(session) ?? []) listener(page);
     await this.closeParkingPage(runtime);
     return entry;
+    } catch (error) {
+      if (entry?.idleTimer) clearTimeout(entry.idleTimer);
+      session.pages.clear();
+      for (const [key, value] of priorSessionPages) session.pages.set(key, value);
+      session.windowIds.clear();
+      for (const id of priorWindowIds) session.windowIds.add(id);
+      if (priorOwner === undefined) runtime.windowOwners.delete(windowId);
+      else runtime.windowOwners.set(windowId, priorOwner);
+      if (priorEntry && entry) {
+        Object.assign(entry, priorEntry);
+        entry.idleTimer = undefined;
+        if (priorHadIdleTimer) this.refreshIdleTimer(runtime, session, entry.leaseKey, entry);
+      } else if (entry) {
+        runtime.targetPages.delete(targetId);
+        if (entry.closeListener) entry.page.off('close', entry.closeListener);
+        await disposeHumanizedPage(entry.page);
+      }
+      throw error;
+    }
   }
 
   private attachPageLifecycle(runtime: ProfileRuntime, entry: PageEntry): void {
-    entry.page.once('close', () => {
-      runtime.targetPages.delete(entry.targetId);
-      if (entry.sessionId) {
-        const session = runtime.sessions.get(entry.sessionId);
-        if (session?.pages.get(entry.leaseKey) === entry) session.pages.delete(entry.leaseKey);
-      }
-      this.clearIdleTimer(entry);
+    const closeListener = () => {
       if (runtime.parkingPage === entry.page) runtime.parkingPage = undefined;
-      this.scheduleProfileIdle(runtime.profileId, runtime);
-    });
+      const session = entry.sessionId ? runtime.sessions.get(entry.sessionId) : undefined;
+      if (session) void this.removeEntry(runtime, session, entry, false);
+      else {
+        runtime.targetPages.delete(entry.targetId);
+        this.clearIdleTimer(entry);
+        void this.detachPageCdp(entry.page);
+        this.scheduleProfileIdle(runtime.profileId, runtime);
+      }
+    };
+    entry.closeListener = closeListener;
+    entry.page.on('close', closeListener);
   }
 
   private async targetIdForPage(runtime: ProfileRuntime, page: PlaywrightPage): Promise<string> {
@@ -1160,14 +1462,15 @@ export class SlabSessionManager {
     if (pending) return pending;
     const correlation = (async () => {
       const session = await runtime.context.newCDPSession(page);
-      const { targetInfo } = await session.send('Target.getTargetInfo') as { targetInfo: { targetId: string } };
-      this.pageTargetIds.set(page, targetInfo.targetId);
-      this.pageCdpSessions.set(page, session);
-      page.once('close', () => {
-        this.pageTargetIds.delete(page);
-        void this.detachPageCdp(page);
-      });
-      return targetInfo.targetId;
+      try {
+        const { targetInfo } = await session.send('Target.getTargetInfo') as { targetInfo: { targetId: string } };
+        if (!targetInfo?.targetId) throw new Error('SLAB page target identity is unavailable.');
+        this.pageTargetIds.set(page, targetInfo.targetId);
+        page.once('close', () => this.pageTargetIds.delete(page));
+        return targetInfo.targetId;
+      } finally {
+        await session.detach().catch(() => {});
+      }
     })();
     this.pageTargetIdPromises.set(page, correlation);
     try {
@@ -1177,10 +1480,43 @@ export class SlabSessionManager {
     }
   }
 
+  private async targetIdForPageInWindow(
+    runtime: ProfileRuntime,
+    page: PlaywrightPage,
+    expectedWindowId: number,
+  ): Promise<string | undefined> {
+    const cached = this.pageTargetIds.get(page);
+    if (cached) {
+      return await this.windowIdForTarget(runtime, cached, page).catch(() => undefined) === expectedWindowId
+        ? cached
+        : undefined;
+    }
+    const probe = await runtime.context.newCDPSession(page);
+    try {
+      const { targetInfo } = await probe.send('Target.getTargetInfo') as { targetInfo: { targetId: string } };
+      const windowId = await (runtime.cdp ?? probe).send('Browser.getWindowForTarget', {
+        targetId: targetInfo.targetId,
+      }).then(result => (result as { windowId: number }).windowId);
+      if (windowId !== expectedWindowId) return undefined;
+      this.pageTargetIds.set(page, targetInfo.targetId);
+      page.once('close', () => this.pageTargetIds.delete(page));
+      return targetInfo.targetId;
+    } finally {
+      await probe.detach().catch(() => {});
+    }
+  }
+
+  private async openerTargetIdForTarget(runtime: ProfileRuntime, targetId: string): Promise<string | undefined> {
+    if (!runtime.cdp) return undefined;
+    const { targetInfo } = await runtime.cdp.send('Target.getTargetInfo', { targetId }) as {
+      targetInfo: { openerId?: string };
+    };
+    return targetInfo.openerId;
+  }
+
   private async windowIdForTarget(runtime: ProfileRuntime, targetId: string, page?: PlaywrightPage): Promise<number> {
     const entry = runtime.targetPages.get(targetId);
-    const targetPage = page ?? entry?.page;
-    const cdp = runtime.cdp ?? (targetPage ? this.pageCdpSessions.get(targetPage) : undefined);
+    const cdp = runtime.cdp;
     if (!cdp) throw new Error('SLAB page has no CDP session.');
     const { windowId } = await cdp.send('Browser.getWindowForTarget', { targetId }) as { windowId: number };
     return windowId;
@@ -1222,7 +1558,7 @@ export class SlabSessionManager {
 
   private refreshIdleTimer(runtime: ProfileRuntime, session: SessionRuntime, leaseKey: string, entry: PageEntry): void {
     this.clearIdleTimer(entry);
-    if (!entry.idleTimeout || entry.idleTimeout <= 0 || entry.siteSession === 'persistent') return;
+    if (!entry.idleTimeout || entry.idleTimeout <= 0 || entry.siteSession === 'persistent' || entry.provenance === 'human-adopted') return;
     entry.idleTimer = setTimeout(() => {
       void this.expireLease(runtime, session, leaseKey, entry);
     }, entry.idleTimeout);
@@ -1235,8 +1571,9 @@ export class SlabSessionManager {
     if (entry.siteSession !== 'persistent') await this.removeEntry(runtime, session, entry, true);
   }
 
-  private async removeEntry(runtime: ProfileRuntime, session: SessionRuntime, entry: PageEntry, close: boolean): Promise<void> {
-    const shouldPark = close && runtime.useParkingKeeper
+  private async removeEntry(runtime: ProfileRuntime, session: SessionRuntime, entry: PageEntry, close: boolean, force = false): Promise<void> {
+    const destructiveClose = close && (entry.provenance === 'agent-created' || force);
+    const shouldPark = destructiveClose && runtime.useParkingKeeper
       && [...runtime.targetPages.values()].every(candidate => candidate === entry || pageIsClosed(candidate.page));
     const parkingWindowId = shouldPark
       ? await this.windowIdForTarget(runtime, entry.targetId, entry.page).catch(() => undefined)
@@ -1246,7 +1583,13 @@ export class SlabSessionManager {
     this.clearIdleTimer(entry);
     this.clearSelectedPage(session, entry);
     this.networkCapture.stop(entry.page);
-    if (close && !pageIsClosed(entry.page)) {
+    if (entry.closeListener) {
+      entry.page.off('close', entry.closeListener);
+      entry.closeListener = undefined;
+    }
+    await this.detachPageCdp(entry.page);
+    await disposeHumanizedPage(entry.page);
+    if (destructiveClose && !pageIsClosed(entry.page)) {
       if (shouldPark) {
         await entry.page.goto('about:blank', { waitUntil: 'load' }).catch(() => {});
         entry.sessionId = undefined;
@@ -1264,6 +1607,14 @@ export class SlabSessionManager {
         if (!pageIsClosed(entry.page)) await entry.page.close().catch(() => {});
       }
     }
+    const windowStillOwned = [...runtime.targetPages.values()].some(candidate => (
+      candidate.sessionId === session.id && candidate.windowId === entry.windowId && !pageIsClosed(candidate.page)
+    ));
+    if (!windowStillOwned) {
+      runtime.windowOwners.delete(entry.windowId);
+      session.windowIds.delete(entry.windowId);
+    }
+    if (session.pages.size === 0) runtime.sessions.delete(session.id);
     this.scheduleProfileIdle(runtime.profileId, runtime);
   }
 
@@ -1275,12 +1626,26 @@ export class SlabSessionManager {
     await this.detachPageCdp(parkingPage);
   }
 
-  private detachPageCdp(page: PlaywrightPage): Promise<void> {
-    const existing = this.pageCdpDetaches.get(page);
-    if (existing) return existing;
-    const detach = this.pageCdpSessions.get(page)?.detach().catch(() => {}) ?? Promise.resolve();
-    this.pageCdpDetaches.set(page, detach);
-    return detach;
+  private detachPageCdp(_page: PlaywrightPage): Promise<void> {
+    return Promise.resolve();
+  }
+
+  private rememberPendingTargetPage(runtime: ProfileRuntime, targetId: string, page: PlaywrightPage): void {
+    this.clearPendingTargetPage(runtime, targetId);
+    this.pendingTargetPages.get(runtime)?.set(targetId, page);
+    const forget = () => this.clearPendingTargetPage(runtime, targetId, page);
+    page.on('close', forget);
+    this.pendingTargetCloseListeners.get(runtime)?.set(targetId, { page, listener: forget });
+  }
+
+  private clearPendingTargetPage(runtime: ProfileRuntime, targetId: string, expectedPage?: PlaywrightPage): void {
+    const pending = this.pendingTargetPages.get(runtime);
+    if (expectedPage && pending?.get(targetId) !== expectedPage) return;
+    pending?.delete(targetId);
+    const closeListeners = this.pendingTargetCloseListeners.get(runtime);
+    const closeListener = closeListeners?.get(targetId);
+    if (closeListener) closeListener.page.off('close', closeListener.listener);
+    closeListeners?.delete(targetId);
   }
 
   private clearIdleTimer(entry: PageEntry): void {

--- a/src/browser/runtime/provider.ts
+++ b/src/browser/runtime/provider.ts
@@ -8,12 +8,13 @@ export interface RuntimeStatusOptions {
 export interface BrowserRuntimeProvider {
   status(opts?: RuntimeStatusOptions): Promise<BrowserRuntimeStatus>;
   resolveProfileId?(command: BrowserRuntimeCommand): string;
+  ensureProfile?(input: { alias: string; idempotencyKey: string }): Promise<{ profile: { id: string; displayName: string }; created: boolean }>;
   createSession?(command: BrowserRuntimeCommand): Promise<BrowserSessionRecord>;
   requireSession?(command: BrowserRuntimeCommand): Promise<BrowserSessionRecord>;
   resolveAdapterDefault?(command: BrowserRuntimeCommand): Promise<BrowserSessionRecord>;
   startSessionHandoff?(command: BrowserRuntimeCommand): Promise<BrowserSessionRecord>;
   clearSessionHandoff?(command: BrowserRuntimeCommand): Promise<BrowserSessionRecord>;
-  listSessions?(input: { profileId?: string; limit?: number }): Promise<BrowserSessionListRow[]>;
+  listSessions?(input: { profileId?: string; limit?: number; includeDiscovered?: boolean }): Promise<BrowserSessionListRow[]>;
   closeSession?(command: BrowserRuntimeCommand): Promise<{ closed: boolean; alreadyIdle: boolean; session: string }>;
   dispatch(command: BrowserRuntimeCommand, signal?: AbortSignal): Promise<BrowserRuntimeResult>;
   shutdown(): Promise<void>;

--- a/src/browser/sessions.ts
+++ b/src/browser/sessions.ts
@@ -23,9 +23,26 @@ export interface BrowserSessionRecord {
   handoff?: { site: string; expiresAt: string };
 }
 
-export interface BrowserSessionListRow extends BrowserSessionRecord {
+export interface ManagedBrowserSessionListRow extends BrowserSessionRecord {
+  rowKind?: 'session';
   runtimeState: 'idle' | 'active';
+  provenance?: 'agent-created' | 'human-adopted';
+  window?: string;
 }
+
+export interface DiscoveredBrowserWindowListRow {
+  rowKind: 'discovered';
+  profileId: string;
+  runtimeState: 'available';
+  window: string;
+  page: string;
+  tabCount: number;
+  title: string;
+  url: string;
+  ownership: 'unowned';
+}
+
+export type BrowserSessionListRow = ManagedBrowserSessionListRow | DiscoveredBrowserWindowListRow;
 
 export interface LocalBrowserSessionStoreOptions {
   baseDir?: string;
@@ -106,7 +123,7 @@ export class LocalBrowserSessionStore {
     return { ...record };
   }
 
-  list(profileId?: string, limit = 20): BrowserSessionListRow[] {
+  list(profileId?: string, limit = 20): ManagedBrowserSessionListRow[] {
     if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
       throw new CliError('INVALID_SESSION_LIMIT', 'Session list limit must be an integer from 1 to 100.', undefined, EXIT_CODES.USAGE_ERROR);
     }
@@ -114,7 +131,7 @@ export class LocalBrowserSessionStore {
       .filter((row) => profileId === undefined || row.profileId === profileId)
       .sort((left, right) => right.lastUsedAt.localeCompare(left.lastUsedAt) || left.id.localeCompare(right.id))
       .slice(0, limit);
-    return rows.map((row) => ({ ...row, runtimeState: 'idle' as const }));
+    return rows.map((row) => ({ ...row, rowKind: 'session' as const, runtimeState: 'idle' as const }));
   }
 
   markHandoff(profileId: string, sessionId: string, handoff: { site: string; expiresAt: string }): BrowserSessionRecord {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1304,6 +1304,14 @@ name: 'search',
     }
   });
 
+  it('describes session close cleanup consistently with its discard behavior', () => {
+    const program = createProgram('', '');
+    const session = program.commands.find(cmd => cmd.name() === 'session')!;
+    const close = session.commands.find(cmd => cmd.name() === 'close')!;
+
+    expect(close.description()).toBe('Close a browser Session runtime and discard its durable record');
+  });
+
   it('renders plugin namespace structured help with positional + option leaves', () => {
     const argv = process.argv;
     try {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1438,7 +1438,7 @@ name: 'search',
       expect(data.commands.map((cmd: any) => cmd.name)).toEqual(['create', 'list', 'rename', 'use']);
       const list = data.commands.find((cmd: any) => cmd.name === 'list');
       expect(list).toMatchObject({
-        description: 'List Chrome and Chromium profiles available through the Cloak runtime',
+        description: 'List profiles available through the Cloak runtime',
       });
       const rename = data.commands.find((cmd: any) => cmd.name === 'rename');
       expect(rename).toMatchObject({
@@ -2371,6 +2371,14 @@ describe('browser raw session commands', () => {
     const program = createProgram('', '');
     await program.parseAsync(['node', 'webcmd', '--session', 'work-k7', 'browser', 'close']);
     expect(mockSendCommand).toHaveBeenCalledWith('close-window', { session: 'work-k7', surface: 'browser' });
+  });
+
+  it('routes exact-page force only on browser close', async () => {
+    const program = createProgram('', '');
+    await program.parseAsync(['node', 'webcmd', '--session', 'work-k7', 'browser', 'close', '--page', 'page-7', '--force']);
+    expect(mockSendCommand).toHaveBeenCalledWith('close-window', {
+      session: 'work-k7', surface: 'browser', page: 'page-7', force: true,
+    });
   });
 });
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2563,6 +2563,7 @@ describe('browser Session lifecycle commands', () => {
       contextId: 'default',
       session: 'work-project-k7',
       force: false,
+      discard: true,
     });
     expect(JSON.parse(consoleLogSpy.mock.calls.flat().join('\n'))).toMatchObject({
       closed: false,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,7 +46,8 @@ import { daemonRestart, daemonStatus, daemonStop } from './commands/daemon.js';
 import { enableVerbose, isVerbose, log } from './logger.js';
 import { BrowserCommandError, listExistingBrowserTabs, releaseSiteSessionLease, sendCommand } from './browser/daemon-client.js';
 import { fetchDaemonStatus } from './browser/daemon-transport.js';
-import { aliasForContextId, createProfile, loadProfileConfig, normalizeContextId, ProfileNotFoundError, profileListRows, profileRouteParams, renameProfile, resolveKnownProfile, resolveProfileSelection, setDefaultProfile, type ProfileSelection } from './browser/profile.js';
+import { aliasForContextId, commitSlabProfileEnsure, createProviderProfile, loadProfileConfig, normalizeContextId, prepareSlabProfileEnsure, ProfileNotFoundError, profileListRows, profileRouteParams, renameProviderProfile, resolveKnownProfile, resolveProfileSelection, rotateSlabProfileEnsure, setProviderDefaultProfile, type ProfileProvider, type ProfileSelection } from './browser/profile.js';
+import { loadWebcmdConfig } from './hosted/config.js';
 import { formatDaemonVersion, isDaemonStale } from './browser/daemon-version.js';
 import { DEFAULT_BROWSER_CONNECT_TIMEOUT } from './browser/config.js';
 import { CLI_COMMAND, PACKAGE_NAME } from './brand.js';
@@ -68,6 +69,15 @@ import { resolveAdapterSourcePath, splitAdapterCommandKey } from './adapter-sour
 
 const CLI_FILE = fileURLToPath(import.meta.url);
 const FOLLOW_POLL_MS = 1_000;
+
+function selectedProfileProvider(): ProfileProvider {
+  const config = loadWebcmdConfig();
+  return config.mode === 'local' ? config.browser.kind : 'cloak';
+}
+function selectedProfileProviderLabel(): string {
+  const provider = selectedProfileProvider();
+  return provider === 'slab' ? 'SLAB' : provider === 'cloak' ? 'Cloak' : provider === 'chrome' ? 'Chrome' : 'custom browser';
+}
 const externalRootCommands = new WeakSet<Command>();
 
 function parsePositiveIntOption(value: string | undefined, _label: string, fallback: number): number {
@@ -458,7 +468,7 @@ async function requireKnownProfileId(command?: Command): Promise<string> {
 }
 
 function formatHandoff(row: BrowserSessionListRow): string {
-  return row.handoff ? `${row.handoff.site} until ${row.handoff.expiresAt}` : '';
+  return row.rowKind !== 'discovered' && row.handoff ? `${row.handoff.site} until ${row.handoff.expiresAt}` : '';
 }
 
 function sessionCreateOutput(data: unknown): unknown {
@@ -797,7 +807,11 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string, pluginsDi
       // `profileId` is a column because these rows are scoped to the selected
       // Profile. Without it the table reads as every Session on the machine,
       // which is what led agents to act on Sessions from unrelated Profiles.
-      await renderOutput(output, { fmt, fmtExplicit: outputFormatIsExplicit(command), columns: ['id', 'profileId', 'kind', 'runtimeState', 'handoff'] });
+      await renderOutput(output, {
+        fmt,
+        fmtExplicit: outputFormatIsExplicit(command),
+        columns: ['rowKind', 'id', 'profileId', 'kind', 'runtimeState', 'window', 'page', 'tabCount', 'ownership', 'title', 'url', 'handoff'],
+      });
     });
 
   const sessionCloseCmd = addOutputFormatOption(sessionCmd
@@ -1280,10 +1294,14 @@ cli({
 
   browser.addCommand(withBrowserVerbose(new Command('close')
     .description('Close or detach this browser session')
-    .action(rawBrowserAction((session, routing) => sendCommand('close-window', {
+    .addOption(new Option('--page <id>', 'Stable page id to close exactly').argParser(browserOptionValueParser('close', 'page')!))
+    .option('--force', 'Allow destructive closure of a human-adopted tab')
+    .action(rawBrowserAction((session, routing, opts) => sendCommand('close-window', {
       session,
       surface: 'browser',
       ...routing,
+      ...(typeof opts.page === 'string' && opts.page.trim() ? { page: opts.page.trim() } : {}),
+      ...(opts.force === true ? { force: true } : {}),
     })))));
   // ── Built-in: doctor / completion ──────────────────────────────────────────
 
@@ -1916,7 +1934,7 @@ cli({
 
   const profileListCmd = addOutputFormatOption(profileCmd
     .command('list')
-    .description('List Chrome and Chromium profiles available through the Cloak runtime'));
+    .description(`List profiles available through the ${selectedProfileProviderLabel()} runtime`));
   profileListCmd.action(async (opts: { format?: string }, command: Command) => {
       const fmt = resolveCommandOutputFormat(command, opts.format);
       if (fmt === null) return;
@@ -1961,13 +1979,13 @@ cli({
         return;
       }
       if (profiles.length === 0) {
-        console.log('No Cloak runtime profiles are active.');
+        console.log(`No ${selectedProfileProviderLabel()} runtime profiles are active.`);
         console.log('Run a browser-backed command or webcmd <site> login to create one.');
         return;
       }
 
       const knownContextIds = new Set(profiles.map((profile) => profile.contextId));
-      console.log('Available Cloak profiles');
+      console.log(`Available ${selectedProfileProviderLabel()} profiles`);
       console.log();
       for (const profile of profiles) {
         const alias = aliasForContextId(config, profile.contextId);
@@ -1995,10 +2013,29 @@ cli({
 
   profileCmd
     .command('create')
-    .description('Create a Cloak profile alias')
+    .description(`Create a ${selectedProfileProviderLabel()} profile alias`)
     .argument('<alias>', 'Local alias, e.g. work or personal')
     .action(async (alias: string, _opts: unknown, command: Command) => {
-      const result = createProfile(alias);
+      const provider = selectedProfileProvider();
+      if (provider === 'slab') {
+        let pending = await prepareSlabProfileEnsure(alias);
+        let ensured: { profile: { id: string; displayName: string }; created: boolean };
+        try {
+          ensured = await sendCommand('profile-ensure', pending) as typeof ensured;
+        } catch (error) {
+          if (!(error instanceof BrowserCommandError) || error.code !== 'PROFILE_REPAIR_REQUIRED') throw error;
+          pending = await rotateSlabProfileEnsure(pending.alias, pending.idempotencyKey);
+          ensured = await sendCommand('profile-ensure', pending) as typeof ensured;
+        }
+        await commitSlabProfileEnsure(pending.alias, pending.idempotencyKey, ensured.profile.id);
+        await emitActionResult(command, { ok: true, action: 'create', alias: pending.alias, contextId: ensured.profile.id, created: ensured.created }, () => {
+          console.log(ensured.created
+            ? `Profile ${pending.alias} created (contextId: ${ensured.profile.id}).`
+            : `Profile ${pending.alias} already exists (contextId: ${ensured.profile.id}).`);
+        });
+        return;
+      }
+      const result = await createProviderProfile(provider, alias);
       await emitActionResult(command, {
         ok: true,
         action: 'create',
@@ -2014,12 +2051,12 @@ cli({
 
   profileCmd
     .command('rename')
-    .description('Assign a local alias to an available Cloak profile')
+    .description(`Assign a local alias to an available ${selectedProfileProviderLabel()} profile`)
     .argument('<contextId>', 'Profile contextId from webcmd profile list')
     .argument('<alias>', 'Local alias, e.g. work or personal')
     .action(async (contextId: string, alias: string, _opts: unknown, command: Command) => {
       try {
-        renameProfile(contextId, alias);
+        await renameProviderProfile(selectedProfileProvider(), contextId, alias);
         await emitActionResult(command, { ok: true, action: 'rename', contextId, alias }, () => {
           console.log(`Profile ${contextId} is now aliased as ${alias}.`);
         });
@@ -2031,7 +2068,7 @@ cli({
 
   profileCmd
     .command('use')
-    .description('Set the default Cloak profile for future commands')
+    .description(`Set the default ${selectedProfileProviderLabel()} profile for future commands`)
     .argument('<profile>', 'Profile alias or contextId from webcmd profile list')
     .action(async (profile: string, _opts: unknown, command: Command) => {
       const status = await fetchDaemonStatus();
@@ -2039,14 +2076,14 @@ cli({
       const connected = status && !isDaemonStale(status, PKG_VERSION) && Array.isArray(status.profiles)
         ? status.profiles
         : [];
-      const next = setDefaultProfile(profile, profileListRows(config, connected));
+      const defaultContextId = await setProviderDefaultProfile(selectedProfileProvider(), profile, profileListRows(config, connected));
       await emitActionResult(command, {
         ok: true,
         action: 'use',
         profile,
-        defaultContextId: next.defaultContextId ?? profile,
+        defaultContextId,
       }, () => {
-        console.log(`Default Cloak profile: ${next.defaultContextId ?? profile}`);
+        console.log(`Default ${selectedProfileProviderLabel()} profile: ${defaultContextId}`);
       });
     });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -816,7 +816,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string, pluginsDi
 
   const sessionCloseCmd = addOutputFormatOption(sessionCmd
     .command('close')
-    .description('Close a browser Session runtime without deleting its durable record')
+    .description('Close a browser Session runtime and discard its durable record')
     .argument('[session-id]', 'Existing readable Session ID from `webcmd session create <name>` (or pass the root `--session <id>` selector)')
     .option('--force', 'Close even while the Session is busy or paused for handoff'), 'yaml');
   sessionCloseCmd.action(async (positionalSessionId: string | undefined, opts: { format?: string; force?: boolean }, command) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -839,6 +839,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string, pluginsDi
             contextId: profileId,
             session: sessionId,
             force: opts.force === true,
+            discard: true,
           });
           await renderOutput(data, { fmt, fmtExplicit: outputFormatIsExplicit(command) });
           return;
@@ -847,7 +848,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string, pluginsDi
         }
       }
       if (opts.force === true) {
-        const data = await sendCommand('session-close', { contextId: profileId, session: sessionId, force: true });
+        const data = await sendCommand('session-close', { contextId: profileId, session: sessionId, force: true, discard: true });
         await renderOutput(data, { fmt, fmtExplicit: outputFormatIsExplicit(command) });
         return;
       }

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -5,7 +5,7 @@ import { DAEMON_HEADER_NAME } from '../constants.js';
 import type { BrowserRuntimeCommand, BrowserRuntimeResult, BrowserRuntimeStatus } from '../browser/protocol.js';
 import type { BrowserSessionListRow, BrowserSessionRecord } from '../browser/sessions.js';
 import type { BrowserRuntimeProvider } from '../browser/runtime/provider.js';
-import { createDaemonServer } from './server.js';
+import { createDaemonServer, ensureProfileCoalesced } from './server.js';
 
 class FakeProvider implements BrowserRuntimeProvider {
   commands: BrowserRuntimeCommand[] = [];
@@ -117,6 +117,43 @@ class FakeProvider implements BrowserRuntimeProvider {
       }));
   }
 }
+
+describe('profile ensure coalescing', () => {
+  const result = (alias: string) => ({ profile: { id: alias, displayName: alias }, created: true });
+
+  it('coalesces only the same provider, alias, and idempotency key', async () => {
+    let resolve!: (value: ReturnType<typeof result>) => void;
+    const operation = new Promise<ReturnType<typeof result>>(done => { resolve = done; });
+    const ensureProfile = vi.fn(() => operation);
+    const provider = { ensureProfile } as unknown as BrowserRuntimeProvider;
+    const first = ensureProfileCoalesced(provider, 'work', 'key-1');
+    const second = ensureProfileCoalesced(provider, 'work', 'key-1');
+    expect(ensureProfile).toHaveBeenCalledOnce();
+    await expect(ensureProfileCoalesced(provider, 'work', 'key-2')).rejects.toMatchObject({ code: 'PROFILE_ENSURE_CONFLICT' });
+    resolve(result('work'));
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+  });
+
+  it('does not coalesce different aliases or provider instances and retries after failure', async () => {
+    let brokenAttempts = 0;
+    const firstEnsure = vi.fn(async ({ alias }: { alias: string }) => {
+      if (alias === 'broken' && ++brokenAttempts === 1) throw new Error('boom');
+      return result(alias);
+    });
+    const secondEnsure = vi.fn(async ({ alias }: { alias: string }) => result(alias));
+    const first = { ensureProfile: firstEnsure } as unknown as BrowserRuntimeProvider;
+    const second = { ensureProfile: secondEnsure } as unknown as BrowserRuntimeProvider;
+    await Promise.all([
+      ensureProfileCoalesced(first, 'work', 'key-work'),
+      ensureProfileCoalesced(first, 'personal', 'key-personal'),
+      ensureProfileCoalesced(second, 'work', 'key-work'),
+    ]);
+    await expect(ensureProfileCoalesced(first, 'broken', 'key-broken')).rejects.toThrow('boom');
+    await expect(ensureProfileCoalesced(first, 'broken', 'key-broken')).resolves.toMatchObject({ profile: { id: 'broken' } });
+    expect(firstEnsure).toHaveBeenCalledTimes(4);
+    expect(secondEnsure).toHaveBeenCalledOnce();
+  });
+});
 
 describe('createDaemonServer', () => {
   const servers: Array<{ close: () => Promise<void> }> = [];

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -92,7 +92,41 @@ function waitForCommandResult(
 const UNRESOLVED_SESSION_LIFECYCLE_ACTIONS = new Set<BrowserRuntimeCommand['action']>([
   'session-create',
   'session-list',
+  'profile-ensure',
 ]);
+
+type ProfileEnsureResult = { profile: { id: string; displayName: string }; created: boolean };
+const profileEnsures = new WeakMap<BrowserRuntimeProvider, Map<string, {
+  idempotencyKey: string;
+  operation: Promise<ProfileEnsureResult>;
+}>>();
+
+/** @internal Exported for deterministic concurrency contract tests. */
+export async function ensureProfileCoalesced(provider: BrowserRuntimeProvider, alias: string, idempotencyKey: string) {
+  const key = alias.trim();
+  let providerEnsures = profileEnsures.get(provider);
+  if (!providerEnsures) {
+    providerEnsures = new Map();
+    profileEnsures.set(provider, providerEnsures);
+  }
+  const existing = providerEnsures.get(key);
+  if (existing) {
+    if (existing.idempotencyKey !== idempotencyKey) {
+      throw new CliError(
+        'PROFILE_ENSURE_CONFLICT',
+        `Profile ensure for alias "${key}" is already in progress with a different idempotency key.`,
+      );
+    }
+    return existing.operation;
+  }
+  const operation = provider.ensureProfile!({ alias: key, idempotencyKey });
+  providerEnsures.set(key, { idempotencyKey, operation });
+  try {
+    return await operation;
+  } finally {
+    if (providerEnsures.get(key)?.operation === operation) providerEnsures.delete(key);
+  }
+}
 
 function commandProfileId(provider: BrowserRuntimeProvider, command: BrowserRuntimeCommand): string | undefined {
   return provider.resolveProfileId?.(command)
@@ -180,6 +214,17 @@ async function handleSessionLifecycle(
   command: BrowserRuntimeCommand,
 ): Promise<BrowserRuntimeResult | null> {
   switch (command.action) {
+    case 'profile-ensure': {
+      if (!command.alias?.trim() || !command.idempotencyKey?.trim()) {
+        return { id: command.id, ok: false, errorCode: 'invalid_request', error: 'Profile ensure requires alias and idempotencyKey.' };
+      }
+      const ensured = provider.ensureProfile
+        ? await ensureProfileCoalesced(provider, command.alias.trim(), command.idempotencyKey.trim())
+        : undefined;
+      return ensured ? { id: command.id, ok: true, data: ensured } : {
+        id: command.id, ok: false, errorCode: 'PROFILE_ENSURE_UNSUPPORTED', error: 'Selected browser runtime does not support eager Profile creation.',
+      };
+    }
     case 'session-create': {
       const session = await provider.createSession?.(command);
       return session ? { id: command.id, ok: true, data: session } : null;

--- a/src/fetch/safe-proxy.test.ts
+++ b/src/fetch/safe-proxy.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fetch as undiciFetch, ProxyAgent } from 'undici';
 import { describe, expect, it } from 'vitest';
 import { createSafeProxy, isSafeAddress } from './safe-proxy.js';
 
@@ -186,7 +187,7 @@ describe('createSafeProxy policy errors', () => {
         callback(null, [{ address, family: 6 }]);
       }) as never,
     });
-    await expect(fetch('http://example.test/', { dispatcher: new (await import('undici')).ProxyAgent(proxy.url) } as never))
+    await expect(undiciFetch('http://example.test/', { dispatcher: new ProxyAgent(proxy.url) } as never))
       .rejects.toThrow('fetch failed');
     expect(proxy.policyError()?.message).toBe('Unsafe fetch destination: example.test');
     await proxy.close();

--- a/src/site-memory/__fixtures__/git-test-support.ts
+++ b/src/site-memory/__fixtures__/git-test-support.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared support for the site memory tests that drive real `git`.
+ *
+ * These tests run git subprocesses against a throwaway home directory. Two
+ * things about that are hostile to Windows, and both surfaced as intermittent
+ * CI failures rather than as anything the tests actually assert.
+ */
+import { rm } from 'node:fs/promises';
+
+/**
+ * Per-test budget for a file that drives real git.
+ *
+ * A single test here spawns a handful of git processes and commits through
+ * them. That costs a second or two on an idle machine and several times more
+ * under a parallel suite on Windows, where process creation is expensive — well
+ * past vitest's 5s default, which then fails the test on the clock rather than
+ * on its assertions. The slowest tests in these files already opted into this
+ * same budget individually; applying it per file makes the whole class honest.
+ *
+ * This does not hide a hang: a test that never finishes still fails, at 20s.
+ */
+export const GIT_TEST_TIMEOUT_MS = 20_000;
+
+/**
+ * Drain a list of throwaway directories a test created, removing each one.
+ *
+ * On Windows a git child's handles on `.git` outlive its exit by a few
+ * milliseconds, and a test that vitest aborts on timeout leaves one running
+ * outright, so a plain recursive remove intermittently fails the suite during
+ * cleanup with:
+ *
+ *     EBUSY: resource busy or locked, rmdir '…\.webcmd\sites'
+ *
+ * `rm` retries exactly that family of errors when asked to; it just does not by
+ * default (`maxRetries` is 0). Retrying here keeps a slow or aborted test from
+ * turning into a second, unrelated-looking failure.
+ */
+export async function removeTempDirs(dirs: string[]): Promise<void> {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, {
+    recursive: true,
+    force: true,
+    maxRetries: 10,
+    retryDelay: 50,
+  })));
+}

--- a/src/site-memory/candidates.test.ts
+++ b/src/site-memory/candidates.test.ts
@@ -1,23 +1,26 @@
 import { execFile } from 'node:child_process';
 import { chmodSync } from 'node:fs';
-import { chmod, mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { addCandidate, listCandidates, searchCandidates, showCandidate } from './candidates.js';
 import { classifyProduct } from './classify.js';
 import { installGitShim, restoreGitShim } from './git-shim.js';
 import { openSitesRepository } from './git-store.js';
 import { listSiteMemory, readProductFile, showSiteMemory, writeProductFile } from './local-store.js';
 import type { Candidate } from './model.js';
+import { GIT_TEST_TIMEOUT_MS, removeTempDirs } from './__fixtures__/git-test-support.js';
+
+vi.setConfig({ testTimeout: GIT_TEST_TIMEOUT_MS });
 
 const run = promisify(execFile);
 const tempHomes: string[] = [];
 
 afterEach(async () => {
   restoreGitShim();
-  await Promise.all(tempHomes.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  await removeTempDirs(tempHomes);
 });
 
 describe('candidate capture', () => {

--- a/src/site-memory/checkpoint.test.ts
+++ b/src/site-memory/checkpoint.test.ts
@@ -879,7 +879,7 @@ describe('checkpoint git transaction', () => {
     expect((await git(sites, ['show', `HEAD:example.test/candidates/${second.id}.json`]))).toMatch(/"status": "ingested"/);
     expect((await git(sites, ['status', '--porcelain', '-uall', '--', 'example.test/candidates'])).trim()).toBe('');
     expect(JSON.parse(await git(sites, ['show', `HEAD:example.test/candidates/${later.id}.json`])).status).toBe('pending');
-  });
+  }, 20_000);
 
   it('recovers interrupted ingested provenance after an unrelated later product commit', async () => {
     const { homeDir, sites } = await primed();
@@ -938,7 +938,7 @@ describe('checkpoint git transaction', () => {
     expect((await git(sites, ['show', `HEAD:example.test/candidates/${second.id}.json`]))).toMatch(/"status": "ingested"/);
     expect((await git(sites, ['status', '--porcelain', '-uall', '--', 'example.test/candidates'])).trim()).toBe('');
     expect(JSON.parse(await git(sites, ['show', `HEAD:example.test/candidates/${first.id}.json`])).memory_commit).toBe(memoryRevision);
-  });
+  }, 20_000);
 
   it('recovers a rejected-only interrupted provenance batch on a later product write', async () => {
     const { homeDir, sites } = await primed();
@@ -963,7 +963,7 @@ describe('checkpoint git transaction', () => {
     expect((await git(sites, ['show', `HEAD:example.test/candidates/${second.id}.json`]))).toMatch(/"status": "rejected"/);
     expect((await git(sites, ['status', '--porcelain', '-uall', '--', 'example.test/candidates'])).trim()).toBe('');
     expect(JSON.parse(await git(sites, ['show', `HEAD:example.test/candidates/${later.id}.json`])).status).toBe('pending');
-  });
+  }, 20_000);
 
   it('does not auto-commit a pending candidate whose payload was edited into a terminal record', async () => {
     const { homeDir, sites } = await primed();

--- a/src/site-memory/checkpoint.test.ts
+++ b/src/site-memory/checkpoint.test.ts
@@ -12,6 +12,9 @@ import { getMemoryContext, parseProductManifest } from './context.js';
 import { installGitShim, restoreGitShim } from './git-shim.js';
 import { openSitesRepository } from './git-store.js';
 import { readProductFile, writeProductFile } from './local-store.js';
+import { GIT_TEST_TIMEOUT_MS, removeTempDirs } from './__fixtures__/git-test-support.js';
+
+vi.setConfig({ testTimeout: GIT_TEST_TIMEOUT_MS });
 
 const run = promisify(execFile);
 const tempHomes: string[] = [];
@@ -26,7 +29,7 @@ if (process.platform === 'win32') {
 
 afterEach(async () => {
   restoreGitShim();
-  await Promise.all(tempHomes.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  await removeTempDirs(tempHomes);
 });
 
 describe('checkpoint compare-and-swap', () => {

--- a/src/site-memory/checkpoint.test.ts
+++ b/src/site-memory/checkpoint.test.ts
@@ -4,7 +4,7 @@ import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { addCandidate, showCandidate } from './candidates.js';
 import { checkpointMemory, type CheckpointInput } from './checkpoint.js';
 import { classifyProduct } from './classify.js';
@@ -19,6 +19,10 @@ const FACT = '- [verified 2026-08-31] Prefer /new for fresh posts.\n';
 const SITE = `# Example\n\n${FACT}`;
 const POINTER = '- More: [references/listing.md](references/listing.md).\n';
 const REF = `# Listing\n\n${FACT}`;
+
+if (process.platform === 'win32') {
+  vi.setConfig({ testTimeout: 30_000 });
+}
 
 afterEach(async () => {
   restoreGitShim();

--- a/src/site-memory/classify.test.ts
+++ b/src/site-memory/classify.test.ts
@@ -1,10 +1,10 @@
 import { execFile } from 'node:child_process';
 import { chmodSync } from 'node:fs';
-import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { classifyProduct } from './classify.js';
 import { getMemoryContext, parseProductManifest } from './context.js';
 import { installGitShim, restoreGitShim } from './git-shim.js';
@@ -12,13 +12,16 @@ import { openSitesRepository } from './git-store.js';
 import { readProductFile, writeProductFile } from './local-store.js';
 import type { SeedLookupResult } from './model.js';
 import { canonicalProductKey } from './product-resolver.js';
+import { GIT_TEST_TIMEOUT_MS, removeTempDirs } from './__fixtures__/git-test-support.js';
+
+vi.setConfig({ testTimeout: GIT_TEST_TIMEOUT_MS });
 
 const run = promisify(execFile);
 const tempHomes: string[] = [];
 
 afterEach(async () => {
   restoreGitShim();
-  await Promise.all(tempHomes.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  await removeTempDirs(tempHomes);
 });
 
 describe('product classification', () => {

--- a/src/site-memory/context.test.ts
+++ b/src/site-memory/context.test.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
 import { chmodSync } from 'node:fs';
-import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, chmod, mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
@@ -11,13 +11,16 @@ import { openSitesRepository } from './git-store.js';
 import { readProductFile, writeProductFile } from './local-store.js';
 import type { GlobalSeedProvider } from './seed-client.js';
 import type { SeedLookupResult } from './model.js';
+import { GIT_TEST_TIMEOUT_MS, removeTempDirs } from './__fixtures__/git-test-support.js';
+
+vi.setConfig({ testTimeout: GIT_TEST_TIMEOUT_MS });
 
 const run = promisify(execFile);
 const tempHomes: string[] = [];
 
 afterEach(async () => {
   restoreGitShim();
-  await Promise.all(tempHomes.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  await removeTempDirs(tempHomes);
 });
 
 describe('parseProductManifest', () => {

--- a/src/site-memory/git-shim.test.ts
+++ b/src/site-memory/git-shim.test.ts
@@ -1,16 +1,19 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { installGitShim, restoreGitShim } from './git-shim.js';
 import { openSitesRepository } from './git-store.js';
 import { writeProductFile } from './local-store.js';
+import { GIT_TEST_TIMEOUT_MS, removeTempDirs } from './__fixtures__/git-test-support.js';
+
+vi.setConfig({ testTimeout: GIT_TEST_TIMEOUT_MS });
 
 const tempHomes: string[] = [];
 
 afterEach(async () => {
   restoreGitShim();
-  await Promise.all(tempHomes.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  await removeTempDirs(tempHomes);
 });
 
 describe('installGitShim', () => {

--- a/src/site-memory/git-store.test.ts
+++ b/src/site-memory/git-store.test.ts
@@ -1,9 +1,9 @@
 import { execFile, spawnSync } from 'node:child_process';
-import { mkdir, mkdtemp, readFile, realpath, rm, utimes, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, realpath, utimes, writeFile } from 'node:fs/promises';
 import { hostname, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   LOCK_STALE_MS,
   LOCK_TIMEOUT_MS,
@@ -14,13 +14,16 @@ import {
 import { installGitShim, restoreGitShim } from './git-shim.js';
 import { openSitesRepository } from './git-store.js';
 import { listProductKeys, readProductFile, writeProductFile } from './local-store.js';
+import { GIT_TEST_TIMEOUT_MS, removeTempDirs } from './__fixtures__/git-test-support.js';
+
+vi.setConfig({ testTimeout: GIT_TEST_TIMEOUT_MS });
 
 const run = promisify(execFile);
 const tempHomes: string[] = [];
 
 afterEach(async () => {
   restoreGitShim();
-  await Promise.all(tempHomes.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  await removeTempDirs(tempHomes);
 });
 
 describe('sites git repository', () => {

--- a/src/site-memory/local-store.test.ts
+++ b/src/site-memory/local-store.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   addFieldMapping,
   addResponseSample,
@@ -23,6 +23,9 @@ import {
   showSiteMemory,
   writeProductFile,
 } from './local-store.js';
+import { GIT_TEST_TIMEOUT_MS, removeTempDirs } from './__fixtures__/git-test-support.js';
+
+vi.setConfig({ testTimeout: GIT_TEST_TIMEOUT_MS });
 
 const tempHomes: string[] = [];
 const base = { site: 'example.test' };
@@ -34,7 +37,7 @@ afterEach(async () => {
   else process.env.HOME = originalHome;
   if (originalUserProfile === undefined) delete process.env.USERPROFILE;
   else process.env.USERPROFILE = originalUserProfile;
-  await Promise.all(tempHomes.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  await removeTempDirs(tempHomes);
   await rm(join(process.cwd(), '.webcmd/sites/no-home.test'), { recursive: true, force: true });
 });
 

--- a/src/site-memory/self-learning.integration.test.ts
+++ b/src/site-memory/self-learning.integration.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
@@ -13,6 +13,9 @@ import { openSitesRepository } from './git-store.js';
 import { listSiteMemory, readProductFile, showSiteMemory, writeProductFile } from './local-store.js';
 import type { CandidateDisposition, SeedLookupResult } from './model.js';
 import { createHttpSeedProvider } from './seed-client.js';
+import { GIT_TEST_TIMEOUT_MS, removeTempDirs } from './__fixtures__/git-test-support.js';
+
+vi.setConfig({ testTimeout: GIT_TEST_TIMEOUT_MS });
 
 const run = promisify(execFile);
 const tempHomes: string[] = [];
@@ -30,7 +33,7 @@ const CLOCK = {
 
 afterEach(async () => {
   restoreGitShim();
-  await Promise.all(tempHomes.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  await removeTempDirs(tempHomes);
 });
 
 describe('self-learning lifecycle', () => {

--- a/src/slab/bridge-client.test.ts
+++ b/src/slab/bridge-client.test.ts
@@ -72,6 +72,10 @@ function helloOk(id: string, browserVersion = '152.0.7977.65'): string {
   })}\n`;
 }
 
+function helloV2Ok(id: string): string {
+  return `${JSON.stringify({ id, ok: true, result: { protocolVersion: 2, browserVersion: '152.0.7977.65', browserPid: 1234, profiles: [] } })}\n`;
+}
+
 function attachOk(id: string, credential = CREDENTIAL): string {
   return `${JSON.stringify({
     id,
@@ -112,6 +116,60 @@ function sizedHello(id: string, targetBytes: number): string {
 }
 
 describe.skipIf(process.platform === 'win32')('SlabBridgeClient', () => {
+  it('negotiates revision 2 before creating a Profile', async () => {
+    const harness = await listen((socket) => {
+      collectRequests(socket, harness.requests, (req) => {
+        socket.write(req.method === 'hello' ? helloV2Ok(req.id) : `${JSON.stringify({ id: req.id, ok: true, result: { profile: { id: 'Profile 1', displayName: 'Work' }, created: true } })}\n`);
+      });
+    });
+    const client = await SlabBridgeClient.connect(harness.endpoint);
+    await client.hello();
+    await expect(client.createProfile('Work', 'stable-key')).resolves.toMatchObject({ created: true, profile: { id: 'Profile 1' } });
+    expect(harness.requests.map(request => (request as { method: string }).method)).toEqual(['hello', 'createProfile']);
+    await client.close();
+  });
+
+  it('sends the exact negotiated v2 range object for attach and release', async () => {
+    const harness = await listen((socket) => collectRequests(socket, harness.requests, (req) => {
+      socket.write(req.method === 'hello' ? helloV2Ok(req.id) : req.method === 'attach' ? attachOk(req.id) : releaseOk(req.id));
+    }));
+    const client = await SlabBridgeClient.connect(harness.endpoint);
+    await client.hello();
+    const attachment = await client.attach('default');
+    await client.release(attachment.connectionId);
+    const [, attach, release] = harness.requests as Array<{ params: { protocolVersion: unknown } }>;
+    expect(attach.params.protocolVersion).toEqual({ min: 2, max: 2 });
+    expect(release.params.protocolVersion).toEqual({ min: 2, max: 2 });
+    await client.close();
+  });
+
+  it('does not probe revision 1 with createProfile', async () => {
+    const harness = await listen((socket) => collectRequests(socket, harness.requests, req => socket.write(helloOk(req.id))));
+    const client = await SlabBridgeClient.connect(harness.endpoint);
+    await client.hello();
+    await expect(client.createProfile('Work', 'stable-key')).rejects.toMatchObject({ code: 'SLAB_UPGRADE_REQUIRED' });
+    expect(harness.requests.map(request => (request as { method: string }).method)).toEqual(['hello']);
+    await client.close();
+  });
+  it('requires hello before lease operations and validates native v2 limits before writing', async () => {
+    const harness = await listen((socket) => collectRequests(socket, harness.requests, req => socket.write(
+      req.method === 'hello'
+        ? helloV2Ok(req.id)
+        : `${JSON.stringify({ id: req.id, ok: true, result: { profile: { id: 'Profile 1', displayName: 'valid' }, created: true } })}\n`,
+    )));
+    const client = await SlabBridgeClient.connect(harness.endpoint);
+    await expect(client.attach('default')).rejects.toThrow(/hello.*required/i);
+    await expect(client.release('connection')).rejects.toThrow(/hello.*required/i);
+    await client.hello();
+    await expect(client.createProfile('x'.repeat(129), 'key')).rejects.toMatchObject({ code: 'INVALID_REQUEST' });
+    await expect(client.createProfile('🙂'.repeat(128), 'valid-key')).resolves.toMatchObject({ created: true });
+    await expect(client.createProfile('🙂'.repeat(129), 'key')).rejects.toMatchObject({ code: 'INVALID_REQUEST' });
+    await expect(client.createProfile('\ud800', 'key')).rejects.toMatchObject({ code: 'INVALID_REQUEST' });
+    await expect(client.createProfile('work', 'x'.repeat(257))).rejects.toMatchObject({ code: 'INVALID_REQUEST' });
+    await expect(client.createProfile('work', 'bad key')).rejects.toMatchObject({ code: 'INVALID_REQUEST' });
+    expect(harness.requests).toHaveLength(2);
+    await client.close();
+  });
   it('reassembles fragmented JSONL responses', async () => {
     const harness = await listen((socket) => {
       collectRequests(socket, harness.requests, (req) => {
@@ -328,10 +386,13 @@ describe.skipIf(process.platform === 'win32')('SlabBridgeClient', () => {
     for (const code of codes) {
       const harness = await listen((socket) => {
         collectRequests(socket, harness.requests, (req) => {
-          socket.write(errorLine(req.id, code, `secret ${CREDENTIAL} raw={"ok":false}`));
+          socket.write(req.method === 'hello'
+            ? helloOk(req.id)
+            : errorLine(req.id, code, `secret ${CREDENTIAL} raw={"ok":false}`));
         });
       });
       const client = await SlabBridgeClient.connect(harness.endpoint);
+      await client.hello();
       const error = await client.attach('default').then(
         () => {
           throw new Error(`expected ${code}`);
@@ -356,6 +417,7 @@ describe.skipIf(process.platform === 'win32')('SlabBridgeClient', () => {
       });
     });
     const client = await SlabBridgeClient.connect(harness.endpoint);
+    await client.hello();
     const lease = await client.attach('default');
     expect(lease.transport.kind).toBe('cdp-ipc');
     expect(lease.transport.credential).toBeInstanceOf(SlabCredential);

--- a/src/slab/bridge-client.ts
+++ b/src/slab/bridge-client.ts
@@ -131,9 +131,7 @@ export class SlabBridgeClient {
     if (this.negotiatedVersion === undefined) return Promise.reject(new Error('SLAB control hello is required before attach.'));
     const profileId = typeof profile === 'string' ? profile : profile.id;
     return this.request('attach', {
-      protocolVersion: this.negotiatedVersion === undefined
-        ? { min: SLAB_PROTOCOL_MIN_VERSION, max: SLAB_PROTOCOL_VERSION }
-        : { min: this.negotiatedVersion, max: this.negotiatedVersion },
+      protocolVersion: negotiatedProtocolVersionParam(this.negotiatedVersion),
       profileId,
     }) as Promise<SlabAttachResult>;
   }
@@ -141,9 +139,7 @@ export class SlabBridgeClient {
   release(connectionId: string): Promise<null> {
     if (this.negotiatedVersion === undefined) return Promise.reject(new Error('SLAB control hello is required before release.'));
     return this.request('release', {
-      protocolVersion: this.negotiatedVersion === undefined
-        ? { min: SLAB_PROTOCOL_MIN_VERSION, max: SLAB_PROTOCOL_VERSION }
-        : { min: this.negotiatedVersion, max: this.negotiatedVersion },
+      protocolVersion: negotiatedProtocolVersionParam(this.negotiatedVersion),
       connectionId,
     }) as Promise<null>;
   }
@@ -248,4 +244,8 @@ export class SlabBridgeClient {
     }
     this.socket.destroy();
   }
+}
+
+function negotiatedProtocolVersionParam(revision: number): number | { min: number; max: number } {
+  return revision === 1 ? 1 : { min: revision, max: revision };
 }

--- a/src/slab/bridge-client.ts
+++ b/src/slab/bridge-client.ts
@@ -3,6 +3,7 @@ import { StringDecoder } from 'node:string_decoder';
 import { PKG_VERSION } from '../version.js';
 import {
   parseAttachResult,
+  parseCreateProfileResult,
   parseControlResponse,
   parseHelloResult,
   parseReleaseResult,
@@ -10,9 +11,11 @@ import {
   SLAB_ERROR_MESSAGES,
   SLAB_MAX_CONTROL_LINE_BYTES,
   SLAB_PROTOCOL_VERSION,
+  SLAB_PROTOCOL_MIN_VERSION,
   type SlabAttachResult,
   type SlabErrorCode,
   type SlabHelloResult,
+  type SlabCreateProfileResult,
 } from './protocol.js';
 
 export interface SlabBridgeClientOptions {
@@ -37,8 +40,27 @@ interface PendingRequest {
   timer?: ReturnType<typeof setTimeout>;
 }
 
+function isValidDisplayName(value: string): boolean {
+  if (!value) return false;
+  let count = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const unit = value.charCodeAt(index);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return false;
+      index += 1;
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      return false;
+    }
+    count += 1;
+    if (count > 128) return false;
+  }
+  return true;
+}
+
 function parseResultForMethod(method: string, result: unknown): unknown {
   if (method === 'hello') return parseHelloResult(result);
+  if (method === 'createProfile') return parseCreateProfileResult(result);
   if (method === 'attach') return parseAttachResult(result);
   if (method === 'release') return parseReleaseResult(result);
   throw new Error('SLAB control response has unknown fields');
@@ -53,6 +75,7 @@ export class SlabBridgeClient {
   private pendingBytes = Buffer.alloc(0);
   private nextId = 0;
   private closed = false;
+  private negotiatedVersion?: number;
 
   private constructor(socket: Socket, options: SlabBridgeClientOptions = {}) {
     this.socket = socket;
@@ -77,23 +100,50 @@ export class SlabBridgeClient {
   }
 
   hello(): Promise<SlabHelloResult> {
-    return this.request('hello', {
-      protocolVersion: { min: SLAB_PROTOCOL_VERSION, max: SLAB_PROTOCOL_VERSION },
+    return (this.request('hello', {
+      protocolVersion: { min: SLAB_PROTOCOL_MIN_VERSION, max: SLAB_PROTOCOL_VERSION },
       clientVersion: this.clientVersion,
-    }) as Promise<SlabHelloResult>;
+    }) as Promise<SlabHelloResult>).then(result => {
+      this.negotiatedVersion = result.protocolVersion;
+      return result;
+    });
+  }
+
+  createProfile(displayName: string, idempotencyKey: string): Promise<SlabCreateProfileResult> {
+    if ((this.negotiatedVersion ?? 0) < 2) {
+      return Promise.reject(Object.assign(
+        new Error('Installed SLAB does not support native Profile creation; update SLAB and retry.'),
+        { code: 'SLAB_UPGRADE_REQUIRED' },
+      ));
+    }
+    if (!isValidDisplayName(displayName)
+      || !/^[A-Za-z0-9:._-]{1,256}$/.test(idempotencyKey)) {
+      return Promise.reject(new SlabProtocolError('INVALID_REQUEST'));
+    }
+    return this.request('createProfile', {
+      protocolVersion: { min: 2, max: 2 },
+      displayName,
+      idempotencyKey,
+    }) as Promise<SlabCreateProfileResult>;
   }
 
   attach(profile: string | { id: string }): Promise<SlabAttachResult> {
+    if (this.negotiatedVersion === undefined) return Promise.reject(new Error('SLAB control hello is required before attach.'));
     const profileId = typeof profile === 'string' ? profile : profile.id;
     return this.request('attach', {
-      protocolVersion: { min: SLAB_PROTOCOL_VERSION, max: SLAB_PROTOCOL_VERSION },
+      protocolVersion: this.negotiatedVersion === undefined
+        ? { min: SLAB_PROTOCOL_MIN_VERSION, max: SLAB_PROTOCOL_VERSION }
+        : { min: this.negotiatedVersion, max: this.negotiatedVersion },
       profileId,
     }) as Promise<SlabAttachResult>;
   }
 
   release(connectionId: string): Promise<null> {
+    if (this.negotiatedVersion === undefined) return Promise.reject(new Error('SLAB control hello is required before release.'));
     return this.request('release', {
-      protocolVersion: { min: SLAB_PROTOCOL_VERSION, max: SLAB_PROTOCOL_VERSION },
+      protocolVersion: this.negotiatedVersion === undefined
+        ? { min: SLAB_PROTOCOL_MIN_VERSION, max: SLAB_PROTOCOL_VERSION }
+        : { min: this.negotiatedVersion, max: this.negotiatedVersion },
       connectionId,
     }) as Promise<null>;
   }

--- a/src/slab/contract-parity.test.ts
+++ b/src/slab/contract-parity.test.ts
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { SLAB_ERROR_CODES } from './protocol.js';
 
 const LOCAL_FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '../browser/runtime/local-slab/__fixtures__');
 const FIXTURE_FILES = [
@@ -11,6 +12,9 @@ const FIXTURE_FILES = [
   'attach.response.json',
   'release.response.json',
   'errors.json',
+  'errors-v2.json',
+  'hello-v2.response.json',
+  'create-profile-v2.response.json',
 ] as const;
 const CONNECTION_ID = '00000000-0000-4000-8000-000000000000';
 const PROFILE_ID = 'default';
@@ -30,10 +34,12 @@ function keysOf(value: unknown): string[] {
 }
 
 function findSiblingFixtures(): string | null {
+  const explicit = process.env.WEBCMD_SLAB_CONTRACT_DIR;
+  if (explicit) return explicit;
   let dir = dirname(fileURLToPath(import.meta.url));
   for (let i = 0; i < 8; i += 1) {
     const parent = dirname(dir);
-    const candidate = join(parent, 'slab-browser/.worktrees/slab-macos-first-alpha/protocol/fixtures');
+    const candidate = join(parent, 'SLAB/protocol/fixtures');
     if (existsSync(join(candidate, 'hello.response.json'))) return candidate;
     if (parent === dir) break;
     dir = parent;
@@ -52,6 +58,9 @@ describe('SLAB protocol fixture parity', () => {
     const attach = await loadLocal('attach.response.json');
     const release = await loadLocal('release.response.json');
     const errors = await loadLocal('errors.json');
+    const errorsV2 = await loadLocal('errors-v2.json');
+    const helloV2 = await loadLocal('hello-v2.response.json');
+    const create = await loadLocal('create-profile-v2.response.json');
 
     expect(keysOf(hello.parsed)).toEqual(['request', 'response']);
     const helloDoc = hello.parsed as {
@@ -73,7 +82,11 @@ describe('SLAB protocol fixture parity', () => {
     expect(helloDoc.response.ok).toBe(true);
     expect(keysOf(helloDoc.response.result)).toEqual(['browserPid', 'browserVersion', 'profiles', 'protocolVersion']);
     expect(helloDoc.response.result.protocolVersion).toBe(1);
-    expect(helloDoc.response.result.profiles).toEqual([{ id: PROFILE_ID, displayName: 'Default' }]);
+    expect(helloDoc.response.result.profiles).toEqual([{ id: PROFILE_ID, displayName: 'default' }]);
+
+    const helloV2Doc = helloV2.parsed as { request: { params: { protocolVersion: { min: number; max: number } } }; response: { result: { protocolVersion: number } } };
+    expect(helloV2Doc.request.params.protocolVersion).toEqual({ min: 1, max: 2 });
+    expect(helloV2Doc.response.result.protocolVersion).toBe(2);
 
     const attachDoc = attach.parsed as {
       request: { id: string; params: { profileId: string } };
@@ -116,19 +129,35 @@ describe('SLAB protocol fixture parity', () => {
       expect(errorDoc[code].response.error.code).toBe(code);
       expect(errorDoc[code].response.error.message).not.toContain(CREDENTIAL);
     }
+    const errorV2Doc = errorsV2.parsed as Record<string, { response: { error: { code: string; message: string } } }>;
+    expect(Object.keys(errorV2Doc)).toEqual([...SLAB_ERROR_CODES]);
+    for (const code of SLAB_ERROR_CODES) {
+      expect(errorV2Doc[code].response.error.code).toBe(code);
+      expect(errorV2Doc[code].response.error.message).not.toContain(CREDENTIAL);
+    }
+    const createDoc = create.parsed as { request: { method: string; params: { protocolVersion: { min: number; max: number } } }; response: { result: { created: boolean; profile: { id: string } } }; retried: { response: { result: { created: boolean; profile: { id: string } } } } };
+    expect(createDoc.request.method).toBe('createProfile');
+    expect(createDoc.request.params.protocolVersion).toEqual({ min: 2, max: 2 });
+    expect(createDoc.response.result.created).toBe(true);
+    expect(createDoc.retried.response.result).toEqual({ profile: createDoc.response.result.profile, created: false });
   });
 
-  it('matches sibling fixture bytes and parsed values when the worktree is present', async () => {
+  it.skipIf(process.env.WEBCMD_STRICT_SLAB_CONTRACT !== '1' && !process.env.WEBCMD_SLAB_CONTRACT_DIR)(
+    'matches sibling fixture bytes and parsed values (opt-in: SLAB sibling contract comparison)', async () => {
     const sibling = findSiblingFixtures();
+    expect(sibling, 'Strict SLAB contract comparison requested, but no current sibling fixtures were found; set WEBCMD_SLAB_CONTRACT_DIR.').not.toBeNull();
     for (const name of FIXTURE_FILES) {
       const local = await loadLocal(name);
       const localHash = createHash('sha256').update(local.bytes).digest('hex');
       expect(localHash).toMatch(/^[0-9a-f]{64}$/);
-      if (!sibling) continue;
-      const remoteBytes = await readFile(join(sibling, name));
+      const remoteBytes = await readFile(join(sibling!, name));
       expect(createHash('sha256').update(remoteBytes).digest('hex'), name).toBe(localHash);
       expect(JSON.parse(remoteBytes.toString('utf8')), name).toEqual(local.parsed);
     }
-    if (sibling) expect(existsSync(sibling)).toBe(true);
+    const v2Schema = JSON.parse(await readFile(join(dirname(sibling!), 'bridge-v2.schema.json'), 'utf8')) as {
+      $defs: { error: { properties: { code: { enum: string[] } } } };
+    };
+    expect(v2Schema.$defs.error.properties.code.enum).toEqual([...SLAB_ERROR_CODES]);
+    expect(existsSync(sibling!)).toBe(true);
   });
 });

--- a/src/slab/control-bridge.test.ts
+++ b/src/slab/control-bridge.test.ts
@@ -5,6 +5,7 @@ describe('SLAB control bridge', () => {
   it('probes or opens SLAB before creating the lease-owning control client', async () => {
     const calls: string[] = [];
     const client = {
+      hello: vi.fn(async () => ({ protocolVersion: 2 })),
       attach: vi.fn(async () => ({ connectionId: 'connection-1' })),
       release: vi.fn(async () => null),
       close: vi.fn(async () => { calls.push('close'); }),
@@ -21,12 +22,14 @@ describe('SLAB control bridge', () => {
     await bridge.release('connection-1');
 
     expect(calls).toEqual(['launch', 'connect', 'close']);
+    expect(client.hello).toHaveBeenCalledOnce();
     expect(client.attach).toHaveBeenCalledWith('default');
     expect(client.release).toHaveBeenCalledWith('connection-1');
   });
 
   it('can close the control client before a lease exists', async () => {
     const client = {
+      hello: vi.fn(async () => ({ protocolVersion: 1 })),
       attach: vi.fn(),
       release: vi.fn(),
       close: vi.fn(async () => null),
@@ -38,6 +41,27 @@ describe('SLAB control bridge', () => {
 
     await bridge.close();
 
+    expect(client.hello).toHaveBeenCalledOnce();
     expect(client.close).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    new Error('incompatible protocol'),
+    new Error('malformed hello response'),
+    new Error('connection closed during hello'),
+  ])('closes the control client exactly once when required hello fails: %s', async (failure) => {
+    const client = {
+      hello: vi.fn().mockRejectedValue(failure),
+      attach: vi.fn(),
+      release: vi.fn(),
+      close: vi.fn().mockRejectedValue(new Error('secondary close failure')),
+    };
+    await expect(connectSlabControlBridge({
+      ensureLaunched: async () => undefined,
+      connect: async () => client as never,
+    })).rejects.toBe(failure);
+    expect(client.hello).toHaveBeenCalledOnce();
+    expect(client.close).toHaveBeenCalledOnce();
+    expect(client.attach).not.toHaveBeenCalled();
   });
 });

--- a/src/slab/control-bridge.ts
+++ b/src/slab/control-bridge.ts
@@ -2,7 +2,7 @@ import { homedir } from 'node:os';
 import { SlabBridgeClient } from './bridge-client.js';
 import { slabControlEndpoint } from './installation.js';
 import { launchSlab } from './launch.js';
-import type { SlabAttachResult } from './protocol.js';
+import type { SlabAttachResult, SlabCreateProfileResult } from './protocol.js';
 
 export interface SlabControlBridge {
   attach(profileId: string): Promise<SlabAttachResult>;
@@ -12,12 +12,18 @@ export interface SlabControlBridge {
 
 export interface SlabControlBridgeIo {
   ensureLaunched(): Promise<unknown>;
-  connect(): Promise<Pick<SlabBridgeClient, 'attach' | 'release' | 'close'>>;
+  connect(): Promise<Pick<SlabBridgeClient, 'hello' | 'attach' | 'release' | 'close'>>;
 }
 
 export async function connectSlabControlBridge(io: SlabControlBridgeIo = createSlabControlBridgeIo()): Promise<SlabControlBridge> {
   await io.ensureLaunched();
   const client = await io.connect();
+  try {
+    await client.hello();
+  } catch (error) {
+    await client.close().catch(() => {});
+    throw error;
+  }
   return {
     attach: profileId => client.attach(profileId),
     release: async connectionId => {
@@ -36,4 +42,18 @@ export function createSlabControlBridgeIo(): SlabControlBridgeIo {
     ensureLaunched: launchSlab,
     connect: () => SlabBridgeClient.connect(slabControlEndpoint(homedir())),
   };
+}
+
+/** Profile creation deliberately owns a short-lived control connection. */
+export async function ensureSlabProfile(
+  input: { alias: string; idempotencyKey: string },
+  connect: () => Promise<SlabBridgeClient> = () => SlabBridgeClient.connect(slabControlEndpoint(homedir())),
+): Promise<SlabCreateProfileResult> {
+  const client = await connect();
+  try {
+    await client.hello();
+    return await client.createProfile(input.alias, input.idempotencyKey);
+  } finally {
+    await client.close();
+  }
 }

--- a/src/slab/protocol.test.ts
+++ b/src/slab/protocol.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { parseAttachResult, parseControlResponse, parseCreateProfileResult, parseHelloResult } from './protocol.js';
+
+describe('SLAB revision 2 protocol', () => {
+  it('accepts a negotiated revision in the supported range', () => {
+    expect(parseHelloResult({ protocolVersion: 2, browserVersion: '152', browserPid: 7, profiles: [] }, { min: 1, max: 2 }).protocolVersion).toBe(2);
+  });
+
+  it('rejects a negotiated revision outside the supported range', () => {
+    expect(() => parseHelloResult({ protocolVersion: 3, browserVersion: '152', browserPid: 7, profiles: [] }, { min: 1, max: 2 })).toThrow(/revision|version|range/i);
+  });
+
+  it('strictly parses createProfile results', () => {
+    expect(parseCreateProfileResult({ profile: { id: 'Profile 1', displayName: 'Work' }, created: true })).toEqual({
+      profile: { id: 'Profile 1', displayName: 'Work' },
+      created: true,
+    });
+    expect(() => parseCreateProfileResult({ profile: { id: 'Profile 1', displayName: 'Work' }, created: true, extra: 1 })).toThrow(/unknown fields/);
+  });
+
+  it.each([
+    { id: '', displayName: 'Work' },
+    { id: 'Profile 1', displayName: '' },
+  ])('rejects empty profile identity fields: %j', (profile) => {
+    expect(() => parseHelloResult({
+      protocolVersion: 2, browserVersion: '152', browserPid: 7, profiles: [profile],
+    })).toThrow(/unknown fields/);
+    expect(() => parseCreateProfileResult({ profile, created: true })).toThrow(/unknown fields/);
+    expect(() => parseAttachResult({
+      connectionId: 'lease-1',
+      profile,
+      transport: { kind: 'cdp-ipc', endpoint: '/tmp/slab.sock', credential: 'secret' },
+    })).toThrow(/unknown fields/);
+  });
+
+  it('rejects an empty attachment connection id', () => {
+    expect(() => parseAttachResult({
+      connectionId: '',
+      profile: { id: 'Profile 1', displayName: 'Work' },
+      transport: { kind: 'cdp-ipc', endpoint: '/tmp/slab.sock', credential: 'secret' },
+    })).toThrow(/unknown fields/);
+  });
+
+  it.each(['PROFILE_CREATE_FAILED', 'PROFILE_GONE', 'PROFILE_REPAIR_REQUIRED'] as const)(
+    'accepts revision 2 error code %s',
+    (code) => {
+      expect(parseControlResponse(JSON.stringify({
+        id: '2', ok: false, error: { code, message: 'stable message' },
+      }))).toMatchObject({ error: { code } });
+    },
+  );
+});

--- a/src/slab/protocol.ts
+++ b/src/slab/protocol.ts
@@ -1,6 +1,7 @@
 import { inspect } from 'node:util';
 
-export const SLAB_PROTOCOL_VERSION = 1;
+export const SLAB_PROTOCOL_MIN_VERSION = 1;
+export const SLAB_PROTOCOL_VERSION = 2;
 export const SLAB_MAX_CONTROL_LINE_BYTES = 64 * 1024;
 
 export const SLAB_ERROR_CODES = [
@@ -10,17 +11,23 @@ export const SLAB_ERROR_CODES = [
   'ATTACH_FAILED',
   'AUTHENTICATION_FAILED',
   'CONNECTION_NOT_FOUND',
+  'PROFILE_CREATE_FAILED',
+  'PROFILE_GONE',
+  'PROFILE_REPAIR_REQUIRED',
 ] as const;
 
 export type SlabErrorCode = (typeof SLAB_ERROR_CODES)[number];
 
 export const SLAB_ERROR_MESSAGES: Record<SlabErrorCode, string> = {
   INVALID_REQUEST: 'Invalid JSON, framing, shape, size, or params',
-  INCOMPATIBLE_PROTOCOL: 'Client range does not include v1',
+  INCOMPATIBLE_PROTOCOL: 'Client range does not include a supported revision',
   PROFILE_NOT_FOUND: 'Requested profile is unavailable',
   ATTACH_FAILED: 'Browser could not create the attachment',
   AUTHENTICATION_FAILED: 'CDP IPC credential was missing or wrong',
   CONNECTION_NOT_FOUND: 'A non-release operation referenced an unknown lease',
+  PROFILE_CREATE_FAILED: 'Chromium could not initialize the profile',
+  PROFILE_GONE: 'Profile was removed during attachment',
+  PROFILE_REPAIR_REQUIRED: 'Saved profile mapping conflicts with native state',
 };
 
 const SUCCESS_KEYS = ['id', 'ok', 'result'] as const;
@@ -30,6 +37,7 @@ const HELLO_RESULT_KEYS = ['protocolVersion', 'browserVersion', 'browserPid', 'p
 const ATTACH_RESULT_KEYS = ['connectionId', 'profile', 'transport'] as const;
 const TRANSPORT_KEYS = ['kind', 'endpoint', 'credential'] as const;
 const PROFILE_KEYS = ['id', 'displayName'] as const;
+const CREATE_PROFILE_RESULT_KEYS = ['profile', 'created'] as const;
 
 export class SlabCredential {
   readonly #value: string;
@@ -65,6 +73,13 @@ export interface SlabHelloResult {
   browserVersion: string;
   browserPid: number;
   profiles: SlabProfileInfo[];
+}
+
+export interface SlabProtocolRange { min: number; max: number }
+
+export interface SlabCreateProfileResult {
+  profile: SlabProfileInfo;
+  created: boolean;
 }
 
 export interface SlabAttachTransport {
@@ -147,34 +162,48 @@ export function parseControlResponse(line: string): SlabControlResponse {
 function parseProfile(value: unknown): SlabProfileInfo {
   if (!isPlainObject(value)) throw new SlabProtocolShapeError('response has unknown fields');
   assertExactKeys(value, PROFILE_KEYS);
-  if (typeof value.id !== 'string' || typeof value.displayName !== 'string') {
+  if (typeof value.id !== 'string' || value.id.length === 0
+    || typeof value.displayName !== 'string' || value.displayName.length === 0) {
     throw new SlabProtocolShapeError('response has unknown fields');
   }
   return { id: value.id, displayName: value.displayName };
 }
 
-export function parseHelloResult(value: unknown): SlabHelloResult {
+export function parseHelloResult(
+  value: unknown,
+  supported: SlabProtocolRange = { min: SLAB_PROTOCOL_MIN_VERSION, max: SLAB_PROTOCOL_VERSION },
+): SlabHelloResult {
   if (!isPlainObject(value)) throw new SlabProtocolShapeError('response has unknown fields');
   assertExactKeys(value, HELLO_RESULT_KEYS);
-  if (value.protocolVersion !== SLAB_PROTOCOL_VERSION) {
-    throw new SlabProtocolShapeError('response has unknown fields');
+  if (typeof value.protocolVersion !== 'number' || !Number.isInteger(value.protocolVersion)
+    || value.protocolVersion < supported.min || value.protocolVersion > supported.max) {
+    throw new SlabProtocolShapeError('negotiated protocol version is outside the supported range');
   }
   if (typeof value.browserVersion !== 'string' || typeof value.browserPid !== 'number' || !Number.isInteger(value.browserPid)) {
     throw new SlabProtocolShapeError('response has unknown fields');
   }
   if (!Array.isArray(value.profiles)) throw new SlabProtocolShapeError('response has unknown fields');
   return {
-    protocolVersion: SLAB_PROTOCOL_VERSION,
+    protocolVersion: value.protocolVersion,
     browserVersion: value.browserVersion,
     browserPid: value.browserPid,
     profiles: value.profiles.map(parseProfile),
   };
 }
 
+export function parseCreateProfileResult(value: unknown): SlabCreateProfileResult {
+  if (!isPlainObject(value)) throw new SlabProtocolShapeError('response has unknown fields');
+  assertExactKeys(value, CREATE_PROFILE_RESULT_KEYS);
+  if (typeof value.created !== 'boolean') throw new SlabProtocolShapeError('response has unknown fields');
+  return { profile: parseProfile(value.profile), created: value.created };
+}
+
 export function parseAttachResult(value: unknown): SlabAttachResult {
   if (!isPlainObject(value)) throw new SlabProtocolShapeError('response has unknown fields');
   assertExactKeys(value, ATTACH_RESULT_KEYS);
-  if (typeof value.connectionId !== 'string') throw new SlabProtocolShapeError('response has unknown fields');
+  if (typeof value.connectionId !== 'string' || value.connectionId.length === 0) {
+    throw new SlabProtocolShapeError('response has unknown fields');
+  }
   if (!isPlainObject(value.transport)) throw new SlabProtocolShapeError('response has unknown fields');
   assertExactKeys(value.transport, TRANSPORT_KEYS);
   if (value.transport.kind !== 'cdp-ipc') throw new SlabProtocolShapeError('response has unknown fields');


### PR DESCRIPTION
## Summary
- allow native SLAB profile ids such as `Profile 1`
- negotiate SLAB protocol v2 attach/release requests
- claim the sole startup blank page instead of leaking an unowned tab
- make explicit `webcmd session close` discard SLAB session records cleanly
- add focused regressions for profile ids, page claiming, provider discard, and Node 26 safe-proxy fetch behavior

## Verification
- `npm test -- src/fetch/safe-proxy.test.ts`
- `npm test`
- `npm run build`
- live smoke against local rebuilt SLAB.app: profile create/use, two parallel sessions in one profile, `browser run`, tabs, clean close

## Notes
- Paired with SLAB branch `feat/slab-webcmd-full-parity`.
