### PR TITLE
feat(browser): import Chrome cookies during local setup

### DIFF
--- a/src/browser/google-chrome.test.ts
+++ b/src/browser/google-chrome.test.ts
@@ -1,6 +1,13 @@
 import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
-import { findInstalledGoogleChrome, googleChromeCandidates } from './google-chrome.js';
+import {
+  chromeUserDataDir,
+  findChromeCookieSource,
+  findInstalledGoogleChrome,
+  googleChromeCandidates,
+  importChromeCookies,
+  listChromeCookieSources,
+} from './google-chrome.js';
 
 describe('Google Chrome discovery', () => {
   it('checks system and user application folders on macOS', () => {
@@ -54,5 +61,92 @@ describe('Google Chrome discovery', () => {
       stat: (async () => ({ isFile: () => true })) as never,
       access: (async () => undefined) as never,
     })).resolves.toBe(canonicalUserChrome);
+  });
+});
+
+describe('Chrome cookie import', () => {
+  it('resolves the Chrome user-data dir per platform', () => {
+    expect(chromeUserDataDir({ platform: 'darwin', homeDir: '/Users/test' }))
+      .toBe('/Users/test/Library/Application Support/Google/Chrome');
+    expect(chromeUserDataDir({ platform: 'win32', env: { LOCALAPPDATA: 'C:\\Users\\test\\AppData\\Local' } }))
+      .toBe(path.win32.join('C:\\Users\\test\\AppData\\Local', 'Google', 'Chrome', 'User Data'));
+    expect(chromeUserDataDir({ platform: 'win32', env: {} })).toBeUndefined();
+    expect(chromeUserDataDir({ platform: 'linux', homeDir: '/home/test' })).toBe('/home/test/.config/google-chrome');
+  });
+
+  it('lists profiles found on disk with their display name and cookies path', () => {
+    const userDataDir = '/Users/test/Library/Application Support/Google/Chrome';
+    const sources = listChromeCookieSources({
+      platform: 'darwin',
+      homeDir: '/Users/test',
+      existsSync: (candidate) => [
+        userDataDir,
+        path.join(userDataDir, 'Default', 'Cookies'),
+        path.join(userDataDir, 'Profile 1', 'Network', 'Cookies'),
+      ].includes(candidate as string),
+      listProfileFolders: (dir) => {
+        expect(dir).toBe(userDataDir);
+        return ['Default', 'Profile 1', 'Profile 2', 'System Profile'];
+      },
+      readFileSync: () => JSON.stringify({
+        profile: { info_cache: { Default: { name: 'Person 1' }, 'Profile 1': { name: 'Work' } } },
+      }),
+    });
+
+    expect(sources).toEqual([
+      { folder: 'Default', name: 'Person 1', cookiesPath: path.join(userDataDir, 'Default', 'Cookies') },
+      { folder: 'Profile 1', name: 'Work', cookiesPath: path.join(userDataDir, 'Profile 1', 'Network', 'Cookies') },
+      { folder: 'Profile 2', name: 'Profile 2', cookiesPath: undefined },
+    ]);
+  });
+
+  it('returns an empty list when Chrome is not installed', () => {
+    expect(listChromeCookieSources({ platform: 'darwin', homeDir: '/Users/test', existsSync: () => false }))
+      .toEqual([]);
+  });
+
+  it('finds a source profile by folder name or display name', () => {
+    const opts = {
+      platform: 'darwin' as const,
+      homeDir: '/Users/test',
+      existsSync: () => true,
+      listProfileFolders: () => ['Default'],
+      readFileSync: () => JSON.stringify({ profile: { info_cache: { Default: { name: 'Person 1' } } } }),
+    };
+    expect(findChromeCookieSource('Default', opts)?.cookiesPath).toContain('Default/Cookies');
+    expect(findChromeCookieSource('Person 1', opts)?.cookiesPath).toContain('Default/Cookies');
+    expect(findChromeCookieSource('Nope', opts)).toBeUndefined();
+  });
+
+  it('copies the cookies database and journal into the target profile', () => {
+    const copyFileSync = vi.fn();
+    const mkdirSync = vi.fn();
+    const result = importChromeCookies(
+      { folder: 'Default', name: 'Default', cookiesPath: '/chrome/Default/Cookies' },
+      '/webcmd/chrome/profiles/default',
+      {
+        mkdirSync,
+        copyFileSync,
+        existsSync: (candidate) => candidate === '/chrome/Default/Cookies-journal',
+      },
+    );
+
+    expect(mkdirSync).toHaveBeenCalledWith(path.join('/webcmd/chrome/profiles/default', 'Default'), { recursive: true });
+    expect(copyFileSync).toHaveBeenCalledWith(
+      '/chrome/Default/Cookies',
+      path.join('/webcmd/chrome/profiles/default', 'Default', 'Cookies'),
+    );
+    expect(copyFileSync).toHaveBeenCalledWith(
+      '/chrome/Default/Cookies-journal',
+      path.join('/webcmd/chrome/profiles/default', 'Default', 'Cookies-journal'),
+    );
+    expect(result).toEqual({ imported: true, destPath: path.join('/webcmd/chrome/profiles/default', 'Default', 'Cookies') });
+  });
+
+  it('does nothing when the source has no cookies database', () => {
+    const copyFileSync = vi.fn();
+    const result = importChromeCookies({ folder: 'Default', name: 'Default' }, '/webcmd/chrome/profiles/default', { copyFileSync });
+    expect(copyFileSync).not.toHaveBeenCalled();
+    expect(result).toEqual({ imported: false });
   });
 });

--- a/src/browser/google-chrome.test.ts
+++ b/src/browser/google-chrome.test.ts
@@ -81,8 +81,8 @@ describe('Chrome cookie import', () => {
       homeDir: '/Users/test',
       existsSync: (candidate) => [
         userDataDir,
-        path.join(userDataDir, 'Default', 'Cookies'),
-        path.join(userDataDir, 'Profile 1', 'Network', 'Cookies'),
+        path.posix.join(userDataDir, 'Default', 'Cookies'),
+        path.posix.join(userDataDir, 'Profile 1', 'Network', 'Cookies'),
       ].includes(candidate as string),
       listProfileFolders: (dir) => {
         expect(dir).toBe(userDataDir);
@@ -94,10 +94,36 @@ describe('Chrome cookie import', () => {
     });
 
     expect(sources).toEqual([
-      { folder: 'Default', name: 'Person 1', cookiesPath: path.join(userDataDir, 'Default', 'Cookies') },
-      { folder: 'Profile 1', name: 'Work', cookiesPath: path.join(userDataDir, 'Profile 1', 'Network', 'Cookies') },
+      { folder: 'Default', name: 'Person 1', cookiesPath: path.posix.join(userDataDir, 'Default', 'Cookies') },
+      { folder: 'Profile 1', name: 'Work', cookiesPath: path.posix.join(userDataDir, 'Profile 1', 'Network', 'Cookies') },
       { folder: 'Profile 2', name: 'Profile 2', cookiesPath: undefined },
     ]);
+  });
+
+  it('uses Windows separators throughout profile discovery when targeting Windows', () => {
+    const userDataDir = 'C:\\Users\\test\\AppData\\Local\\Google\\Chrome\\User Data';
+    const defaultCookies = path.win32.join(userDataDir, 'Default', 'Cookies');
+    const localState = path.win32.join(userDataDir, 'Local State');
+    const readFileSync = vi.fn((candidate: string) => {
+      expect(candidate).toBe(localState);
+      return JSON.stringify({ profile: { info_cache: { Default: { name: 'Personal' } } } });
+    });
+
+    const sources = listChromeCookieSources({
+      platform: 'win32',
+      env: { LOCALAPPDATA: 'C:\\Users\\test\\AppData\\Local' },
+      existsSync: candidate => candidate === userDataDir || candidate === defaultCookies,
+      listProfileFolders: dir => {
+        expect(dir).toBe(userDataDir);
+        return ['Default'];
+      },
+      readFileSync,
+    });
+
+    expect(sources).toEqual([
+      { folder: 'Default', name: 'Personal', cookiesPath: defaultCookies },
+    ]);
+    expect(readFileSync).toHaveBeenCalledOnce();
   });
 
   it('returns an empty list when Chrome is not installed', () => {

--- a/src/browser/google-chrome.ts
+++ b/src/browser/google-chrome.ts
@@ -92,13 +92,14 @@ export function chromeUserDataDir(opts: ChromeCookieImportOptions = {}): string 
   const platform = opts.platform ?? process.platform;
   const env = opts.env ?? process.env;
   const homeDir = opts.homeDir ?? os.homedir();
+  const platformPath = pathForPlatform(platform);
 
-  if (platform === 'darwin') return path.join(homeDir, 'Library', 'Application Support', 'Google', 'Chrome');
+  if (platform === 'darwin') return platformPath.join(homeDir, 'Library', 'Application Support', 'Google', 'Chrome');
   if (platform === 'win32') {
     const base = env.LOCALAPPDATA;
-    return base ? path.win32.join(base, 'Google', 'Chrome', 'User Data') : undefined;
+    return base ? platformPath.join(base, 'Google', 'Chrome', 'User Data') : undefined;
   }
-  if (platform === 'linux') return path.join(homeDir, '.config', 'google-chrome');
+  if (platform === 'linux') return platformPath.join(homeDir, '.config', 'google-chrome');
   return undefined;
 }
 
@@ -106,17 +107,26 @@ const PROFILE_FOLDER_PATTERN = /^(Default|Profile \d+)$/;
 
 // Chrome moved cookies into a Network/ subfolder for a few releases before
 // reverting; check both so this works across the versions users actually have.
-function findCookiesFile(profileDir: string, existsSync: typeof fs.existsSync): string | undefined {
-  return [path.join(profileDir, 'Cookies'), path.join(profileDir, 'Network', 'Cookies')]
+function pathForPlatform(platform: NodeJS.Platform): typeof path.posix {
+  return platform === 'win32' ? path.win32 : path.posix;
+}
+
+function findCookiesFile(
+  profileDir: string,
+  existsSync: typeof fs.existsSync,
+  platformPath: typeof path.posix,
+): string | undefined {
+  return [platformPath.join(profileDir, 'Cookies'), platformPath.join(profileDir, 'Network', 'Cookies')]
     .find(candidate => existsSync(candidate));
 }
 
 function readProfileDisplayNames(
   userDataDir: string,
   readFileSync: (path: string, encoding: 'utf-8') => string,
+  platformPath: typeof path.posix,
 ): Record<string, string> {
   try {
-    const raw = readFileSync(path.join(userDataDir, 'Local State'), 'utf-8');
+    const raw = readFileSync(platformPath.join(userDataDir, 'Local State'), 'utf-8');
     const cache = (JSON.parse(raw) as { profile?: { info_cache?: Record<string, { name?: unknown }> } })
       .profile?.info_cache ?? {};
     const names: Record<string, string> = {};
@@ -135,6 +145,8 @@ function readProfileDisplayNames(
  * Chrome install just yields an empty list.
  */
 export function listChromeCookieSources(opts: ChromeCookieImportOptions = {}): ChromeCookieSource[] {
+  const platform = opts.platform ?? process.platform;
+  const platformPath = pathForPlatform(platform);
   const userDataDir = chromeUserDataDir(opts);
   const existsSync = opts.existsSync ?? fs.existsSync;
   const readFileSync = opts.readFileSync ?? fs.readFileSync;
@@ -149,11 +161,11 @@ export function listChromeCookieSources(opts: ChromeCookieImportOptions = {}): C
   } catch {
     return [];
   }
-  const names = readProfileDisplayNames(userDataDir, readFileSync);
+  const names = readProfileDisplayNames(userDataDir, readFileSync, platformPath);
   return folders.map(folder => ({
     folder,
     name: names[folder] ?? folder,
-    cookiesPath: findCookiesFile(path.join(userDataDir, folder), existsSync),
+    cookiesPath: findCookiesFile(platformPath.join(userDataDir, folder), existsSync, platformPath),
   }));
 }
 

--- a/src/browser/google-chrome.ts
+++ b/src/browser/google-chrome.ts
@@ -1,4 +1,5 @@
 import { constants } from 'node:fs';
+import * as fs from 'node:fs';
 import { access, realpath, stat } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -65,4 +66,135 @@ export async function findInstalledGoogleChrome(
     }
   }
   return undefined;
+}
+
+export interface ChromeCookieImportOptions {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+  /** Returns the directory names directly under the Chrome user-data dir. Injectable for tests. */
+  listProfileFolders?: (userDataDir: string) => string[];
+  readFileSync?: (path: string, encoding: 'utf-8') => string;
+  existsSync?: typeof fs.existsSync;
+}
+
+export interface ChromeCookieSource {
+  /** Chrome's on-disk profile folder, e.g. "Default" or "Profile 1". */
+  folder: string;
+  /** Display name from Chrome's Local State, falls back to the folder name. */
+  name: string;
+  /** Absolute path to the profile's cookie database, if one was found. */
+  cookiesPath?: string;
+}
+
+/** The root Chrome stores all its profile folders under, one level above "Default". */
+export function chromeUserDataDir(opts: ChromeCookieImportOptions = {}): string | undefined {
+  const platform = opts.platform ?? process.platform;
+  const env = opts.env ?? process.env;
+  const homeDir = opts.homeDir ?? os.homedir();
+
+  if (platform === 'darwin') return path.join(homeDir, 'Library', 'Application Support', 'Google', 'Chrome');
+  if (platform === 'win32') {
+    const base = env.LOCALAPPDATA;
+    return base ? path.win32.join(base, 'Google', 'Chrome', 'User Data') : undefined;
+  }
+  if (platform === 'linux') return path.join(homeDir, '.config', 'google-chrome');
+  return undefined;
+}
+
+const PROFILE_FOLDER_PATTERN = /^(Default|Profile \d+)$/;
+
+// Chrome moved cookies into a Network/ subfolder for a few releases before
+// reverting; check both so this works across the versions users actually have.
+function findCookiesFile(profileDir: string, existsSync: typeof fs.existsSync): string | undefined {
+  return [path.join(profileDir, 'Cookies'), path.join(profileDir, 'Network', 'Cookies')]
+    .find(candidate => existsSync(candidate));
+}
+
+function readProfileDisplayNames(
+  userDataDir: string,
+  readFileSync: (path: string, encoding: 'utf-8') => string,
+): Record<string, string> {
+  try {
+    const raw = readFileSync(path.join(userDataDir, 'Local State'), 'utf-8');
+    const cache = (JSON.parse(raw) as { profile?: { info_cache?: Record<string, { name?: unknown }> } })
+      .profile?.info_cache ?? {};
+    const names: Record<string, string> = {};
+    for (const [folder, info] of Object.entries(cache)) {
+      if (typeof info?.name === 'string' && info.name.trim()) names[folder] = info.name.trim();
+    }
+    return names;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * List the Chrome profiles found on disk, each annotated with whether it has
+ * a cookies database to import. Never throws — an unreadable or absent
+ * Chrome install just yields an empty list.
+ */
+export function listChromeCookieSources(opts: ChromeCookieImportOptions = {}): ChromeCookieSource[] {
+  const userDataDir = chromeUserDataDir(opts);
+  const existsSync = opts.existsSync ?? fs.existsSync;
+  const readFileSync = opts.readFileSync ?? fs.readFileSync;
+  const listProfileFolders = opts.listProfileFolders ?? ((dir: string) => fs.readdirSync(dir, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name));
+  if (!userDataDir || !existsSync(userDataDir)) return [];
+
+  let folders: string[];
+  try {
+    folders = listProfileFolders(userDataDir).filter(name => PROFILE_FOLDER_PATTERN.test(name)).sort();
+  } catch {
+    return [];
+  }
+  const names = readProfileDisplayNames(userDataDir, readFileSync);
+  return folders.map(folder => ({
+    folder,
+    name: names[folder] ?? folder,
+    cookiesPath: findCookiesFile(path.join(userDataDir, folder), existsSync),
+  }));
+}
+
+/** Find a Chrome profile by its folder name (e.g. "Profile 1") or display name (e.g. "Work"). */
+export function findChromeCookieSource(
+  source: string,
+  opts: ChromeCookieImportOptions = {},
+): ChromeCookieSource | undefined {
+  const target = source.trim();
+  return listChromeCookieSources(opts).find(profile => profile.folder === target || profile.name === target);
+}
+
+export interface ImportChromeCookiesIo {
+  mkdirSync?: typeof fs.mkdirSync;
+  copyFileSync?: typeof fs.copyFileSync;
+  existsSync?: typeof fs.existsSync;
+}
+
+/**
+ * Copy a Chrome profile's cookie database into the "Default" profile
+ * Chromium creates inside a webcmd-managed --user-data-dir. Cookies only —
+ * no cache, history, extensions, or saved passwords — and no decryption:
+ * Chromium decrypts its own Cookies file via the OS keychain at launch time,
+ * so this is a plain file copy.
+ */
+export function importChromeCookies(
+  source: ChromeCookieSource,
+  targetUserDataDir: string,
+  io: ImportChromeCookiesIo = {},
+): { imported: boolean; destPath?: string } {
+  if (!source.cookiesPath) return { imported: false };
+  const mkdirSync = io.mkdirSync ?? fs.mkdirSync;
+  const copyFileSync = io.copyFileSync ?? fs.copyFileSync;
+  const existsSync = io.existsSync ?? fs.existsSync;
+
+  const destDir = path.join(targetUserDataDir, 'Default');
+  mkdirSync(destDir, { recursive: true });
+  const destPath = path.join(destDir, 'Cookies');
+  copyFileSync(source.cookiesPath, destPath);
+
+  const journalSource = `${source.cookiesPath}-journal`;
+  if (existsSync(journalSource)) copyFileSync(journalSource, `${destPath}-journal`);
+  return { imported: true, destPath };
 }

--- a/src/hosted/setup.test.ts
+++ b/src/hosted/setup.test.ts
@@ -267,25 +267,33 @@ describe('webcmd setup', () => {
       argv: ['--mode', 'local', '--browser', 'chrome', '--import-chrome-cookies'],
       isTTY: false,
       resolveGoogleChromeExecutable: async () => executablePath,
-      findChromeCookieSource: (name) => name === 'Default'
-        ? { folder: 'Default', name: 'Person 1', cookiesPath: '/real-chrome/Default/Cookies' }
-        : undefined,
+      listChromeCookieSources: () => [
+        { folder: 'Default', name: 'Person 1', cookiesPath: '/real-chrome/Default/Cookies' },
+        { folder: 'Profile 1', name: 'Work', cookiesPath: '/real-chrome/Profile 1/Cookies' },
+      ],
       importChromeCookies,
       fetchDaemonStatus: async () => null,
       write: message => { messages.push(message); },
     })).resolves.toBe(0);
 
-    expect(importChromeCookies).toHaveBeenCalledWith(
+    expect(importChromeCookies).toHaveBeenNthCalledWith(
+      1,
       { folder: 'Default', name: 'Person 1', cookiesPath: '/real-chrome/Default/Cookies' },
       expect.stringContaining(join('chrome', 'profiles', 'default')),
     );
-    expect(messages.join('')).toContain('Imported cookies from Chrome profile "Person 1"');
+    expect(importChromeCookies).toHaveBeenNthCalledWith(
+      2,
+      { folder: 'Profile 1', name: 'Work', cookiesPath: '/real-chrome/Profile 1/Cookies' },
+      expect.stringContaining(join('chrome', 'profiles', 'work')),
+    );
+    expect(messages.join('')).toContain('Chrome "Person 1" (Default) -> webcmd --profile default');
+    expect(messages.join('')).toContain('Chrome "Work" (Profile 1) -> webcmd --profile work');
   });
 
   it('skips Chrome cookie import with --no-import-chrome-cookies', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-chrome-cookies-skip-'));
     const executablePath = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
-    const findChromeCookieSource = vi.fn();
+    const listChromeCookieSources = vi.fn();
     const importChromeCookies = vi.fn();
 
     await expect(runHostedSetup({
@@ -293,13 +301,13 @@ describe('webcmd setup', () => {
       argv: ['--mode', 'local', '--browser', 'chrome', '--no-import-chrome-cookies'],
       isTTY: false,
       resolveGoogleChromeExecutable: async () => executablePath,
-      findChromeCookieSource,
+      listChromeCookieSources,
       importChromeCookies,
       fetchDaemonStatus: async () => null,
       write: () => undefined,
     })).resolves.toBe(0);
 
-    expect(findChromeCookieSource).not.toHaveBeenCalled();
+    expect(listChromeCookieSources).not.toHaveBeenCalled();
     expect(importChromeCookies).not.toHaveBeenCalled();
   });
 
@@ -314,14 +322,14 @@ describe('webcmd setup', () => {
       argv: ['--mode', 'local', '--browser', 'chrome', '--import-chrome-cookies'],
       isTTY: false,
       resolveGoogleChromeExecutable: async () => executablePath,
-      findChromeCookieSource: () => undefined,
+      listChromeCookieSources: () => [],
       importChromeCookies,
       fetchDaemonStatus: async () => null,
       write: message => { messages.push(message); },
     })).resolves.toBe(0);
 
     expect(importChromeCookies).not.toHaveBeenCalled();
-    expect(messages.join('')).toContain('No cookies found for Chrome profile "Default"; skipping import.');
+    expect(messages.join('')).toContain('No Chrome profiles with cookies found; skipping import.');
   });
 
   it('prompts to import Chrome cookies interactively and honors a "no" answer', async () => {
@@ -338,35 +346,117 @@ describe('webcmd setup', () => {
         return answers.shift() ?? '';
       },
       resolveGoogleChromeExecutable: async () => '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-      findChromeCookieSource: () => ({ folder: 'Default', name: 'Person 1', cookiesPath: '/real-chrome/Default/Cookies' }),
+      listChromeCookieSources: () => [
+        { folder: 'Default', name: 'Person 1', cookiesPath: '/real-chrome/Default/Cookies' },
+        { folder: 'Profile 1', name: 'Work', cookiesPath: '/real-chrome/Profile 1/Cookies' },
+      ],
       importChromeCookies,
       fetchDaemonStatus: async () => null,
       write: () => undefined,
     })).resolves.toBe(0);
 
-    expect(prompts).toContain('Import cookies from Chrome profile "Person 1" so webcmd starts signed in? [Y/n] ');
+    expect(prompts).toContain('Import cookies from 2 Chrome profiles so webcmd starts signed in? [Y/n] ');
     expect(importChromeCookies).not.toHaveBeenCalled();
   });
 
   it('imports a named --chrome-profile', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-chrome-cookies-named-'));
-    const findChromeCookieSource = vi.fn((name: string) => name === 'Work'
-      ? { folder: 'Profile 1', name: 'Work', cookiesPath: '/real-chrome/Profile 1/Cookies' }
-      : undefined);
-    const importChromeCookies = vi.fn(() => ({ imported: true }));
+    const listChromeCookieSources = vi.fn(() => [
+      { folder: 'Default', name: 'Personal', cookiesPath: '/real-chrome/Default/Cookies' },
+      { folder: 'Profile 1', name: 'Work', cookiesPath: '/real-chrome/Profile 1/Cookies' },
+    ]);
+    const importChromeCookies = vi.fn((_source: unknown, target: string) => ({ imported: true, destPath: target }));
 
     await expect(runHostedSetup({
       env: { WEBCMD_CONFIG_DIR: tempDir },
       argv: ['--mode', 'local', '--browser', 'chrome', '--chrome-profile', 'Work', '--import-chrome-cookies'],
       isTTY: false,
       resolveGoogleChromeExecutable: async () => '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-      findChromeCookieSource,
+      listChromeCookieSources,
       importChromeCookies,
       fetchDaemonStatus: async () => null,
       write: () => undefined,
     })).resolves.toBe(0);
 
-    expect(findChromeCookieSource).toHaveBeenCalledWith('Work');
+    expect(listChromeCookieSources).toHaveBeenCalledOnce();
+    expect(importChromeCookies).toHaveBeenCalledWith(
+      { folder: 'Profile 1', name: 'Work', cookiesPath: '/real-chrome/Profile 1/Cookies' },
+      expect.stringContaining(join('chrome', 'profiles', 'work')),
+    );
+  });
+
+  it('keeps a colliding profile slug stable when importing that Chrome folder by name', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-chrome-cookies-named-collision-'));
+    const importChromeCookies = vi.fn((_source: unknown, target: string) => ({ imported: true, destPath: target }));
+
+    await expect(runHostedSetup({
+      env: { WEBCMD_CONFIG_DIR: tempDir },
+      argv: ['--mode', 'local', '--browser', 'chrome', '--chrome-profile', 'Profile 2', '--import-chrome-cookies'],
+      isTTY: false,
+      resolveGoogleChromeExecutable: async () => '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      listChromeCookieSources: () => [
+        { folder: 'Default', name: 'Personal', cookiesPath: '/real-chrome/Default/Cookies' },
+        { folder: 'Profile 1', name: 'Work!', cookiesPath: '/real-chrome/Profile 1/Cookies' },
+        { folder: 'Profile 2', name: 'Work', cookiesPath: '/real-chrome/Profile 2/Cookies' },
+      ],
+      importChromeCookies,
+      fetchDaemonStatus: async () => null,
+      write: () => undefined,
+    })).resolves.toBe(0);
+
+    expect(importChromeCookies).toHaveBeenCalledWith(
+      { folder: 'Profile 2', name: 'Work', cookiesPath: '/real-chrome/Profile 2/Cookies' },
+      expect.stringContaining(join('chrome', 'profiles', 'work-2')),
+    );
+  });
+
+  it('creates deterministic unique webcmd profile slugs when Chrome display names collide', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-chrome-cookies-collisions-'));
+    const importChromeCookies = vi.fn((_source: unknown, target: string) => ({ imported: true, destPath: target }));
+    const messages: string[] = [];
+
+    await expect(runHostedSetup({
+      env: { WEBCMD_CONFIG_DIR: tempDir },
+      argv: ['--mode', 'local', '--browser', 'chrome', '--import-chrome-cookies'],
+      isTTY: false,
+      resolveGoogleChromeExecutable: async () => '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      listChromeCookieSources: () => [
+        { folder: 'Default', name: 'Your Chrome', cookiesPath: '/real-chrome/Default/Cookies' },
+        { folder: 'Profile 1', name: 'Work!', cookiesPath: '/real-chrome/Profile 1/Cookies' },
+        { folder: 'Profile 2', name: 'Work', cookiesPath: '/real-chrome/Profile 2/Cookies' },
+        { folder: 'Profile 3', name: '仕事', cookiesPath: '/real-chrome/Profile 3/Cookies' },
+      ],
+      importChromeCookies,
+      fetchDaemonStatus: async () => null,
+      write: message => { messages.push(message); },
+    })).resolves.toBe(0);
+
+    const targets = importChromeCookies.mock.calls.map(([, target]) => target);
+    expect(targets[0]).toContain(join('chrome', 'profiles', 'default'));
+    expect(targets[1]).toContain(join('chrome', 'profiles', 'work'));
+    expect(targets[2]).toContain(join('chrome', 'profiles', 'work-2'));
+    expect(targets[3]).toContain(join('chrome', 'profiles', 'profile-3'));
+    expect(messages.join('')).toContain('Chrome "仕事" (Profile 3) -> webcmd --profile profile-3');
+  });
+
+  it('skips Chrome people without a cookie database during an all-profile import', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-chrome-cookies-partial-'));
+    const importChromeCookies = vi.fn(() => ({ imported: true }));
+
+    await expect(runHostedSetup({
+      env: { WEBCMD_CONFIG_DIR: tempDir },
+      argv: ['--mode', 'local', '--browser', 'chrome', '--import-chrome-cookies'],
+      isTTY: false,
+      resolveGoogleChromeExecutable: async () => '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      listChromeCookieSources: () => [
+        { folder: 'Default', name: 'Your Chrome', cookiesPath: '/real-chrome/Default/Cookies' },
+        { folder: 'Profile 1', name: 'Empty' },
+      ],
+      importChromeCookies,
+      fetchDaemonStatus: async () => null,
+      write: () => undefined,
+    })).resolves.toBe(0);
+
     expect(importChromeCookies).toHaveBeenCalledOnce();
   });
 
@@ -644,6 +734,8 @@ describe('webcmd setup', () => {
 
     expect(messages.join('')).toContain('--browser <cloak|chrome|slab|absolute-path>');
     expect(messages.join('')).toContain('Cloak is default, Chrome reuses an installed Google Chrome');
+    expect(messages.join('')).toContain('Import only this Chrome profile');
+    expect(messages.join('')).toContain('import all Chrome profiles without prompting');
   });
 
   it('reports the configured custom browser without probing SLAB', async () => {

--- a/src/hosted/setup.test.ts
+++ b/src/hosted/setup.test.ts
@@ -255,6 +255,137 @@ describe('webcmd setup', () => {
     expect(messages.join('')).toContain('https://www.google.com/chrome/');
   });
 
+  it('imports Chrome cookies on explicit confirmation with --import-chrome-cookies', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-chrome-cookies-'));
+    const env = { WEBCMD_CONFIG_DIR: tempDir } as NodeJS.ProcessEnv;
+    const executablePath = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+    const messages: string[] = [];
+    const importChromeCookies = vi.fn(() => ({ imported: true, destPath: '/webcmd/chrome/profiles/default/Default/Cookies' }));
+
+    await expect(runHostedSetup({
+      env,
+      argv: ['--mode', 'local', '--browser', 'chrome', '--import-chrome-cookies'],
+      isTTY: false,
+      resolveGoogleChromeExecutable: async () => executablePath,
+      findChromeCookieSource: (name) => name === 'Default'
+        ? { folder: 'Default', name: 'Person 1', cookiesPath: '/real-chrome/Default/Cookies' }
+        : undefined,
+      importChromeCookies,
+      fetchDaemonStatus: async () => null,
+      write: message => { messages.push(message); },
+    })).resolves.toBe(0);
+
+    expect(importChromeCookies).toHaveBeenCalledWith(
+      { folder: 'Default', name: 'Person 1', cookiesPath: '/real-chrome/Default/Cookies' },
+      expect.stringContaining(join('chrome', 'profiles', 'default')),
+    );
+    expect(messages.join('')).toContain('Imported cookies from Chrome profile "Person 1"');
+  });
+
+  it('skips Chrome cookie import with --no-import-chrome-cookies', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-chrome-cookies-skip-'));
+    const executablePath = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+    const findChromeCookieSource = vi.fn();
+    const importChromeCookies = vi.fn();
+
+    await expect(runHostedSetup({
+      env: { WEBCMD_CONFIG_DIR: tempDir },
+      argv: ['--mode', 'local', '--browser', 'chrome', '--no-import-chrome-cookies'],
+      isTTY: false,
+      resolveGoogleChromeExecutable: async () => executablePath,
+      findChromeCookieSource,
+      importChromeCookies,
+      fetchDaemonStatus: async () => null,
+      write: () => undefined,
+    })).resolves.toBe(0);
+
+    expect(findChromeCookieSource).not.toHaveBeenCalled();
+    expect(importChromeCookies).not.toHaveBeenCalled();
+  });
+
+  it('warns instead of importing when --import-chrome-cookies finds no cookies', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-chrome-cookies-missing-'));
+    const executablePath = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+    const messages: string[] = [];
+    const importChromeCookies = vi.fn();
+
+    await expect(runHostedSetup({
+      env: { WEBCMD_CONFIG_DIR: tempDir },
+      argv: ['--mode', 'local', '--browser', 'chrome', '--import-chrome-cookies'],
+      isTTY: false,
+      resolveGoogleChromeExecutable: async () => executablePath,
+      findChromeCookieSource: () => undefined,
+      importChromeCookies,
+      fetchDaemonStatus: async () => null,
+      write: message => { messages.push(message); },
+    })).resolves.toBe(0);
+
+    expect(importChromeCookies).not.toHaveBeenCalled();
+    expect(messages.join('')).toContain('No cookies found for Chrome profile "Default"; skipping import.');
+  });
+
+  it('prompts to import Chrome cookies interactively and honors a "no" answer', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-chrome-cookies-prompt-'));
+    const env = { WEBCMD_CONFIG_DIR: tempDir } as NodeJS.ProcessEnv;
+    const answers = ['local', 'chrome', 'n'];
+    const prompts: string[] = [];
+    const importChromeCookies = vi.fn();
+
+    await expect(runHostedSetup({
+      env,
+      question: async prompt => {
+        prompts.push(prompt);
+        return answers.shift() ?? '';
+      },
+      resolveGoogleChromeExecutable: async () => '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      findChromeCookieSource: () => ({ folder: 'Default', name: 'Person 1', cookiesPath: '/real-chrome/Default/Cookies' }),
+      importChromeCookies,
+      fetchDaemonStatus: async () => null,
+      write: () => undefined,
+    })).resolves.toBe(0);
+
+    expect(prompts).toContain('Import cookies from Chrome profile "Person 1" so webcmd starts signed in? [Y/n] ');
+    expect(importChromeCookies).not.toHaveBeenCalled();
+  });
+
+  it('imports a named --chrome-profile', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-chrome-cookies-named-'));
+    const findChromeCookieSource = vi.fn((name: string) => name === 'Work'
+      ? { folder: 'Profile 1', name: 'Work', cookiesPath: '/real-chrome/Profile 1/Cookies' }
+      : undefined);
+    const importChromeCookies = vi.fn(() => ({ imported: true }));
+
+    await expect(runHostedSetup({
+      env: { WEBCMD_CONFIG_DIR: tempDir },
+      argv: ['--mode', 'local', '--browser', 'chrome', '--chrome-profile', 'Work', '--import-chrome-cookies'],
+      isTTY: false,
+      resolveGoogleChromeExecutable: async () => '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      findChromeCookieSource,
+      importChromeCookies,
+      fetchDaemonStatus: async () => null,
+      write: () => undefined,
+    })).resolves.toBe(0);
+
+    expect(findChromeCookieSource).toHaveBeenCalledWith('Work');
+    expect(importChromeCookies).toHaveBeenCalledOnce();
+  });
+
+  it('rejects --chrome-profile without --browser chrome', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-chrome-profile-invalid-'));
+    const messages: string[] = [];
+
+    await expect(runHostedSetup({
+      env: { WEBCMD_CONFIG_DIR: tempDir },
+      argv: ['--mode', 'local', '--browser', 'cloak', '--chrome-profile', 'Work'],
+      isTTY: false,
+      fetchDaemonStatus: async () => null,
+      write: message => { messages.push(message); },
+      stderr: new Writable({ write: (chunk, _enc, cb) => { messages.push(chunk.toString()); cb(); } }),
+    })).resolves.not.toBe(0);
+
+    expect(messages.join('')).toContain('--chrome-profile and --import-chrome-cookies are only valid with --browser chrome');
+  });
+
   it('reuses an existing SLAB app without downloading it again', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-slab-reuse-'));
     const events: string[] = [];

--- a/src/hosted/setup.ts
+++ b/src/hosted/setup.ts
@@ -5,12 +5,18 @@ import { homedir } from 'node:os';
 import { access, realpath, stat } from 'node:fs/promises';
 import { isAbsolute } from 'node:path';
 import { CLI_COMMAND } from '../brand.js';
-import { ArgumentError, toEnvelope } from '../errors.js';
+import { ArgumentError, getErrorMessage, toEnvelope } from '../errors.js';
 import { formatErrorEnvelope } from '../output.js';
 import { writeToStream } from '../stream-write.js';
 import { fetchDaemonStatus, type DaemonStatus } from '../browser/daemon-transport.js';
 import { restartDaemon, type DaemonRestartResult } from '../browser/daemon-lifecycle.js';
-import { findInstalledGoogleChrome } from '../browser/google-chrome.js';
+import {
+  findChromeCookieSource,
+  findInstalledGoogleChrome,
+  importChromeCookies,
+  type ChromeCookieSource,
+} from '../browser/google-chrome.js';
+import { resolveCloakProfileDir } from '../browser/runtime/local-cloak/profiles.js';
 import { createSlabInstallerIo, installSlabMacos, verifySlabApp } from '../slab/install.js';
 import { findSlabInstallation, type SlabInstallation } from '../slab/installation.js';
 import { createSlabLaunchIo } from '../slab/launch.js';
@@ -44,6 +50,8 @@ export interface SetupIo extends ConfigIo, HostedCredentialIo {
   isTTY?: boolean;
   resolveCloakPackage?: () => string | Promise<string>;
   resolveGoogleChromeExecutable?: () => Promise<string | undefined>;
+  findChromeCookieSource?: (source: string) => ChromeCookieSource | undefined;
+  importChromeCookies?: typeof importChromeCookies;
   realpath?: (path: string) => Promise<string>;
   stat?: (path: string) => Promise<{ isFile(): boolean }>;
   access?: (path: string, mode: number) => Promise<void>;
@@ -60,7 +68,7 @@ export interface SetupIo extends ConfigIo, HostedCredentialIo {
 type SetupMode = 'local' | 'hosted';
 type LocalBrowserSelection = LocalBrowserConfig | { kind: 'chrome' };
 
-const SETUP_USAGE = `usage: ${CLI_COMMAND} setup --mode <local|hosted> [--browser <cloak|chrome|slab|absolute-path>] [--api-key <key>]`;
+const SETUP_USAGE = `usage: ${CLI_COMMAND} setup --mode <local|hosted> [--browser <cloak|chrome|slab|absolute-path>] [--chrome-profile <name>] [--import-chrome-cookies|--no-import-chrome-cookies] [--api-key <key>]`;
 const SETUP_EXAMPLE = `example: ${CLI_COMMAND} setup --mode local`;
 const SETUP_HELP = [
   `${CLI_COMMAND} setup`,
@@ -69,6 +77,9 @@ const SETUP_HELP = [
   '',
   '  --mode <local|hosted>   Required when stdin is not a TTY',
   '  --browser <cloak|chrome|slab|absolute-path>  Local browser; Cloak is default, Chrome reuses an installed Google Chrome, SLAB is macOS alpha',
+  '  --chrome-profile <name>          Chrome profile to import cookies from (folder or display name; default: Default)',
+  '  --import-chrome-cookies          With --browser chrome, import that profile\'s cookies without prompting',
+  '  --no-import-chrome-cookies       With --browser chrome, skip cookie import without prompting',
   '  --api-key <key>         Required for --mode hosted when stdin is not a TTY',
   '  --status                Show the configured mode and local browser',
   '  -h, --help',
@@ -126,6 +137,12 @@ export async function runHostedSetup(io: SetupIo = {}): Promise<number> {
           `${SETUP_USAGE}\n${SETUP_EXAMPLE}`,
         );
       }
+      if ((parsed.chromeProfile || parsed.importChromeCookies !== undefined) && parsed.browser && parsed.browser.kind !== 'chrome') {
+        throw new ArgumentError(
+          '--chrome-profile and --import-chrome-cookies are only valid with --browser chrome.',
+          `${SETUP_USAGE}\n${SETUP_EXAMPLE}`,
+        );
+      }
       let chromeDiscovery: { executablePath: string | undefined } | undefined;
       let browser = parsed.browser;
       if (!browser && interactive) {
@@ -139,6 +156,7 @@ export async function runHostedSetup(io: SetupIo = {}): Promise<number> {
       const before = await (io.fetchDaemonStatus ?? fetchDaemonStatus)();
       try {
         const selected = await validateLocalBrowser(browser, io, chromeDiscovery);
+        if (selected.kind === 'chrome') await maybeImportChromeCookies(parsed, io, interactive, ask, write);
         (io.saveConfig ?? saveWebcmdConfig)(makeLocalConfig(io.now?.() ?? new Date(), selected), io);
         if (before) await restartConfiguredDaemon(selected, io);
       } catch (err) {
@@ -154,6 +172,12 @@ export async function runHostedSetup(io: SetupIo = {}): Promise<number> {
     if (parsed.browser) {
       throw new ArgumentError(
         '--browser is only valid with --mode local.',
+        `${SETUP_USAGE}\n${SETUP_EXAMPLE}`,
+      );
+    }
+    if (parsed.chromeProfile || parsed.importChromeCookies !== undefined) {
+      throw new ArgumentError(
+        '--chrome-profile and --import-chrome-cookies are only valid with --browser chrome.',
         `${SETUP_USAGE}\n${SETUP_EXAMPLE}`,
       );
     }
@@ -270,6 +294,57 @@ function resolveGoogleChromeExecutable(io: SetupIo): Promise<string | undefined>
   })))();
 }
 
+/**
+ * Offers to copy cookies from an installed Chrome profile into the separate,
+ * webcmd-managed profile that `--browser chrome` launches with (so `chrome`
+ * reuses the Chrome binary but starts from a blank profile otherwise).
+ * Best-effort: any failure here is reported but never fails setup, since the
+ * chrome browser selection itself already succeeded.
+ */
+async function maybeImportChromeCookies(
+  parsed: { chromeProfile?: string; importChromeCookies?: boolean },
+  io: SetupIo,
+  interactive: boolean,
+  ask: (prompt: string) => Promise<string>,
+  write: (message: string) => Promise<void>,
+): Promise<void> {
+  if (parsed.importChromeCookies === false) return;
+
+  const sourceName = parsed.chromeProfile ?? 'Default';
+  let source: ChromeCookieSource | undefined;
+  try {
+    source = (io.findChromeCookieSource ?? (name => findChromeCookieSource(name, {
+      platform: io.platform ?? process.platform,
+      env: io.env ?? process.env,
+      homeDir: io.homeDir,
+    })))(sourceName);
+  } catch (err) {
+    await write(`Could not look for a Chrome profile to import cookies from: ${getErrorMessage(err)}\n`);
+    return;
+  }
+
+  if (!source?.cookiesPath) {
+    if (parsed.importChromeCookies === true) {
+      await write(`No cookies found for Chrome profile "${sourceName}"; skipping import.\n`);
+    }
+    return;
+  }
+
+  if (parsed.importChromeCookies !== true) {
+    if (!interactive) return;
+    const answer = (await ask(`Import cookies from Chrome profile "${source.name}" so webcmd starts signed in? [Y/n] `)).trim().toLowerCase();
+    if (answer.startsWith('n')) return;
+  }
+
+  try {
+    const targetUserDataDir = resolveCloakProfileDir('default', { profileNamespace: 'chrome' });
+    (io.importChromeCookies ?? importChromeCookies)(source, targetUserDataDir);
+    await write(`Imported cookies from Chrome profile "${source.name}".\n`);
+  } catch (err) {
+    await write(`Could not import Chrome cookies: ${getErrorMessage(err)}\n`);
+  }
+}
+
 async function waitForSlabHello(io: SetupIo, timeoutMs = 60_000): Promise<boolean> {
   const inspect = io.inspectSlabStatus ?? inspectSlabStatus;
   const wait = io.wait ?? (ms => new Promise<void>(resolve => setTimeout(resolve, ms)));
@@ -318,16 +393,42 @@ export async function getSetupStatus(io: SetupIo = {}): Promise<SetupStatus> {
   return status;
 }
 
-function parseSetupArgs(argv: readonly string[]): { help?: true; status?: true; mode?: SetupMode; browser?: LocalBrowserSelection; apiKey?: string } {
+function parseSetupArgs(argv: readonly string[]): {
+  help?: true;
+  status?: true;
+  mode?: SetupMode;
+  browser?: LocalBrowserSelection;
+  apiKey?: string;
+  chromeProfile?: string;
+  importChromeCookies?: boolean;
+} {
   let mode: SetupMode | undefined;
   let browser: LocalBrowserSelection | undefined;
   let apiKey: string | undefined;
   let status: true | undefined;
+  let chromeProfile: string | undefined;
+  let importChromeCookies: boolean | undefined;
   for (let i = 0; i < argv.length; i++) {
     const token = argv[i]!;
     if (token === '--help' || token === '-h') return { help: true };
     if (token === '--status') {
       status = true;
+      continue;
+    }
+    if (token === '--import-chrome-cookies') {
+      importChromeCookies = true;
+      continue;
+    }
+    if (token === '--no-import-chrome-cookies') {
+      importChromeCookies = false;
+      continue;
+    }
+    if (token === '--chrome-profile' || token.startsWith('--chrome-profile=')) {
+      const value = token.startsWith('--chrome-profile=') ? token.slice('--chrome-profile='.length) : argv[++i];
+      if (!value || value.startsWith('-')) {
+        throw new ArgumentError('--chrome-profile requires a value.', `${SETUP_USAGE}\n${SETUP_EXAMPLE}`);
+      }
+      chromeProfile = value;
       continue;
     }
     if (token === '--mode' || token.startsWith('--mode=')) {
@@ -362,10 +463,10 @@ function parseSetupArgs(argv: readonly string[]): { help?: true; status?: true; 
 
     throw new ArgumentError(
       `unknown flag ${token} for \`setup\``,
-      `valid flags for \`setup\`: --mode, --browser, --api-key, --status, --help\n${SETUP_USAGE}`,
+      `valid flags for \`setup\`: --mode, --browser, --chrome-profile, --import-chrome-cookies, --no-import-chrome-cookies, --api-key, --status, --help\n${SETUP_USAGE}`,
     );
   }
-  return { ...(status ? { status } : {}), mode, browser, apiKey };
+  return { ...(status ? { status } : {}), mode, browser, apiKey, chromeProfile, importChromeCookies };
 }
 
 function parseLocalBrowser(value: string | undefined): LocalBrowserSelection {

--- a/src/hosted/setup.ts
+++ b/src/hosted/setup.ts
@@ -4,16 +4,16 @@ import { constants, existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { access, realpath, stat } from 'node:fs/promises';
 import { isAbsolute } from 'node:path';
-import { CLI_COMMAND } from '../brand.js';
+import { CLI_COMMAND, ENV_PREFIX } from '../brand.js';
 import { ArgumentError, getErrorMessage, toEnvelope } from '../errors.js';
 import { formatErrorEnvelope } from '../output.js';
 import { writeToStream } from '../stream-write.js';
 import { fetchDaemonStatus, type DaemonStatus } from '../browser/daemon-transport.js';
 import { restartDaemon, type DaemonRestartResult } from '../browser/daemon-lifecycle.js';
 import {
-  findChromeCookieSource,
   findInstalledGoogleChrome,
   importChromeCookies,
+  listChromeCookieSources,
   type ChromeCookieSource,
 } from '../browser/google-chrome.js';
 import { resolveCloakProfileDir } from '../browser/runtime/local-cloak/profiles.js';
@@ -50,7 +50,7 @@ export interface SetupIo extends ConfigIo, HostedCredentialIo {
   isTTY?: boolean;
   resolveCloakPackage?: () => string | Promise<string>;
   resolveGoogleChromeExecutable?: () => Promise<string | undefined>;
-  findChromeCookieSource?: (source: string) => ChromeCookieSource | undefined;
+  listChromeCookieSources?: () => ChromeCookieSource[];
   importChromeCookies?: typeof importChromeCookies;
   realpath?: (path: string) => Promise<string>;
   stat?: (path: string) => Promise<{ isFile(): boolean }>;
@@ -77,8 +77,8 @@ const SETUP_HELP = [
   '',
   '  --mode <local|hosted>   Required when stdin is not a TTY',
   '  --browser <cloak|chrome|slab|absolute-path>  Local browser; Cloak is default, Chrome reuses an installed Google Chrome, SLAB is macOS alpha',
-  '  --chrome-profile <name>          Chrome profile to import cookies from (folder or display name; default: Default)',
-  '  --import-chrome-cookies          With --browser chrome, import that profile\'s cookies without prompting',
+  '  --chrome-profile <name>          Import only this Chrome profile (folder or display name)',
+  '  --import-chrome-cookies          With --browser chrome, import all Chrome profiles without prompting',
   '  --no-import-chrome-cookies       With --browser chrome, skip cookie import without prompting',
   '  --api-key <key>         Required for --mode hosted when stdin is not a TTY',
   '  --status                Show the configured mode and local browser',
@@ -295,9 +295,9 @@ function resolveGoogleChromeExecutable(io: SetupIo): Promise<string | undefined>
 }
 
 /**
- * Offers to copy cookies from an installed Chrome profile into the separate,
- * webcmd-managed profile that `--browser chrome` launches with (so `chrome`
- * reuses the Chrome binary but starts from a blank profile otherwise).
+ * Offers to copy cookies from installed Chrome profiles into separate,
+ * webcmd-managed profiles that `--browser chrome` launches with (so `chrome`
+ * reuses the Chrome binary but starts from blank profiles otherwise).
  * Best-effort: any failure here is reported but never fails setup, since the
  * chrome browser selection itself already succeeded.
  */
@@ -310,39 +310,83 @@ async function maybeImportChromeCookies(
 ): Promise<void> {
   if (parsed.importChromeCookies === false) return;
 
-  const sourceName = parsed.chromeProfile ?? 'Default';
-  let source: ChromeCookieSource | undefined;
+  let mappings: Array<{ source: ChromeCookieSource; profileId: string }>;
   try {
-    source = (io.findChromeCookieSource ?? (name => findChromeCookieSource(name, {
-      platform: io.platform ?? process.platform,
-      env: io.env ?? process.env,
-      homeDir: io.homeDir,
-    })))(sourceName);
+    const discovered = (io.listChromeCookieSources ?? (() => listChromeCookieSources(chromeCookieImportOptions(io))))();
+    const discoveredMappings = mapChromeSourcesToWebcmdProfiles(discovered);
+    if (parsed.chromeProfile) {
+      const target = parsed.chromeProfile.trim();
+      const selected = discoveredMappings.find(({ source }) => source.folder === target || source.name === target);
+      mappings = selected?.source.cookiesPath ? [selected] : [];
+    } else {
+      mappings = discoveredMappings.filter(({ source }) => source.cookiesPath);
+    }
   } catch (err) {
-    await write(`Could not look for a Chrome profile to import cookies from: ${getErrorMessage(err)}\n`);
+    await write(`Could not look for Chrome profiles to import cookies from: ${getErrorMessage(err)}\n`);
     return;
   }
 
-  if (!source?.cookiesPath) {
+  if (mappings.length === 0) {
     if (parsed.importChromeCookies === true) {
-      await write(`No cookies found for Chrome profile "${sourceName}"; skipping import.\n`);
+      await write(parsed.chromeProfile
+        ? `No cookies found for Chrome profile "${parsed.chromeProfile}"; skipping import.\n`
+        : 'No Chrome profiles with cookies found; skipping import.\n');
     }
     return;
   }
 
   if (parsed.importChromeCookies !== true) {
     if (!interactive) return;
-    const answer = (await ask(`Import cookies from Chrome profile "${source.name}" so webcmd starts signed in? [Y/n] `)).trim().toLowerCase();
+    const prompt = parsed.chromeProfile
+      ? `Import cookies from Chrome profile "${mappings[0].source.name}" so webcmd starts signed in? [Y/n] `
+      : `Import cookies from ${mappings.length} Chrome ${mappings.length === 1 ? 'profile' : 'profiles'} so webcmd starts signed in? [Y/n] `;
+    const answer = (await ask(prompt)).trim().toLowerCase();
     if (answer.startsWith('n')) return;
   }
 
-  try {
-    const targetUserDataDir = resolveCloakProfileDir('default', { profileNamespace: 'chrome' });
-    (io.importChromeCookies ?? importChromeCookies)(source, targetUserDataDir);
-    await write(`Imported cookies from Chrome profile "${source.name}".\n`);
-  } catch (err) {
-    await write(`Could not import Chrome cookies: ${getErrorMessage(err)}\n`);
+  for (const { source, profileId } of mappings) {
+    try {
+      const targetUserDataDir = resolveCloakProfileDir(profileId, {
+        baseDir: io.env?.[`${ENV_PREFIX}_CONFIG_DIR`],
+        profileNamespace: 'chrome',
+      });
+      const result = (io.importChromeCookies ?? importChromeCookies)(source, targetUserDataDir);
+      if (result.imported) {
+        await write(`Chrome "${source.name}" (${source.folder}) -> webcmd --profile ${profileId}\n`);
+      }
+    } catch (err) {
+      await write(`Could not import cookies from Chrome profile "${source.name}": ${getErrorMessage(err)}\n`);
+    }
   }
+}
+
+function chromeCookieImportOptions(io: SetupIo) {
+  return {
+    platform: io.platform ?? process.platform,
+    env: io.env ?? process.env,
+    homeDir: io.homeDir,
+  };
+}
+
+function mapChromeSourcesToWebcmdProfiles(sources: ChromeCookieSource[]): Array<{ source: ChromeCookieSource; profileId: string }> {
+  const used = new Set<string>(['default']);
+  return sources.map(source => {
+    if (source.folder === 'Default') return { source, profileId: 'default' };
+    const base = chromeProfileSlug(source.name) || chromeProfileSlug(source.folder) || 'chrome-profile';
+    let profileId = base;
+    for (let suffix = 2; used.has(profileId); suffix += 1) profileId = `${base}-${suffix}`;
+    used.add(profileId);
+    return { source, profileId };
+  });
+}
+
+function chromeProfileSlug(value: string): string {
+  return value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
 async function waitForSlabHello(io: SetupIo, timeoutMs = 60_000): Promise<boolean> {


### PR DESCRIPTION
## Summary

- discover Chrome people and import each cookie database into a separate webcmd profile
- map Chrome Default to webcmd default and slug other display names with stable collision suffixes
- keep --chrome-profile as a single-person override and print the resulting profile mappings

## Verification

- npm run typecheck
- npm test (3,497 passed; 92 skipped)