### PR TITLE
fix(browser): keep installed Chrome profile loaded on macOS

### DIFF
--- a/src/browser/runtime/local-cloak/chrome-launch.test.ts
+++ b/src/browser/runtime/local-cloak/chrome-launch.test.ts
@@ -42,7 +42,7 @@ describe('chromeLaunchArgs', () => {
     const args = chromeLaunchArgs([
       '--fingerprint=123', '--enable-automation', '--remote-debugging-pipe', '--remote-debugging-port=0', '--headless',
       '--remote-debugging-address=0.0.0.0', '--headless=old',
-    ], '/profiles/work', 43123);
+    ], '/profiles/work', 43123, 'linux');
     expect(args).toContain('--remote-debugging-address=127.0.0.1');
     expect(args).toContain('--remote-debugging-port=43123');
     expect(args).toContain('--user-data-dir=/profiles/work');
@@ -52,6 +52,13 @@ describe('chromeLaunchArgs', () => {
     expect(args).not.toContain('--headless');
     expect(args).not.toContain('--headless=old');
     expect(args).not.toContain('--remote-debugging-address=0.0.0.0');
+    expect(args).not.toContain('--disable-features=DestroyProfileOnBrowserClose');
+  });
+
+  it('keeps the profile loaded after its last visible window closes on macOS', () => {
+    const args = chromeLaunchArgs(['--fingerprint=123'], '/profiles/work', 43123, 'darwin');
+
+    expect(args).toContain('--disable-features=DestroyProfileOnBrowserClose');
   });
 });
 

--- a/src/browser/runtime/local-cloak/chrome-launch.ts
+++ b/src/browser/runtime/local-cloak/chrome-launch.ts
@@ -53,7 +53,12 @@ export async function allocateNonzeroLoopbackPort(): Promise<number> {
   return port;
 }
 
-export function chromeLaunchArgs(baseArgs: readonly string[], userDataDir: string, port: number): string[] {
+export function chromeLaunchArgs(
+  baseArgs: readonly string[],
+  userDataDir: string,
+  port: number,
+  platform: NodeJS.Platform,
+): string[] {
   const filtered = baseArgs.filter(arg => arg !== '--enable-automation'
     && !arg.startsWith('--headless')
     && arg !== '--remote-debugging-pipe'
@@ -62,6 +67,7 @@ export function chromeLaunchArgs(baseArgs: readonly string[], userDataDir: strin
     && !arg.startsWith('--user-data-dir='));
   return [
     ...filtered,
+    ...(platform === 'darwin' ? ['--disable-features=DestroyProfileOnBrowserClose'] : []),
     `--user-data-dir=${userDataDir}`,
     '--remote-debugging-address=127.0.0.1',
     `--remote-debugging-port=${port}`,
@@ -140,7 +146,7 @@ export async function launchChromePersistentContext(
     let pids: number[] = [];
     let launchedPid: number | undefined;
     try {
-      const args = chromeLaunchArgs(launchOptions.args ?? [], options.userDataDir, port);
+      const args = chromeLaunchArgs(launchOptions.args ?? [], options.userDataDir, port, deps.platform);
       launchedPid = await deps.launch(executablePath, args, deps.platform);
       const endpoint = `http://127.0.0.1:${port}`;
       const deadline = deps.now() + READINESS_TIMEOUT_MS;


### PR DESCRIPTION
## Summary

- pass the runtime platform into installed-Chrome launch argument construction
- disable DestroyProfileOnBrowserClose for installed Google Chrome on macOS
- leave Windows and Linux launch arguments unchanged

## Why

When Doctor closes its only visible probe window, macOS Chrome can unload the profile despite Webcmd retaining a hidden CDP keeper target. Chrome may then terminate with EXC_BREAKPOINT / SIGTRAP. The Cloak macOS launcher already applies this protection.

## Verification

- focused Chrome launcher test failed before the production change and passes afterward
- relevant launcher, session-manager, and Doctor tests: 131 passed
- npm run typecheck
- npm run build
- npm test: 3,483 passed; 92 skipped