### PR TITLE
test(site-memory): stop the suite flaking on Windows git handles and timer skew

### DIFF
--- a/src/site-memory/__fixtures__/git-test-support.ts
+++ b/src/site-memory/__fixtures__/git-test-support.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared support for the site memory tests that drive real `git`.
+ *
+ * These tests run git subprocesses against a throwaway home directory. Two
+ * things about that are hostile to Windows, and both surfaced as intermittent
+ * CI failures rather than as anything the tests actually assert.
+ */
+import { rm } from 'node:fs/promises';
+
+/**
+ * Per-test budget for a file that drives real git.
+ *
+ * A single test here spawns a handful of git processes and commits through
+ * them. That costs a second or two on an idle machine and several times more
+ * under a parallel suite on Windows, where process creation is expensive — well
+ * past vitest's 5s default, which then fails the test on the clock rather than
+ * on its assertions. The slowest tests in these files already opted into this
+ * same budget individually; applying it per file makes the whole class honest.
+ *
+ * This does not hide a hang: a test that never finishes still fails, at 20s.
+ */
+export const GIT_TEST_TIMEOUT_MS = 20_000;
+
+/**
+ * Drain a list of throwaway directories a test created, removing each one.
+ *
+ * On Windows a git child's handles on `.git` outlive its exit by a few
+ * milliseconds, and a test that vitest aborts on timeout leaves one running
+ * outright, so a plain recursive remove intermittently fails the suite during
+ * cleanup with:
+ *
+ *     EBUSY: resource busy or locked, rmdir '…\.webcmd\sites'
+ *
+ * `rm` retries exactly that family of errors when asked to; it just does not by
+ * default (`maxRetries` is 0). Retrying here keeps a slow or aborted test from
+ * turning into a second, unrelated-looking failure.
+ */
+export async function removeTempDirs(dirs: string[]): Promise<void> {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, {
+    recursive: true,
+    force: true,
+    maxRetries: 10,
+    retryDelay: 50,
+  })));
+}

--- a/src/site-memory/candidates.test.ts
+++ b/src/site-memory/candidates.test.ts
@@ -1,23 +1,26 @@
 import { execFile } from 'node:child_process';
 import { chmodSync } from 'node:fs';
-import { chmod, mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { addCandidate, listCandidates, searchCandidates, showCandidate } from './candidates.js';
 import { classifyProduct } from './classify.js';
 import { installGitShim, restoreGitShim } from './git-shim.js';
 import { openSitesRepository } from './git-store.js';
 import { listSiteMemory, readProductFile, showSiteMemory, writeProductFile } from './local-store.js';
 import type { Candidate } from './model.js';
+import { GIT_TEST_TIMEOUT_MS, removeTempDirs } from './__fixtures__/git-test-support.js';
+
+vi.setConfig({ testTimeout: GIT_TEST_TIMEOUT_MS });
 
 const run = promisify(execFile);
 const tempHomes: string[] = [];
 
 afterEach(async () => {
   restoreGitShim();
-  await Promise.all(tempHomes.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  await removeTempDirs(tempHomes);
 });
 
 describe('candidate capture', () => {

--- a/src/site-memory/checkpoint.test.ts
+++ b/src/site-memory/checkpoint.test.ts
@@ -4,7 +4,7 @@ import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { addCandidate, showCandidate } from './candidates.js';
 import { checkpointMemory, type CheckpointInput } from './checkpoint.js';
 import { classifyProduct } from './classify.js';
@@ -12,6 +12,9 @@ import { getMemoryContext, parseProductManifest } from './context.js';
 import { installGitShim, restoreGitShim } from './git-shim.js';
 import { openSitesRepository } from './git-store.js';
 import { readProductFile, writeProductFile } from './local-store.js';
+import { GIT_TEST_TIMEOUT_MS, removeTempDirs } from './__fixtures__/git-test-support.js';
+
+vi.setConfig({ testTimeout: GIT_TEST_TIMEOUT_MS });
 
 const run = promisify(execFile);
 const tempHomes: string[] = [];
@@ -22,7 +25,7 @@ const REF = `# Listing\n\n${FACT}`;
 
 afterEach(async () => {
   restoreGitShim();
-  await Promise.all(tempHomes.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  await removeTempDirs(tempHomes);
 });
 
 describe('checkpoint compare-and-swap', () => {

--- a/src/site-memory/classify.test.ts
+++ b/src/site-memory/classify.test.ts
@@ -1,10 +1,10 @@
 import { execFile } from 'node:child_process';
 import { chmodSync } from 'node:fs';
-import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { classifyProduct } from './classify.js';
 import { getMemoryContext, parseProductManifest } from './context.js';
 import { installGitShim, restoreGitShim } from './git-shim.js';
@@ -12,13 +12,16 @@ import { openSitesRepository } from './git-store.js';
 import { readProductFile, writeProductFile } from './local-store.js';
 import type { SeedLookupResult } from './model.js';
 import { canonicalProductKey } from './product-resolver.js';
+import { GIT_TEST_TIMEOUT_MS, removeTempDirs } from './__fixtures__/git-test-support.js';
+
+vi.setConfig({ testTimeout: GIT_TEST_TIMEOUT_MS });
 
 const run = promisify(execFile);
 const tempHomes: string[] = [];
 
 afterEach(async () => {
   restoreGitShim();
-  await Promise.all(tempHomes.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  await removeTempDirs(tempHomes);
 });
 
 describe('product classification', () => {

--- a/src/site-memory/context.test.ts
+++ b/src/site-memory/context.test.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
 import { chmodSync } from 'node:fs';
-import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, chmod, mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
@@ -11,13 +11,16 @@ import { openSitesRepository } from './git-store.js';
 import { readProductFile, writeProductFile } from './local-store.js';
 import type { GlobalSeedProvider } from './seed-client.js';
 import type { SeedLookupResult } from './model.js';
+import { GIT_TEST_TIMEOUT_MS, removeTempDirs } from './__fixtures__/git-test-support.js';
+
+vi.setConfig({ testTimeout: GIT_TEST_TIMEOUT_MS });
 
 const run = promisify(execFile);
 const tempHomes: string[] = [];
 
 afterEach(async () => {
   restoreGitShim();
-  await Promise.all(tempHomes.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  await removeTempDirs(tempHomes);
 });
 
 describe('parseProductManifest', () => {

--- a/src/site-memory/git-shim.test.ts
+++ b/src/site-memory/git-shim.test.ts
@@ -1,16 +1,19 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { installGitShim, restoreGitShim } from './git-shim.js';
 import { openSitesRepository } from './git-store.js';
 import { writeProductFile } from './local-store.js';
+import { GIT_TEST_TIMEOUT_MS, removeTempDirs } from './__fixtures__/git-test-support.js';
+
+vi.setConfig({ testTimeout: GIT_TEST_TIMEOUT_MS });
 
 const tempHomes: string[] = [];
 
 afterEach(async () => {
   restoreGitShim();
-  await Promise.all(tempHomes.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  await removeTempDirs(tempHomes);
 });
 
 describe('installGitShim', () => {

--- a/src/site-memory/git-store.test.ts
+++ b/src/site-memory/git-store.test.ts
@@ -1,9 +1,9 @@
 import { execFile, spawnSync } from 'node:child_process';
-import { mkdir, mkdtemp, readFile, realpath, rm, utimes, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, realpath, utimes, writeFile } from 'node:fs/promises';
 import { hostname, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   LOCK_STALE_MS,
   LOCK_TIMEOUT_MS,
@@ -14,13 +14,16 @@ import {
 import { installGitShim, restoreGitShim } from './git-shim.js';
 import { openSitesRepository } from './git-store.js';
 import { listProductKeys, readProductFile, writeProductFile } from './local-store.js';
+import { GIT_TEST_TIMEOUT_MS, removeTempDirs } from './__fixtures__/git-test-support.js';
+
+vi.setConfig({ testTimeout: GIT_TEST_TIMEOUT_MS });
 
 const run = promisify(execFile);
 const tempHomes: string[] = [];
 
 afterEach(async () => {
   restoreGitShim();
-  await Promise.all(tempHomes.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  await removeTempDirs(tempHomes);
 });
 
 describe('sites git repository', () => {

--- a/src/site-memory/local-store.test.ts
+++ b/src/site-memory/local-store.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   addFieldMapping,
   addResponseSample,
@@ -23,6 +23,9 @@ import {
   showSiteMemory,
   writeProductFile,
 } from './local-store.js';
+import { GIT_TEST_TIMEOUT_MS, removeTempDirs } from './__fixtures__/git-test-support.js';
+
+vi.setConfig({ testTimeout: GIT_TEST_TIMEOUT_MS });
 
 const tempHomes: string[] = [];
 const base = { site: 'example.test' };
@@ -34,7 +37,7 @@ afterEach(async () => {
   else process.env.HOME = originalHome;
   if (originalUserProfile === undefined) delete process.env.USERPROFILE;
   else process.env.USERPROFILE = originalUserProfile;
-  await Promise.all(tempHomes.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  await removeTempDirs(tempHomes);
   await rm(join(process.cwd(), '.webcmd/sites/no-home.test'), { recursive: true, force: true });
 });
 

--- a/src/site-memory/self-learning.integration.test.ts
+++ b/src/site-memory/self-learning.integration.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
@@ -13,6 +13,9 @@ import { openSitesRepository } from './git-store.js';
 import { listSiteMemory, readProductFile, showSiteMemory, writeProductFile } from './local-store.js';
 import type { CandidateDisposition, SeedLookupResult } from './model.js';
 import { createHttpSeedProvider } from './seed-client.js';
+import { GIT_TEST_TIMEOUT_MS, removeTempDirs } from './__fixtures__/git-test-support.js';
+
+vi.setConfig({ testTimeout: GIT_TEST_TIMEOUT_MS });
 
 const run = promisify(execFile);
 const tempHomes: string[] = [];
@@ -30,7 +33,7 @@ const CLOCK = {
 
 afterEach(async () => {
   restoreGitShim();
-  await Promise.all(tempHomes.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  await removeTempDirs(tempHomes);
 });
 
 describe('self-learning lifecycle', () => {


### PR DESCRIPTION
Two `src/site-memory` tests fail in CI for reasons that have nothing to do with what they assert. Both are environmental, both land on unrelated branches, and between them they have reddened `main` and several open PRs.

## 1. Windows: git handles outlive the test

`Unit tests (windows-latest, shard 1/2)` fails intermittently. It hit #481 on 3 Sep and #483 on 4 Sep, and that shard has gone red on `main` several times recently. The failure is always the same shape:

```
FAIL  src/site-memory/checkpoint.test.ts > checkpoint compare-and-swap > returns a stale-revision conflict…
Error: Test timed out in 5000ms.
Error: EBUSY: resource busy or locked, rmdir 'C:\Users\RUNNER~1\AppData\Local\Temp\webcmd-checkpoint-t05DZ4\.webcmd\sites'
```

The two errors are one cascade, not two problems:

1. Each of these tests spawns several real `git` processes against a throwaway home. That costs a second or two on an idle machine and several times more under a parallel suite on Windows, where process creation is expensive — past vitest's 5s default.
2. vitest aborts the test mid-git. `afterEach` then removes the temp directory while a git child still holds `.git`, so the recursive remove fails too — reported against the same test, and looking like a filesystem bug rather than a clock.

I reproduced both locally on Windows, including the identical `EBUSY … \.webcmd\sites` path. The tests pass in isolation (`checkpoint.test.ts`: 48 tests, 43s) and only fail under full-suite parallelism, which matches CI exactly.

**Fix** — size the budget to what these tests do, and let cleanup tolerate the handles. Both live in one support module, `__fixtures__/git-test-support.ts`, so the reasoning and the numbers have a single home:

- **`GIT_TEST_TIMEOUT_MS = 20_000`**, applied per file via `vi.setConfig`. Not a new policy — it is the value the slowest tests in these same files had already opted into individually (`}, 20_000)`); applying it per file makes the class consistent instead of whack-a-mole. It does not hide a hang: a test that never finishes still fails, at 20s.
- **`removeTempDirs()`** passes `maxRetries`/`retryDelay` to `rm`. Node retries `EBUSY`/`EPERM`/`ENOTEMPTY` for exactly this case, but `maxRetries` defaults to 0.

Applied to the eight site-memory test files that drive real git. No production code changes — the `EBUSY` is a test-cleanup artifact, not a product defect. I checked `file-lock.ts` for a leaked descriptor before concluding that; it closes its handle in a `finally`, so retrying is not papering over a leak.

## 2. Any platform: the seed lookup budget is asserted to the millisecond

The first push of this PR went green on both Windows shards and then failed on `Unit tests (ubuntu-latest, shard 2/2)`:

```
FAIL  src/site-memory/seed-client.test.ts > global seed client > aborts after two seconds and does not retry
AssertionError: expected 1999 to be greater than or equal to 2000
```

`aborts after two seconds and does not retry` asserts that a lookup guarded by `AbortSignal.timeout(2000)` took at least 2000ms by `Date.now()`. Node can run the timer callback when only 1999ms have elapsed by that clock — libuv compares against a loop time it caches and truncates to whole milliseconds, so the two disagree by up to a millisecond.

**Fix** — the bound exists to show the lookup waited for the timeout instead of returning early, which a millisecond of slack still shows. The upper bound that proves it did not retry is unchanged.

## Verification

On Windows 11, Node 22:

- **Before:** every full-suite run reproduced the Windows failure locally — `checkpoint.test.ts` and `self-learning.integration.test.ts` timing out at 5000ms and then failing cleanup with the same `EBUSY … \.webcmd\sites`.
- **After:** three consecutive full-suite runs, zero site-memory git failures. The only remaining site-memory failures on my machine are four `EPERM: symlink` tests, which need Developer Mode and fail identically before this change.
- A scratch test that sleeps 6s passes under `vi.setConfig({ testTimeout: GIT_TEST_TIMEOUT_MS })`, confirming the file-level budget takes effect — it would fail at the 5s default.
- CI on the first push confirmed the Windows half: `Unit tests (windows-latest, shard 1/2)`, the job that had been failing, passed.
- `npm run typecheck` clean.

## Notes

- The per-test `}, 20_000)` markers left in these files are now redundant with the file default. I left them rather than widen the diff; happy to strip them if you'd prefer.
- Two other tests time out under the same load and are deliberately **not** touched here, since they are a different area and want their own change: `src/hosted/programmatic-differential.test.ts` (5s timeout) and `src/browser/run/runner.test.ts` (`EBUSY` unlinking `chrome_debug.log`).
