### PR TITLE
test(hosted): force file credential backend in differential CLI spawns

### DIFF
--- a/src/hosted/programmatic-differential.test.ts
+++ b/src/hosted/programmatic-differential.test.ts
@@ -43,6 +43,7 @@ async function runInstalled(argv: string[]): Promise<{ exitCode: number; stdout:
       env: {
         PATH: process.env.PATH ?? '', HOME: configDir, WEBCMD_CONFIG_DIR: configDir,
         NO_COLOR: '1', COLUMNS: '80', CI: '1', WEBCMD_NO_UPDATE_CHECK: '1',
+        WEBCMD_CREDENTIAL_BACKEND: 'file',
       },
       maxBuffer: 32 * 1024 * 1024,
     });


### PR DESCRIPTION
## Summary
- `programmatic-differential.test.ts`'s `runInstalled()` spawns the real built CLI as a genuine child process on real darwin, with a fixture config carrying a legacy inline `apiKey` that triggers credential migration on first load.
- Without `WEBCMD_CREDENTIAL_BACKEND=file` in that spawned process's env, migration detects real macOS Keychain availability and attempts a real Keychain `put` (then `delete` on failure) before falling back to the file store — roughly doubling this test's runtime, and in a sandboxed/headless exec environment with no accessible keychain session, surfacing a real "Keychain Not Found" system dialog.
- Forces the file backend the same way `main-lifecycle.test.ts` and `config.test.ts` already do for their own spawned/in-process credential paths.

## Root cause (found via bisection)
Ran each `src/hosted/*.test.ts` and daemon-related test file individually against the real macOS unified log (`log show --predicate 'process == "security"'`), correlating timestamps. Two `SecKeychainSearchCreateFromAttributes` events landed precisely inside this file's run window — the only file that took ~10s instead of ~1s. After the fix, that same file drops to ~4.6s with zero keychain calls in its window.

## Test plan
- [x] `npx vitest run src/hosted/programmatic-differential.test.ts` — 43/43 pass, runtime ~10s → ~4.6s
- [x] Full suite: `npm test` — 203/203 files, 3593 passed + 2 skipped, typecheck clean
- [x] Confirmed zero `security` invocations during this file's run window after the fix (previously 2, a reproducible put+delete pair)
- [x] Confirmed no orphaned daemon or webcmd process left running after any run

🤖 Generated with [Claude Code](https://claude.com/claude-code)