### PR TITLE
fix(browser): use monotonic capture timeout

### DIFF
--- a/src/browser/dom-helpers.test.ts
+++ b/src/browser/dom-helpers.test.ts
@@ -49,6 +49,25 @@ describe('waitForCaptureJs', () => {
     delete g.window;
   });
 
+  it('uses monotonic elapsed time when the wall clock jumps forward', async () => {
+    const g = globalThis as unknown as Record<string, unknown>;
+    const captured: unknown[] = [];
+    const originalDateNow = Date.now;
+    let calls = 0;
+    g.__webcmd_xhr = captured;
+    g.window = g;
+    Date.now = () => (calls++ === 0 ? 0 : 60_000);
+    try {
+      const promise = eval(waitForCaptureJs(200)) as Promise<string>;
+      setTimeout(() => captured.push({ data: 'late after wall-clock jump' }), 20);
+      await expect(promise).resolves.toBe('captured');
+    } finally {
+      Date.now = originalDateNow;
+      delete g.__webcmd_xhr;
+      delete g.window;
+    }
+  });
+
   it('resolves immediately when __webcmd_xhr already has data', async () => {
     const g = globalThis as unknown as Record<string, unknown>;
     g.__webcmd_xhr = [{ data: 'already here' }];

--- a/src/browser/dom-helpers.ts
+++ b/src/browser/dom-helpers.ts
@@ -213,10 +213,10 @@ export function waitForDomStableJs(maxMs: number, quietMs: number): string {
 export function waitForCaptureJs(maxMs: number): string {
   return `
     new Promise((resolve, reject) => {
-      const deadline = Date.now() + ${maxMs};
+      const deadline = performance.now() + ${maxMs};
       const check = () => {
         if ((window.__webcmd_xhr || []).length > 0) return resolve('captured');
-        if (Date.now() > deadline) return reject(new Error('No network capture within ${maxMs / 1000}s'));
+        if (performance.now() > deadline) return reject(new Error('No network capture within ${maxMs / 1000}s'));
         setTimeout(check, 100);
       };
       check();


### PR DESCRIPTION
## Summary

Use a monotonic clock for browser network-capture waits.

`waitForCaptureJs()` currently derives its deadline from `Date.now()`. If the host wall clock jumps forward while the wait is active, the capture can time out before the requested elapsed duration has actually passed. `performance.now()` is monotonic and matches the semantics of an elapsed-time budget.

## Regression coverage

Adds a focused test that jumps `Date.now()` forward by 60 seconds while a capture arrives normally. The test fails with the wall-clock deadline and passes with the monotonic deadline.

## Verification

- `npm run typecheck` — pass
- `npm run build` — pass
- `npx vitest run --project unit src/browser/dom-helpers.test.ts` — 10/10 pass
- `git diff --check` — pass

The aggregate unit suite also exposes unrelated timing/process flakes on this host; an unmodified `main` checkout reproduces the Electron launcher timeout. The changed `dom-helpers` surface remains green.
