### PR TITLE
fix(cli): update help text formatting and structure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -199,6 +199,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -245,6 +246,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -276,6 +278,7 @@
       "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2676,6 +2679,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2688,6 +2692,7 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
       "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -3045,6 +3050,7 @@
       "integrity": "sha512-6w9FwtT8WQqRAyTNR+Z+86kghRqpmOLjXUrBlBT6T+CQGDuIMm0VmAqaFUFBIeKDTGobE6/YSigZYLeomzBaRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -3109,6 +3115,7 @@
       "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -641,11 +641,16 @@ describe('createProgram root help descriptions', () => {
   it('renders the actual local root through the shared root presentation seam', () => {
     const program = createProgram('', '');
     const presentation = getInstalledRootHelpPresentation(program);
-    const commanderHelp = program.createHelp();
+    const help = program.helpInformation();
 
     expect(presentation).toBeDefined();
-    expect(presentation!.baseText).toBe(commanderHelp.formatHelp(program, commanderHelp));
-    expect(program.helpInformation()).toBe(formatRootHelp(presentation!));
+    expect(presentation!.baseText).toBeUndefined();
+    expect(help).toBe(formatRootHelp(presentation!));
+    expect(help).toContain('CORE');
+    expect(help).toContain('BROWSER');
+    expect(help).toContain('GLOBAL OPTIONS');
+    expect(help).toContain('EXAMPLES');
+    expect(help).toContain('AGENTS');
   });
 
   it('guides an absent site to explicit plugin search and install without side effects', async () => {
@@ -723,9 +728,9 @@ describe('createProgram root help descriptions', () => {
       const program = createProgram('', '');
       const help = program.helpInformation();
 
-      expect(help).toContain('Site adapters (2):');
+      expect(help).toContain('SITES (2)');
       expect(help).toContain('reddit, youtube');
-      expect(help).toContain("webcmd <site> --help -f yaml");
+      expect(help).toContain('webcmd <site> --help -f yaml');
       expect(help).not.toMatch(/\n  reddit\s+hot/);
       expect(help).not.toMatch(/\n  youtube\s+search/);
     } finally {
@@ -762,13 +767,13 @@ describe('createProgram root help descriptions', () => {
       const help = program.helpInformation();
 
       // Two separate sections, each with own count
-      expect(help).toContain('App adapters (1):');
-      expect(help).toMatch(/App adapters \(1\):\n {2}chatwise/);
-      expect(help).toContain('Site adapters (1):');
-      expect(help).toMatch(/Site adapters \(1\):\n {2}youtube/);
+      expect(help).toContain('APP ADAPTERS (1)');
+      expect(help).toMatch(/APP ADAPTERS \(1\)\n {2}chatwise/);
+      expect(help).toContain('SITES (1)');
+      expect(help).toMatch(/SITES \(1\)\n {2}youtube/);
 
-      // App adapters appear before Site adapters (External CLIs are absent here)
-      expect(help.indexOf('App adapters')).toBeLessThan(help.indexOf('Site adapters'));
+      // Sites appear before app adapters in the redesigned root help
+      expect(help.indexOf('SITES')).toBeLessThan(help.indexOf('APP ADAPTERS'));
     } finally {
       registry.clear();
       for (const [key, value] of snapshot) registry.set(key, value);

--- a/src/command-presentation.test.ts
+++ b/src/command-presentation.test.ts
@@ -8,6 +8,7 @@ import {
   formatRootHelp,
   formatSiteHelp,
   getCommandCompletionCandidates,
+  ROOT_HELP_BANNER,
   toPresentableCommand,
   type RootHelpPresentation,
 } from './command-presentation.js';
@@ -73,7 +74,100 @@ describe('shared command presentation', () => {
     };
     const hosted: RootHelpPresentation = JSON.parse(JSON.stringify(local)) as RootHelpPresentation;
 
-    expect(formatRootHelp(hosted)).toBe(formatRootHelp(local));
+    expect(formatRootHelp(hosted, { color: false })).toBe(formatRootHelp(local, { color: false }));
+  });
+
+  it('groups root commands, shows the banner, and keeps dynamic adapter lists', () => {
+    const help = formatRootHelp({
+      description: 'Make any website your CLI. Zero setup. AI-powered.',
+      usage: ['webcmd [options] [command]'],
+      commands: [
+        { name: 'list', description: 'List all available CLI commands' },
+        { name: 'site', description: 'Read and write per-site memory' },
+        { name: 'browser', description: 'Browser control' },
+        { name: 'session', description: 'Create, list, and close browser Sessions' },
+        { name: 'profile', description: 'Manage browser profiles' },
+        { name: 'auth', description: 'Inspect authentication status' },
+        { name: 'daemon', description: 'Manage the local Webcmd daemon' },
+        { name: 'doctor', description: 'Diagnose readiness' },
+        { name: 'update', description: 'Update the CLI' },
+        { name: 'skills', description: 'Manage bundled skills' },
+        { name: 'plugin', description: 'Manage plugins' },
+        { name: 'adapter', description: 'Manage adapters' },
+        { name: 'external', description: 'Manage external CLIs' },
+        { name: 'validate', description: 'Validate definitions' },
+        { name: 'verify', description: 'Smoke-test adapters' },
+        { name: 'convention-audit', description: 'Audit conventions' },
+        { name: 'completion <shell>', description: 'Output a shell completion script' },
+        { name: 'setup', description: 'Configure local or hosted mode' },
+      ],
+      options: [
+        { flags: '-V, --version', description: 'Output the version number' },
+        { flags: '--profile <name>', description: 'Browser profile/context alias' },
+        { flags: '--session <session-id>', description: 'Existing readable Session ID' },
+        { flags: '-h, --help', description: 'Display help for command' },
+      ],
+      groups: [
+        { label: 'SITES (2)', items: ['github', 'youtube'] },
+        { label: 'EXTERNAL CLIs (1)', items: ['gh'] },
+      ],
+    }, { color: false, columns: 80 });
+
+    expect(help).toContain(ROOT_HELP_BANNER);
+    expect(help).toContain('CORE');
+    expect(help).toContain('BROWSER');
+    expect(help).toContain('SYSTEM');
+    expect(help).toContain('EXTENSIONS');
+    expect(help).toContain('DEVELOPMENT');
+    expect(help).toContain('COMPLETION');
+    expect(help).toContain('GLOBAL OPTIONS');
+    expect(help).toContain('EXTERNAL CLIs (1)');
+    expect(help).toContain('SITES (2)');
+    expect(help).toContain('EXAMPLES');
+    expect(help).toContain('AGENTS');
+    expect(help.indexOf('CORE')).toBeLessThan(help.indexOf('BROWSER'));
+    expect(help.indexOf('BROWSER')).toBeLessThan(help.indexOf('SYSTEM'));
+    expect(help.indexOf('GLOBAL OPTIONS')).toBeLessThan(help.indexOf('SITES (2)'));
+    expect(help.indexOf('SITES (2)')).toBeLessThan(help.indexOf('EXTERNAL CLIs (1)'));
+    expect(help.indexOf('EXTERNAL CLIs (1)')).toBeLessThan(help.indexOf('EXAMPLES'));
+    expect(help).not.toMatch(/\u001b\[/);
+  });
+
+  it('puts a visible Hangul-filler spacer between the banner and the tagline', () => {
+    const description = 'Make any website your CLI. Zero setup. AI-powered.';
+    const help = formatRootHelp({
+      description,
+      commands: [{ name: 'list', description: 'List all available CLI commands' }],
+      options: [{ flags: '-h, --help', description: 'Display help for command' }],
+    }, { color: false });
+
+    expect(help.startsWith(`${ROOT_HELP_BANNER}\nㅤ\n  ${description}\n`)).toBe(true);
+  });
+
+  it('colors only CMD in the banner accent and leaves WEB white', () => {
+    const help = formatRootHelp({
+      description: 'Make any website your CLI. Zero setup. AI-powered.',
+      commands: [{ name: 'list', description: 'List all available CLI commands' }],
+      options: [{ flags: '-h, --help', description: 'Display help for command' }],
+    }, { color: true });
+
+    expect(help).toContain('\u001b[97m██╗    ██╗███████╗██████╗  \u001b[0m');
+    expect(help).toContain('\u001b[38;2;86;197;255m██████╗███╗   ███╗██████╗\u001b[0m');
+    expect(help).not.toMatch(/\u001b\[38;2;86;197;255m██╗    ██╗/);
+  });
+
+  it('degrades ANSI color cleanly when color is disabled', () => {
+    const presentation: RootHelpPresentation = {
+      description: 'Make any website your CLI. Zero setup. AI-powered.',
+      commands: [{ name: 'list', description: 'List all available CLI commands' }],
+      options: [{ flags: '-h, --help', description: 'Display help for command' }],
+    };
+    const plain = formatRootHelp(presentation, { color: false });
+    const colored = formatRootHelp(presentation, { color: true });
+
+    expect(plain).not.toMatch(/\u001b\[/);
+    expect(colored).toMatch(/\u001b\[/);
+    expect(colored.replace(/\u001b\[[0-9;]*m/g, '')).toBe(plain);
   });
 
   it('normalizes local and hosted metadata to byte-identical site and command help', () => {

--- a/src/command-presentation.ts
+++ b/src/command-presentation.ts
@@ -60,12 +60,150 @@ export interface RootHelpPresentation {
   usage?: readonly string[];
   commands: readonly RootHelpCommand[];
   options: readonly RootHelpOption[];
-  /** Commander-generated body retained by local mode for byte-compatible layout. */
+  /**
+   * @deprecated Ignored by formatRootHelp. Kept so older callers that still
+   * attach Commander base text compile until they drop the field.
+   */
   baseText?: string;
   groups?: readonly RootHelpGroup[];
+  examples?: readonly string[];
+  agents?: readonly string[];
   footer?: readonly string[];
   localOnlyCommands?: readonly RootHelpCommand[];
   localOnlyExplanation?: string;
+}
+
+export interface FormatRootHelpOptions {
+  /** Force ANSI color on/off. Defaults to TTY + NO_COLOR/FORCE_COLOR rules. */
+  color?: boolean;
+  /** Terminal width for wrapping dynamic lists. Defaults to process.stdout.columns. */
+  columns?: number;
+}
+
+/** Banner from ascii.md — WEB (white) + CMD (#56C5FF) when color is on. */
+export const ROOT_HELP_BANNER_PARTS = [
+  ['ㅤㅤㅤㅤㅤㅤㅤㅤㅤㅤㅤㅤㅤㅤㅤ', 'ㅤㅤㅤㅤㅤㅤㅤㅤㅤㅤㅤㅤㅤㅤㅤ'],
+  ['██╗    ██╗███████╗██████╗  ', '██████╗███╗   ███╗██████╗'],
+  ['██║    ██║██╔════╝██╔══██╗', '██╔════╝████╗ ████║██╔══██╗'],
+  ['██║ █╗ ██║█████╗  ██████╔╝', '██║     ██╔████╔██║██║  ██║'],
+  ['██║███╗██║██╔══╝  ██╔══██╗', '██║     ██║╚██╔╝██║██║  ██║'],
+  ['╚███╔███╔╝███████╗██████╔╝', '╚██████╗██║ ╚═╝ ██║██████╔╝'],
+  [' ╚══╝╚══╝ ╚══════╝╚═════╝  ', '╚═════╝╚═╝     ╚═╝╚═════╝'],
+] as const;
+
+export const ROOT_HELP_BANNER = ROOT_HELP_BANNER_PARTS
+  .map(([web, cmd]) => `${web}${cmd}`)
+  .join('\n');
+
+interface RootHelpCommandSection {
+  title: string;
+  order: readonly string[];
+}
+
+const ROOT_HELP_COMMAND_SECTIONS: readonly RootHelpCommandSection[] = [
+  { title: 'CORE', order: ['site', 'list', 'web'] },
+  { title: 'BROWSER', order: ['browser', 'session', 'profile', 'tab'] },
+  { title: 'SYSTEM', order: ['auth', 'daemon', 'doctor', 'update', 'setup', 'artifact'] },
+  { title: 'EXTENSIONS', order: ['skills', 'plugin', 'adapter', 'external'] },
+  { title: 'DEVELOPMENT', order: ['validate', 'verify', 'convention-audit'] },
+  { title: 'COMPLETION', order: ['completion'] },
+];
+
+/** Brand accent from docs theme (`colors.light`). */
+const ACCENT_RGB = { r: 0x56, g: 0xc5, b: 0xff } as const;
+
+const ANSI = {
+  reset: '\u001b[0m',
+  bold: '\u001b[1m',
+  dim: '\u001b[2m',
+  white: '\u001b[97m',
+  accent: `\u001b[38;2;${ACCENT_RGB.r};${ACCENT_RGB.g};${ACCENT_RGB.b}m`,
+} as const;
+
+function formatRootHelpBanner(color: boolean): string {
+  if (!color) return ROOT_HELP_BANNER;
+  return ROOT_HELP_BANNER_PARTS
+    .map(([web, cmd]) => `${paint(web, true, ANSI.white)}${paint(cmd, true, ANSI.accent)}`)
+    .join('\n');
+}
+
+function rootHelpColorEnabled(explicit?: boolean): boolean {
+  if (explicit !== undefined) return explicit;
+  if (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== '') return false;
+  if (process.env.FORCE_COLOR === '0') return false;
+  if (process.env.FORCE_COLOR !== undefined && process.env.FORCE_COLOR !== '') return true;
+  return process.stdout.isTTY === true;
+}
+
+function paint(text: string, enabled: boolean, ...codes: string[]): string {
+  if (!enabled || codes.length === 0) return text;
+  return `${codes.join('')}${text}${ANSI.reset}`;
+}
+
+function commandRootName(name: string): string {
+  return name.trim().split(/\s+/, 1)[0] ?? name;
+}
+
+function sortCommandsForSection(
+  commands: readonly RootHelpCommand[],
+  preferredOrder: readonly string[],
+): RootHelpCommand[] {
+  const rank = new Map(preferredOrder.map((name, index) => [name, index]));
+  return [...commands].sort((left, right) => {
+    const leftRoot = commandRootName(left.name);
+    const rightRoot = commandRootName(right.name);
+    const leftRank = rank.get(leftRoot) ?? Number.MAX_SAFE_INTEGER;
+    const rightRank = rank.get(rightRoot) ?? Number.MAX_SAFE_INTEGER;
+    if (leftRank !== rightRank) return leftRank - rightRank;
+    return left.name.localeCompare(right.name);
+  });
+}
+
+function groupRootHelpCommands(
+  commands: readonly RootHelpCommand[],
+): { title: string; commands: RootHelpCommand[] }[] {
+  const remaining = new Map<string, RootHelpCommand[]>();
+  for (const command of commands) {
+    const root = commandRootName(command.name);
+    const bucket = remaining.get(root) ?? [];
+    bucket.push(command);
+    remaining.set(root, bucket);
+  }
+
+  const sections: { title: string; commands: RootHelpCommand[] }[] = [];
+  for (const section of ROOT_HELP_COMMAND_SECTIONS) {
+    const matched: RootHelpCommand[] = [];
+    for (const name of section.order) {
+      const items = remaining.get(name);
+      if (!items) continue;
+      matched.push(...items);
+      remaining.delete(name);
+    }
+    if (matched.length) sections.push({ title: section.title, commands: sortCommandsForSection(matched, section.order) });
+  }
+
+  if (remaining.size > 0) {
+    const other = [...remaining.values()].flat().sort((a, b) => a.name.localeCompare(b.name));
+    sections.push({ title: 'OTHER', commands: other });
+  }
+  return sections;
+}
+
+function defaultRootHelpExamples(): string[] {
+  return [
+    `${CLI_COMMAND} list`,
+    `${CLI_COMMAND} <site> --help`,
+    `${CLI_COMMAND} --session <session-id> browser tabs`,
+    `${CLI_COMMAND} github whoami -f yaml`,
+  ];
+}
+
+function defaultRootHelpAgents(): string[] {
+  return [
+    `${CLI_COMMAND} <site> --help -f yaml`,
+    `${CLI_COMMAND} list -f yaml`,
+    `${CLI_COMMAND} <site> <command> -f yaml`,
+  ];
 }
 
 export interface CommandListPresentation {
@@ -162,52 +300,87 @@ export function toPresentableCommand(command: PresentableCommandSource): Present
   };
 }
 
-export function formatRootHelp(presentation: RootHelpPresentation): string {
-  if (presentation.baseText !== undefined) {
-    const baseText = presentation.baseText.replace(/\n+$/, '');
-    const groups = (presentation.groups ?? []).filter((group) => group.items.length > 0);
-    if (groups.length === 0) return `${baseText}\n`;
-
-    const tail: string[] = [];
-    for (const group of groups) {
-      tail.push(`${group.label}:`, wrapCommaList(group.items), '');
-    }
-    if (presentation.footer?.length) tail.push(...presentation.footer);
-    return `${baseText}\n\n${tail.join('\n')}\n`;
-  }
-
+export function formatRootHelp(
+  presentation: RootHelpPresentation,
+  opts: FormatRootHelpOptions = {},
+): string {
+  const color = rootHelpColorEnabled(opts.color);
+  const wrapWidth = Math.max(opts.columns ?? process.stdout.columns ?? 100, 40);
   const usage = presentation.usage ?? [
+    `${CLI_COMMAND} [options] [command]`,
     `${CLI_COMMAND} <site> <command> [args] [options]`,
     `${CLI_COMMAND} list [options]`,
   ];
+  const examples = presentation.examples ?? defaultRootHelpExamples();
+  const agents = presentation.agents ?? defaultRootHelpAgents();
+  const sectionHeading = (title: string): string => paint(title, color, ANSI.bold, ANSI.accent);
+  const dim = (text: string): string => paint(text, color, ANSI.dim);
+
+  // Visible spacer between the ASCII banner and the tagline (Hangul filler).
+  const banner = formatRootHelpBanner(color).replace(/(?:\r?\n[ \t]*)+$/g, '');
   const lines: string[] = [
-    'Usage:',
+    banner,
+    'ㅤ',
+    `  ${paint(presentation.description, color, ANSI.dim)}`,
+    '',
+    sectionHeading('USAGE'),
     ...usage.map((entry) => `  ${entry}`),
     '',
-    presentation.description,
-    '',
-    'Options:',
-    ...formatRows(presentation.options.map((option) => [option.flags, option.description])),
-    '',
-    'Commands:',
-    ...formatRows(presentation.commands.map((command) => [command.name, command.description])),
   ];
 
-  if (presentation.localOnlyCommands?.length) {
-    lines.push(
-      '',
-      'Local-only commands:',
-      ...formatRows(presentation.localOnlyCommands.map((command) => [command.name, command.description])),
-    );
-    if (presentation.localOnlyExplanation) lines.push('', presentation.localOnlyExplanation);
+  for (const section of groupRootHelpCommands(presentation.commands)) {
+    lines.push(sectionHeading(section.title));
+    lines.push(...formatStyledRows(
+      section.commands.map((command) => ({ left: command.name, right: command.description })),
+      { color, emphasizeLeft: true },
+    ));
+    lines.push('');
   }
+
+  if (presentation.options.length) {
+    lines.push(sectionHeading('GLOBAL OPTIONS'));
+    lines.push(...formatStyledRows(
+      presentation.options.map((option) => ({ left: option.flags, right: option.description })),
+      { color, emphasizeLeft: true },
+    ));
+    lines.push('');
+  }
+
+  if (presentation.localOnlyCommands?.length) {
+    lines.push(sectionHeading('LOCAL-ONLY'));
+    lines.push(...formatStyledRows(
+      presentation.localOnlyCommands.map((command) => ({ left: command.name, right: command.description })),
+      { color, emphasizeLeft: true },
+    ));
+    if (presentation.localOnlyExplanation) lines.push(`  ${dim(presentation.localOnlyExplanation)}`);
+    lines.push('');
+  }
+
   for (const group of presentation.groups ?? []) {
     if (group.items.length === 0) continue;
-    lines.push('', `${group.label}:`, wrapCommaList(group.items));
+    lines.push(sectionHeading(group.label));
+    lines.push(wrapCommaList(group.items, { width: wrapWidth, indent: '  ' }));
+    lines.push('');
   }
-  if (presentation.footer?.length) lines.push('', ...presentation.footer);
-  lines.push('');
-  return lines.join('\n');
+
+  if (examples.length) {
+    lines.push(sectionHeading('EXAMPLES'));
+    for (const example of examples) lines.push(`  ${example}`);
+    lines.push('');
+  }
+
+  if (agents.length) {
+    lines.push(sectionHeading('AGENTS'));
+    for (const tip of agents) lines.push(`  ${tip}`);
+    lines.push('');
+  }
+
+  if (presentation.footer?.length) {
+    for (const line of presentation.footer) lines.push(line);
+    lines.push('');
+  }
+
+  return `${lines.join('\n').replace(/\n+$/, '')}\n`;
 }
 
 export function commandListRows(
@@ -639,6 +812,20 @@ function formatRows(rows: readonly (readonly [string, string])[]): string[] {
   if (rows.length === 0) return [];
   const width = Math.min(Math.max(...rows.map(([left]) => left.length)), 34);
   return rows.map(([left, right]) => `  ${left.padEnd(width + 2)}${right}`);
+}
+
+function formatStyledRows(
+  rows: readonly { left: string; right: string }[],
+  opts: { color: boolean; emphasizeLeft?: boolean },
+): string[] {
+  if (rows.length === 0) return [];
+  const width = Math.min(Math.max(...rows.map((row) => row.left.length), 0), 34);
+  return rows.map((row) => {
+    const padded = row.left.padEnd(width + 2);
+    const left = opts.emphasizeLeft ? paint(padded, opts.color, ANSI.bold) : padded;
+    const right = paint(row.right, opts.color, ANSI.dim);
+    return `  ${left}${right}`;
+  });
 }
 
 function formatArgHelp(arg: Arg): string {

--- a/src/completion-shared.ts
+++ b/src/completion-shared.ts
@@ -60,6 +60,7 @@ const HOSTED_CORE_ROOT_COMMANDS: Record<HostedCoreCommandId, RootHelpCommand | u
 const HOSTED_ROOT_HELP_BASE: Omit<RootHelpPresentation, 'commands'> = {
   description: 'Make any website your CLI. Zero setup. AI-powered.',
   usage: [
+    `${CLI_COMMAND} [options] [command]`,
     `${CLI_COMMAND} <site> <command> [args] [options]`,
     `${CLI_COMMAND} --session <session-id> browser <command> [args] [options]`,
     `${CLI_COMMAND} list [options]`,
@@ -67,12 +68,24 @@ const HOSTED_ROOT_HELP_BASE: Omit<RootHelpPresentation, 'commands'> = {
   ],
   options: [
     { flags: '--profile <name>', description: 'Browser profile/context alias for browser runtime commands' },
+    { flags: '--session <session-id>', description: 'Existing readable Session ID from `webcmd session create <name>`' },
     { flags: '--workspace <id>', description: 'Hosted workspace id/slug; also WEBCMD_WORKSPACE' },
     { flags: '-V, --version', description: 'Output the version number' },
     { flags: '-h, --help', description: 'Display help for command' },
   ],
   localOnlyCommands: [
     { name: 'daemon', description: 'Manage the local Webcmd daemon' },
+  ],
+  examples: [
+    `${CLI_COMMAND} list`,
+    `${CLI_COMMAND} <site> --help`,
+    `${CLI_COMMAND} --session <session-id> browser tabs`,
+    `${CLI_COMMAND} setup`,
+  ],
+  agents: [
+    `${CLI_COMMAND} <site> --help -f yaml`,
+    `${CLI_COMMAND} list -f yaml`,
+    `${CLI_COMMAND} <site> <command> -f yaml`,
   ],
 };
 

--- a/src/help.test.ts
+++ b/src/help.test.ts
@@ -67,7 +67,7 @@ it('lets explicit --format win over --json in structured help', () => {
 });
 
 describe('formatRootAdapterHelpText', () => {
-  it('renders all three sections in External / App / Site order when populated', () => {
+  it('renders all three sections in SITES / APP / EXTERNAL order when populated', () => {
     const text = formatRootAdapterHelpText({
       external: [
         { name: 'gh', label: 'gh' },
@@ -76,12 +76,12 @@ describe('formatRootAdapterHelpText', () => {
       apps: ['chatwise', 'codex'],
       sites: ['youtube'],
     });
-    expect(text).toContain('External CLIs (2):');
-    expect(text).toContain('App adapters (2):');
-    expect(text).toContain('Site adapters (1):');
+    expect(text).toContain('EXTERNAL CLIs (2)');
+    expect(text).toContain('APP ADAPTERS (2)');
+    expect(text).toContain('SITES (1)');
     expect(text).toContain('vercel');
-    expect(text.indexOf('External CLIs')).toBeLessThan(text.indexOf('App adapters'));
-    expect(text.indexOf('App adapters')).toBeLessThan(text.indexOf('Site adapters'));
+    expect(text.indexOf('SITES')).toBeLessThan(text.indexOf('APP ADAPTERS'));
+    expect(text.indexOf('APP ADAPTERS')).toBeLessThan(text.indexOf('EXTERNAL CLIs'));
   });
 
   it('omits empty sections instead of rendering a (0) header', () => {
@@ -90,9 +90,9 @@ describe('formatRootAdapterHelpText', () => {
       apps: [],
       sites: ['youtube'],
     });
-    expect(text).not.toContain('External CLIs');
-    expect(text).not.toContain('App adapters');
-    expect(text).toContain('Site adapters (1):');
+    expect(text).not.toContain('EXTERNAL CLIs');
+    expect(text).not.toContain('APP ADAPTERS');
+    expect(text).toContain('SITES (1)');
   });
 
   it('returns empty string when all groups are empty', () => {

--- a/src/help.ts
+++ b/src/help.ts
@@ -128,20 +128,31 @@ export function buildRootHelpPresentation(program: Command, groups: RootAdapterG
   }));
   return {
     description: program.description(),
-    usage: [`${program.name()} [options] [command]`],
-    baseText: commanderHelp.formatHelp(program, commanderHelp),
+    usage: [
+      `${program.name()} [options] [command]`,
+      `${program.name()} <site> <command> [args] [options]`,
+      `${program.name()} --session <session-id> browser <command> [args] [options]`,
+      `${program.name()} list [options]`,
+    ],
     options,
     commands: program.commands
       .filter((command) => !adapterNames.has(command.name()))
       .map((command) => ({ name: command.name(), description: command.description() })),
     groups: [
-      { label: `External CLIs (${groups.external.length})`, items: groups.external.map((cli) => cli.label) },
-      { label: `App adapters (${groups.apps.length})`, items: groups.apps },
-      { label: `Site adapters (${groups.sites.length})`, items: groups.sites },
+      { label: `SITES (${groups.sites.length})`, items: groups.sites },
+      { label: `APP ADAPTERS (${groups.apps.length})`, items: groups.apps },
+      { label: `EXTERNAL CLIs (${groups.external.length})`, items: groups.external.map((cli) => cli.label) },
     ],
-    footer: [
-      `Run '${CLI_COMMAND} list' for full command details, or '${CLI_COMMAND} <site> --help' to inspect one site.`,
-      `Agent tip: use '${CLI_COMMAND} <site> --help -f yaml' for all command args/options in one structured response.`,
+    examples: [
+      `${CLI_COMMAND} list`,
+      `${CLI_COMMAND} <site> --help`,
+      `${CLI_COMMAND} --session <session-id> browser tabs`,
+      `${CLI_COMMAND} github whoami -f yaml`,
+    ],
+    agents: [
+      `${CLI_COMMAND} <site> --help -f yaml`,
+      `${CLI_COMMAND} list -f yaml`,
+      `${CLI_COMMAND} <site> <command> -f yaml`,
     ],
   };
 }
@@ -166,7 +177,7 @@ export function installRootPresentationHelp(
 function formatGroupSection(label: string, names: readonly string[]): string[] {
   if (names.length === 0) return [];
   return [
-    `${label} (${names.length}):`,
+    `${label} (${names.length})`,
     wrapCommaList(names),
     '',
   ];
@@ -176,9 +187,9 @@ export function formatRootAdapterHelpText(groups: RootAdapterGroups): string {
   const total = groups.external.length + groups.apps.length + groups.sites.length;
   if (total === 0) return '';
   const lines: string[] = [''];
-  lines.push(...formatGroupSection('External CLIs', groups.external.map(cli => cli.label)));
-  lines.push(...formatGroupSection('App adapters', groups.apps));
-  lines.push(...formatGroupSection('Site adapters', groups.sites));
+  lines.push(...formatGroupSection('SITES', groups.sites));
+  lines.push(...formatGroupSection('APP ADAPTERS', groups.apps));
+  lines.push(...formatGroupSection('EXTERNAL CLIs', groups.external.map(cli => cli.label)));
   lines.push(`Run '${CLI_COMMAND} list' for full command details, or '${CLI_COMMAND} <site> --help' to inspect one site.`);
   lines.push(`Agent tip: use '${CLI_COMMAND} <site> --help -f yaml' for all command args/options in one structured response.`);
   lines.push('');

--- a/src/hosted/manifest.test.ts
+++ b/src/hosted/manifest.test.ts
@@ -190,7 +190,7 @@ describe('hosted manifest helpers', () => {
     expect(stdout.text()).toContain('completion');
     expect(stdout.text()).toMatch(/profile\s+Manage hosted browser profiles/);
     expect(stdout.text()).toContain('--profile <name>');
-    expect(stdout.text()).toContain('Local-only commands:');
+    expect(stdout.text()).toContain('LOCAL-ONLY');
   });
 
   it('completes private hosted manifest commands without local discovery', async () => {


### PR DESCRIPTION
## What this PR does:
- Redesign webcmd --help with grouped sections, ASCII banner, and #56C5FF accent on CMD only (WEB stays white)
- Keep dynamic SITES / EXTERNAL CLIs and structured JSON/YAML help unchanged

## Demo:

<img width="831" height="1045" alt="image" src="https://github.com/user-attachments/assets/faeaea3b-5a87-47ab-925a-e0a04811f5fd" />
