### PR TITLE
fix: prune stale stable-root skill symlinks on add/update

### DIFF
--- a/src/skills.test.ts
+++ b/src/skills.test.ts
@@ -451,6 +451,33 @@ describe('webcmd skills content', () => {
     expect(() => updateWebcmdSkill({ packageRoot, homeDir })).toThrow(ArgumentError);
   });
 
+  it('prunes stale stable-root skill symlinks', () => {
+    const packageRoot = makePackageRoot();
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-home-'));
+    const staleLink = path.join(homeDir, '.webcmd', 'skills', 'some-retired-skill');
+    fs.mkdirSync(path.dirname(staleLink), { recursive: true });
+    fs.symlinkSync('/tmp', staleLink, 'dir');
+
+    const added = addWebcmdSkills({ packageRoot, homeDir });
+
+    expect(() => fs.lstatSync(staleLink)).toThrow();
+    expect(added.skills.map((skill) => skill.name)).toEqual(['webcmd-browser']);
+    expect(fs.lstatSync(added.skills[0].stableLink).isSymbolicLink()).toBe(true);
+    expect(real(added.skills[0].stableLink)).toBe(real(added.skills[0].source));
+  });
+
+  it('leaves non-symlink stable-root entries untouched', () => {
+    const packageRoot = makePackageRoot();
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-home-'));
+    const leftover = path.join(homeDir, '.webcmd', 'skills', 'user-owned-skill');
+    fs.mkdirSync(leftover, { recursive: true });
+    fs.writeFileSync(path.join(leftover, 'keep.txt'), 'keep');
+
+    expect(() => addWebcmdSkills({ packageRoot, homeDir })).not.toThrow();
+    expect(fs.statSync(leftover).isDirectory()).toBe(true);
+    expect(fs.readFileSync(path.join(leftover, 'keep.txt'), 'utf8')).toBe('keep');
+  });
+
   it('removes bundled skill links from one provider and scope at a time', () => {
     const packageRoot = makePackageRoot();
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webcmd-home-'));

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -123,12 +123,23 @@ function updateStableSkillLinks(options: WebcmdSkillOptions): WebcmdSkillLink[] 
     throw new ArgumentError(`No Webcmd skills found: ${skillsRoot}`, 'Install a package that includes skills/*/SKILL.md.');
   }
 
-  return skills.map((skill) => {
+  const stableRoot = path.join(options.homeDir ?? os.homedir(), '.webcmd', 'skills');
+  const currentNames = new Set(skills.map((skill) => skill.name));
+  const links = skills.map((skill) => {
     const source = path.join(skillsRoot, skill.name);
-    const stableLink = path.join(options.homeDir ?? os.homedir(), '.webcmd', 'skills', skill.name);
+    const stableLink = path.join(stableRoot, skill.name);
     replaceDirectorySymlink(source, stableLink);
     return { name: skill.name, source, stableLink };
   });
+
+  if (fs.existsSync(stableRoot)) {
+    for (const entry of fs.readdirSync(stableRoot, { withFileTypes: true })) {
+      if (currentNames.has(entry.name)) continue;
+      if (entry.isSymbolicLink()) fs.unlinkSync(path.join(stableRoot, entry.name));
+    }
+  }
+
+  return links;
 }
 
 function destinationFor(name: string, provider: SkillProvider | undefined, scope: SkillScope, options: WebcmdSkillOptions): string {


### PR DESCRIPTION
## Summary
- `~/.webcmd/skills/<name>` is a stable-link directory that `updateStableSkillLinks()` maintains (shared by `skills add` and `skills update`): one symlink per skill bundled by the running package. It only ever created/refreshed entries for the current bundle, never removing ones left over from a different `packageRoot` (an older checkout, a deleted worktree) that once bundled more or differently-named skills.
- Found in production: a real `~/.webcmd/skills/` had 7 symlinks, 6 dangling after an unrelated git worktree was removed, because nothing had ever pruned them.
- `updateStableSkillLinks` now removes any stable-root entry that is a symlink and isn't part of the current skill set, after refreshing the current ones. A non-symlink entry there is left completely alone. Runs silently as part of both `add`/`update` — no CLI or result-shape change.

## Test plan
- [x] `npx vitest run src/skills.test.ts` — 27/27 passed (2 new: prunes a stale symlink, leaves a non-symlink entry untouched)
- [x] Full suite after build: 3622 passed, 81 skipped, 0 real failures (6 pre-existing e2e/smoke failures are a `plugins/` fixture gap present even on a plain checkout, unrelated to this change)
- [x] `npm run typecheck` / `npm run build` — both pass
- [x] Manual smoke: planted a dangling symlink directly in a scratch `HOME`'s `.webcmd/skills/`, ran `skills add --provider agents --scope user --json` — the stale symlink is gone afterward, `webcmd-browser`'s stable link is correct
