### PR TITLE
feat: persist per-SLAB-profile agent behavior and route humanizer input

### DIFF
--- a/src/browser/humanizer/config.ts
+++ b/src/browser/humanizer/config.ts
@@ -73,6 +73,7 @@ export type HumanPreset = 'default' | 'careful';
 export type HumanActionOptions = Partial<HumanConfig> & {
   timeout?: number;
   force?: boolean;
+  sensitive?: boolean;
   human_config?: Partial<HumanConfig>;
 };
 

--- a/src/browser/humanizer/config.ts
+++ b/src/browser/humanizer/config.ts
@@ -249,7 +249,22 @@ export function randIntRange(range: [number, number]): number {
   return randInt(range[0], range[1]);
 }
 
-/** Sleep for `ms` milliseconds. */
-export function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
+/** Sleep for `ms` milliseconds, unless `signal` is aborted first. */
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timeout);
+      signal?.removeEventListener('abort', onAbort);
+      reject(signal!.reason);
+    };
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
 }

--- a/src/browser/humanizer/config.ts
+++ b/src/browser/humanizer/config.ts
@@ -80,7 +80,7 @@ export type HumanActionOptions = Partial<HumanConfig> & {
 // Default preset
 // ---------------------------------------------------------------------------
 
-const DEFAULT_CONFIG: HumanConfig = {
+export const DEFAULT_CONFIG: Readonly<HumanConfig> = {
   // Keyboard
   typing_delay: 70,
   typing_delay_spread: 40,

--- a/src/browser/humanizer/elementhandle.ts
+++ b/src/browser/humanizer/elementhandle.ts
@@ -122,6 +122,7 @@ export function patchSingleElementHandle(
   rawKb: RawKeyboard,
   originals: any,
   stealth: any,
+  signal?: AbortSignal,
 ): void {
   if ((el as any)._humanPatched) return;
   const handles = patchedHandles.get(page) ?? new Map();
@@ -152,14 +153,14 @@ export function patchSingleElementHandle(
   // --- Nested elements are also patched ---
   (el as any).$ = async (selector: string) => {
     const child = await origEl$(selector);
-    if (child) patchSingleElementHandle(child, page, cfg, cursor, raw, rawKb, originals, stealth);
+    if (child) patchSingleElementHandle(child, page, cfg, cursor, raw, rawKb, originals, stealth, signal);
     return child;
   };
 
   (el as any).$$ = async (selector: string) => {
     const children = await origEl$$(selector);
     for (const child of children) {
-      patchSingleElementHandle(child, page, cfg, cursor, raw, rawKb, originals, stealth);
+      patchSingleElementHandle(child, page, cfg, cursor, raw, rawKb, originals, stealth, signal);
     }
     return children;
   };
@@ -170,7 +171,7 @@ export function patchSingleElementHandle(
     timeout?: number;
   }) => {
     const child = await origElWaitForSelector(selector, options ?? {});
-    if (child) patchSingleElementHandle(child, page, cfg, cursor, raw, rawKb, originals, stealth);
+    if (child) patchSingleElementHandle(child, page, cfg, cursor, raw, rawKb, originals, stealth, signal);
     return child;
   };
 
@@ -195,7 +196,7 @@ export function patchSingleElementHandle(
       const { cursorX, cursorY } = await humanScrollIntoView(
         page, raw,
         () => el.boundingBox(),
-        cursor.x, cursor.y, callCfg,
+        cursor.x, cursor.y, callCfg, signal,
       );
       cursor.x = cursorX;
       cursor.y = cursorY;
@@ -208,10 +209,10 @@ export function patchSingleElementHandle(
     const target = clickTarget(box, isInp, callCfg);
 
     if (callCfg.idle_between_actions) {
-      await humanIdle(raw, cursor.x, cursor.y, callCfg);
+      await humanIdle(raw, cursor.x, cursor.y, callCfg, signal);
     }
 
-    await humanMove(raw, cursor.x, cursor.y, target.x, target.y, callCfg);
+    await humanMove(raw, cursor.x, cursor.y, target.x, target.y, callCfg, signal);
     cursor.x = target.x;
     cursor.y = target.y;
     return { box, isInp };
@@ -237,7 +238,7 @@ export function patchSingleElementHandle(
     const info = await moveToElement(callCfg);
     if (!info) return origElClick(options);
     if (!force) await checkPointerEventsHandle(el, cursor.x, cursor.y, Math.min(remainingMs(), 5000));
-    await humanClick(raw, info.isInp, callCfg);
+    await humanClick(raw, info.isInp, callCfg, signal);
   };
 
   // --- el.dblclick() ---
@@ -260,7 +261,7 @@ export function patchSingleElementHandle(
     if (!info) return origElDblclick(options);
     if (!force) await checkPointerEventsHandle(el, cursor.x, cursor.y, Math.min(remainingMs(), 5000));
     await raw.down({ clickCount: 2 });
-    await sleep(rand(30, 60));
+    await sleep(rand(30, 60), signal);
     await raw.up({ clickCount: 2 });
   };
 
@@ -295,12 +296,12 @@ export function patchSingleElementHandle(
     const info = await moveToElement(callCfg);
     if (!info) return origElType(text, options);
     if (!force) await checkPointerEventsHandle(el, cursor.x, cursor.y, Math.min(remainingMs(), 5000));
-    await humanClick(raw, info.isInp, callCfg);
-    await sleep(rand(100, 250));
+    await humanClick(raw, info.isInp, callCfg, signal);
+    await sleep(rand(100, 250), signal);
     let cdpSession: CDPSession | null = null;
     try { cdpSession = await stealth?.getCdpSession(); } catch {}
     const target = await elementHumanTypeTarget(el, options?.sensitive);
-    await humanType(page, rawKb, text, callCfg, cdpSession, target);
+    await humanType(page, rawKb, text, callCfg, cdpSession, target, undefined, signal);
   };
 
   // --- el.fill() ---
@@ -317,23 +318,23 @@ export function patchSingleElementHandle(
     const info = await moveToElement(callCfg);
     if (!info) return origElFill(value, options);
     if (!force) await checkPointerEventsHandle(el, cursor.x, cursor.y, Math.min(remainingMs(), 5000));
-    await humanClick(raw, info.isInp, callCfg);
-    await sleep(rand(100, 250));
+    await humanClick(raw, info.isInp, callCfg, signal);
+    await sleep(rand(100, 250), signal);
     await originals.keyboardPress(SELECT_ALL);
-    await sleep(rand(30, 80));
+    await sleep(rand(30, 80), signal);
     await originals.keyboardPress('Backspace');
-    await sleep(rand(50, 150));
+    await sleep(rand(50, 150), signal);
     let cdpSession: CDPSession | null = null;
     try { cdpSession = await stealth?.getCdpSession(); } catch {}
     const target = await elementHumanTypeTarget(el, options?.sensitive);
-    await humanType(page, rawKb, value, callCfg, cdpSession, target);
+    await humanType(page, rawKb, value, callCfg, cdpSession, target, undefined, signal);
   };
 
   // --- el.press() ---
   (el as any).press = async (key: string, options?: { delay?: number; noWaitAfter?: boolean; timeout?: number }) => {
-    await sleep(rand(20, 60));
+    await sleep(rand(20, 60), signal);
     await originals.keyboardDown(key);
-    await sleep(randRange(cfg.key_hold));
+    await sleep(randRange(cfg.key_hold), signal);
     await originals.keyboardUp(key);
   };
 
@@ -350,8 +351,8 @@ export function patchSingleElementHandle(
     if (!force) await ensureActionableHandle(el, CHECKS_FOCUS, remainingMs(), force);
     const info = await moveToElement();
     if (!info) return origElSelectOption(values, options);
-    await humanClick(raw, false, cfg);
-    await sleep(rand(100, 300));
+    await humanClick(raw, false, cfg, signal);
+    await sleep(rand(100, 300), signal);
     return origElSelectOption(values, options);
   };
 
@@ -375,7 +376,7 @@ export function patchSingleElementHandle(
     const info = await moveToElement();
     if (!info) return origElCheck(options);
     if (!force) await checkPointerEventsHandle(el, cursor.x, cursor.y, Math.min(remainingMs(), 5000));
-    await humanClick(raw, info.isInp, cfg);
+    await humanClick(raw, info.isInp, cfg, signal);
   };
 
   // --- el.uncheck() ---
@@ -398,7 +399,7 @@ export function patchSingleElementHandle(
     const info = await moveToElement();
     if (!info) return origElUncheck(options);
     if (!force) await checkPointerEventsHandle(el, cursor.x, cursor.y, Math.min(remainingMs(), 5000));
-    await humanClick(raw, info.isInp, cfg);
+    await humanClick(raw, info.isInp, cfg, signal);
   };
 
   // --- el.setChecked() ---
@@ -422,7 +423,7 @@ export function patchSingleElementHandle(
       const info = await moveToElement();
       if (!info) return origElSetChecked(checked, options);
       if (!force) await checkPointerEventsHandle(el, cursor.x, cursor.y, Math.min(remainingMs(), 5000));
-      await humanClick(raw, info.isInp, cfg);
+      await humanClick(raw, info.isInp, cfg, signal);
     };
   }
 
@@ -437,7 +438,7 @@ export function patchSingleElementHandle(
   }) => {
     const info = await moveToElement();
     if (!info) return origElTap(options);
-    await humanClick(raw, info.isInp, cfg);
+    await humanClick(raw, info.isInp, cfg, signal);
   };
 
   // --- el.focus() ---
@@ -463,7 +464,7 @@ export function patchSingleElementHandle(
         const { cursorX, cursorY } = await humanScrollIntoView(
           page, raw,
           () => el.boundingBox(),
-          cursor.x, cursor.y, callCfg,
+          cursor.x, cursor.y, callCfg, signal,
         );
         cursor.x = cursorX;
         cursor.y = cursorY;
@@ -487,13 +488,14 @@ export function patchPageElementHandles(
   rawKb: RawKeyboard,
   originals: any,
   stealth: any,
+  signal?: AbortSignal,
 ): void {
   // Patch page.$() — only if the method exists
   if (typeof page.$ === 'function') {
     const orig$ = page.$.bind(page);
     (page as any).$ = async (selector: string) => {
       const el = await orig$(selector);
-      if (el) patchSingleElementHandle(el, page, cfg, cursor, raw, rawKb, originals, stealth);
+      if (el) patchSingleElementHandle(el, page, cfg, cursor, raw, rawKb, originals, stealth, signal);
       return el;
     };
   }
@@ -504,7 +506,7 @@ export function patchPageElementHandles(
     (page as any).$$ = async (selector: string) => {
       const els = await orig$$(selector);
       for (const el of els) {
-        patchSingleElementHandle(el, page, cfg, cursor, raw, rawKb, originals, stealth);
+        patchSingleElementHandle(el, page, cfg, cursor, raw, rawKb, originals, stealth, signal);
       }
       return els;
     };
@@ -519,7 +521,7 @@ export function patchPageElementHandles(
       timeout?: number;
     }) => {
       const el = await origWaitForSelector(selector, options ?? {});
-      if (el) patchSingleElementHandle(el, page, cfg, cursor, raw, rawKb, originals, stealth);
+      if (el) patchSingleElementHandle(el, page, cfg, cursor, raw, rawKb, originals, stealth, signal);
       return el;
     };
   }
@@ -539,13 +541,14 @@ export function patchFrameElementHandles(
   rawKb: RawKeyboard,
   originals: any,
   stealth: any,
+  signal?: AbortSignal,
 ): void {
   // Patch frame.$() — only if the method exists
   if (typeof frame.$ === 'function') {
     const origFrame$ = frame.$.bind(frame);
     (frame as any).$ = async (selector: string) => {
       const el = await origFrame$(selector);
-      if (el) patchSingleElementHandle(el, page, cfg, cursor, raw, rawKb, originals, stealth);
+      if (el) patchSingleElementHandle(el, page, cfg, cursor, raw, rawKb, originals, stealth, signal);
       return el;
     };
   }
@@ -556,7 +559,7 @@ export function patchFrameElementHandles(
     (frame as any).$$ = async (selector: string) => {
       const els = await origFrame$$(selector);
       for (const el of els) {
-        patchSingleElementHandle(el, page, cfg, cursor, raw, rawKb, originals, stealth);
+        patchSingleElementHandle(el, page, cfg, cursor, raw, rawKb, originals, stealth, signal);
       }
       return els;
     };
@@ -571,7 +574,7 @@ export function patchFrameElementHandles(
       timeout?: number;
     }) => {
       const el = await origFrameWaitForSelector(selector, options ?? {});
-      if (el) patchSingleElementHandle(el, page, cfg, cursor, raw, rawKb, originals, stealth);
+      if (el) patchSingleElementHandle(el, page, cfg, cursor, raw, rawKb, originals, stealth, signal);
       return el;
     };
   }

--- a/src/browser/humanizer/elementhandle.ts
+++ b/src/browser/humanizer/elementhandle.ts
@@ -20,7 +20,7 @@ import type { Page, Frame, ElementHandle, CDPSession } from 'playwright-core';
 import type { HumanConfig, HumanActionOptions } from './config.js';
 import { rand, randRange, sleep, mergeConfig } from './config.js';
 import { RawMouse, RawKeyboard, humanMove, humanClick, clickTarget, humanIdle } from './mouse.js';
-import { humanType } from './keyboard.js';
+import { humanType, type HumanTypeTarget } from './keyboard.js';
 import { humanScrollIntoView } from './scroll.js';
 import {
   ensureActionableHandle, checkPointerEventsHandle,
@@ -82,6 +82,19 @@ async function isInputElementHandle(
   } catch {
     return false;
   }
+}
+
+async function elementHumanTypeTarget(
+  el: ElementHandle,
+  sensitive?: boolean,
+): Promise<HumanTypeTarget | undefined> {
+  return el.evaluate((node: Element, sensitive: boolean) => ({
+    tag: node.tagName.toLowerCase(),
+    type: node.getAttribute('type'),
+    autocomplete: node.getAttribute('autocomplete'),
+    contentEditable: (node as HTMLElement).isContentEditable,
+    sensitive,
+  }), Boolean(sensitive)).catch(() => undefined);
 }
 
 
@@ -286,7 +299,8 @@ export function patchSingleElementHandle(
     await sleep(rand(100, 250));
     let cdpSession: CDPSession | null = null;
     try { cdpSession = await stealth?.getCdpSession(); } catch {}
-    await humanType(page, rawKb, text, callCfg, cdpSession);
+    const target = await elementHumanTypeTarget(el, options?.sensitive);
+    await humanType(page, rawKb, text, callCfg, cdpSession, target);
   };
 
   // --- el.fill() ---
@@ -311,7 +325,8 @@ export function patchSingleElementHandle(
     await sleep(rand(50, 150));
     let cdpSession: CDPSession | null = null;
     try { cdpSession = await stealth?.getCdpSession(); } catch {}
-    await humanType(page, rawKb, value, callCfg, cdpSession);
+    const target = await elementHumanTypeTarget(el, options?.sensitive);
+    await humanType(page, rawKb, value, callCfg, cdpSession, target);
   };
 
   // --- el.press() ---

--- a/src/browser/humanizer/elementhandle.ts
+++ b/src/browser/humanizer/elementhandle.ts
@@ -49,6 +49,10 @@ export function restorePatchedElementHandles(page: Page): void {
 // --- Platform-aware select-all shortcut ---
 const SELECT_ALL = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
 
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw signal.reason ?? new Error('Humanizer has been disposed.');
+}
+
 
 // ============================================================================
 // Stealth ElementHandle input check — uses CDP DOM.describeNode
@@ -85,9 +89,31 @@ async function isInputElementHandle(
 }
 
 async function elementHumanTypeTarget(
+  cdp: CDPSession | null,
   el: ElementHandle,
   sensitive?: boolean,
 ): Promise<HumanTypeTarget | undefined> {
+  if (cdp) {
+    const objectId = (el as any)._objectId ?? (el as any)._impl?._objectId;
+    if (!objectId) return undefined;
+    try {
+      const result = await cdp.send('DOM.describeNode', { objectId, depth: 0 });
+      const node = (result as any).node;
+      const attributes = new Map<string, string>();
+      for (let index = 0; index < (node?.attributes?.length ?? 0); index += 2) {
+        attributes.set(node.attributes[index], node.attributes[index + 1]);
+      }
+      return {
+        tag: node?.nodeName?.toLowerCase(),
+        type: attributes.get('type') ?? null,
+        autocomplete: attributes.get('autocomplete') ?? null,
+        contentEditable: attributes.get('contenteditable') === 'true',
+        sensitive: Boolean(sensitive),
+      };
+    } catch {
+      return undefined;
+    }
+  }
   return el.evaluate((node: Element, sensitive: boolean) => ({
     tag: node.tagName.toLowerCase(),
     type: node.getAttribute('type'),
@@ -200,7 +226,10 @@ export function patchSingleElementHandle(
       );
       cursor.x = cursorX;
       cursor.y = cursorY;
-    } catch { /* let boundingBox() decide */ }
+    } catch (error) {
+      if (signal?.aborted) throw error;
+      // Let boundingBox() decide whether to proceed or fall back.
+    }
 
     const box = await el.boundingBox();
     if (!box) return null;
@@ -236,7 +265,10 @@ export function patchSingleElementHandle(
     const remainingMs = () => Math.max(0, deadline - Date.now());
     if (!force) await ensureActionableHandle(el, CHECKS_CLICK, remainingMs(), force);
     const info = await moveToElement(callCfg);
-    if (!info) return origElClick(options);
+    if (!info) {
+      throwIfAborted(signal);
+      return origElClick(options);
+    }
     if (!force) await checkPointerEventsHandle(el, cursor.x, cursor.y, Math.min(remainingMs(), 5000));
     await humanClick(raw, info.isInp, callCfg, signal);
   };
@@ -258,7 +290,10 @@ export function patchSingleElementHandle(
     const remainingMs = () => Math.max(0, deadline - Date.now());
     if (!force) await ensureActionableHandle(el, CHECKS_CLICK, remainingMs(), force);
     const info = await moveToElement(callCfg);
-    if (!info) return origElDblclick(options);
+    if (!info) {
+      throwIfAborted(signal);
+      return origElDblclick(options);
+    }
     if (!force) await checkPointerEventsHandle(el, cursor.x, cursor.y, Math.min(remainingMs(), 5000));
     await raw.down({ clickCount: 2 });
     await sleep(rand(30, 60), signal);
@@ -279,7 +314,10 @@ export function patchSingleElementHandle(
     const remainingMs = () => Math.max(0, deadline - Date.now());
     if (!force) await ensureActionableHandle(el, CHECKS_HOVER, remainingMs(), force);
     const info = await moveToElement(callCfg);
-    if (!info) return origElHover(options);
+    if (!info) {
+      throwIfAborted(signal);
+      return origElHover(options);
+    }
   };
 
   // --- el.type() ---
@@ -294,13 +332,16 @@ export function patchSingleElementHandle(
     const remainingMs = () => Math.max(0, deadline - Date.now());
     if (!force) await ensureActionableHandle(el, CHECKS_INPUT, remainingMs(), force);
     const info = await moveToElement(callCfg);
-    if (!info) return origElType(text, options);
+    if (!info) {
+      throwIfAborted(signal);
+      return origElType(text, options);
+    }
     if (!force) await checkPointerEventsHandle(el, cursor.x, cursor.y, Math.min(remainingMs(), 5000));
     await humanClick(raw, info.isInp, callCfg, signal);
     await sleep(rand(100, 250), signal);
     let cdpSession: CDPSession | null = null;
     try { cdpSession = await stealth?.getCdpSession(); } catch {}
-    const target = await elementHumanTypeTarget(el, options?.sensitive);
+    const target = await elementHumanTypeTarget(cdpSession, el, options?.sensitive);
     await humanType(page, rawKb, text, callCfg, cdpSession, target, undefined, signal);
   };
 
@@ -316,7 +357,10 @@ export function patchSingleElementHandle(
     const remainingMs = () => Math.max(0, deadline - Date.now());
     if (!force) await ensureActionableHandle(el, CHECKS_INPUT, remainingMs(), force);
     const info = await moveToElement(callCfg);
-    if (!info) return origElFill(value, options);
+    if (!info) {
+      throwIfAborted(signal);
+      return origElFill(value, options);
+    }
     if (!force) await checkPointerEventsHandle(el, cursor.x, cursor.y, Math.min(remainingMs(), 5000));
     await humanClick(raw, info.isInp, callCfg, signal);
     await sleep(rand(100, 250), signal);
@@ -326,7 +370,7 @@ export function patchSingleElementHandle(
     await sleep(rand(50, 150), signal);
     let cdpSession: CDPSession | null = null;
     try { cdpSession = await stealth?.getCdpSession(); } catch {}
-    const target = await elementHumanTypeTarget(el, options?.sensitive);
+    const target = await elementHumanTypeTarget(cdpSession, el, options?.sensitive);
     await humanType(page, rawKb, value, callCfg, cdpSession, target, undefined, signal);
   };
 
@@ -350,7 +394,10 @@ export function patchSingleElementHandle(
     const remainingMs = () => Math.max(0, deadline - Date.now());
     if (!force) await ensureActionableHandle(el, CHECKS_FOCUS, remainingMs(), force);
     const info = await moveToElement();
-    if (!info) return origElSelectOption(values, options);
+    if (!info) {
+      throwIfAborted(signal);
+      return origElSelectOption(values, options);
+    }
     await humanClick(raw, false, cfg, signal);
     await sleep(rand(100, 300), signal);
     return origElSelectOption(values, options);
@@ -374,7 +421,10 @@ export function patchSingleElementHandle(
       if (checked) return;
     } catch {}
     const info = await moveToElement();
-    if (!info) return origElCheck(options);
+    if (!info) {
+      throwIfAborted(signal);
+      return origElCheck(options);
+    }
     if (!force) await checkPointerEventsHandle(el, cursor.x, cursor.y, Math.min(remainingMs(), 5000));
     await humanClick(raw, info.isInp, cfg, signal);
   };
@@ -397,7 +447,10 @@ export function patchSingleElementHandle(
       if (!checked) return;
     } catch {}
     const info = await moveToElement();
-    if (!info) return origElUncheck(options);
+    if (!info) {
+      throwIfAborted(signal);
+      return origElUncheck(options);
+    }
     if (!force) await checkPointerEventsHandle(el, cursor.x, cursor.y, Math.min(remainingMs(), 5000));
     await humanClick(raw, info.isInp, cfg, signal);
   };
@@ -421,7 +474,10 @@ export function patchSingleElementHandle(
         if (current === checked) return;
       } catch {}
       const info = await moveToElement();
-      if (!info) return origElSetChecked(checked, options);
+      if (!info) {
+        throwIfAborted(signal);
+        return origElSetChecked(checked, options);
+      }
       if (!force) await checkPointerEventsHandle(el, cursor.x, cursor.y, Math.min(remainingMs(), 5000));
       await humanClick(raw, info.isInp, cfg, signal);
     };
@@ -437,7 +493,10 @@ export function patchSingleElementHandle(
     trial?: boolean;
   }) => {
     const info = await moveToElement();
-    if (!info) return origElTap(options);
+    if (!info) {
+      throwIfAborted(signal);
+      return origElTap(options);
+    }
     await humanClick(raw, info.isInp, cfg, signal);
   };
 
@@ -468,7 +527,8 @@ export function patchSingleElementHandle(
         );
         cursor.x = cursorX;
         cursor.y = cursorY;
-      } catch {
+      } catch (error) {
+        if (signal?.aborted) throw error;
         return origElScrollIntoViewIfNeeded(options);
       }
     };

--- a/src/browser/humanizer/index.ts
+++ b/src/browser/humanizer/index.ts
@@ -245,7 +245,7 @@ async function selectorHumanTypeTarget(
   if (stealth) {
     try {
       const escaped = JSON.stringify(selector);
-      return await stealth.evaluate(`
+      const target = await stealth.evaluate(`
         (() => {
           const el = document.querySelector(${escaped});
           return el ? {
@@ -257,6 +257,7 @@ async function selectorHumanTypeTarget(
           } : undefined;
         })()
       `);
+      if (target) return target;
     } catch {
       // Fall through to page.evaluate.
     }

--- a/src/browser/humanizer/index.ts
+++ b/src/browser/humanizer/index.ts
@@ -313,7 +313,7 @@ async function isSelectorFocused(
 /**
  * Replace page methods with human-like implementations.
  */
-export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
+export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState, signal?: AbortSignal): void {
   const originals = {
     click: page.click.bind(page),
     dblclick: page.dblclick.bind(page),
@@ -388,7 +388,7 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
   }) => {
     const response = await originals.goto(url, options);
     stealth.invalidate();
-    patchFrames(page, cfg, cursor, raw, rawKb, originals, stealth);
+    patchFrames(page, cfg, cursor, raw, rawKb, originals, stealth, signal);
     return response;
   };
 
@@ -406,9 +406,9 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
       await ensureActionable(page, selector, CHECKS_CLICK, remainingMs(), force);
     }
     if (callCfg.idle_between_actions) {
-      await humanIdle(raw, cursor.x, cursor.y, callCfg);
+      await humanIdle(raw, cursor.x, cursor.y, callCfg, signal);
     }
-    const { box, cursorX, cursorY, didScroll } = await scrollToElement(page, raw, selector, cursor.x, cursor.y, callCfg, remainingMs());
+    const { box, cursorX, cursorY, didScroll } = await scrollToElement(page, raw, selector, cursor.x, cursor.y, callCfg, remainingMs(), signal);
     cursor.x = cursorX;
     cursor.y = cursorY;
     const isInput = await isInputElement(stealth, page, selector);
@@ -421,10 +421,10 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
     if (!force) {
       await checkPointerEvents(page, selector, target.x, target.y, stealth, remainingMs());
     }
-    await humanMove(raw, cursor.x, cursor.y, target.x, target.y, callCfg);
+    await humanMove(raw, cursor.x, cursor.y, target.x, target.y, callCfg, signal);
     cursor.x = target.x;
     cursor.y = target.y;
-    await humanClick(raw, isInput, callCfg);
+    await humanClick(raw, isInput, callCfg, signal);
   };
 
   // --- dblclick ---
@@ -438,9 +438,9 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
 
     if (!force) await ensureActionable(page, selector, CHECKS_CLICK, remainingMs(), force);
     if (callCfg.idle_between_actions) {
-      await humanIdle(raw, cursor.x, cursor.y, callCfg);
+      await humanIdle(raw, cursor.x, cursor.y, callCfg, signal);
     }
-    const { box, cursorX, cursorY, didScroll } = await scrollToElement(page, raw, selector, cursor.x, cursor.y, callCfg, remainingMs());
+    const { box, cursorX, cursorY, didScroll } = await scrollToElement(page, raw, selector, cursor.x, cursor.y, callCfg, remainingMs(), signal);
     cursor.x = cursorX;
     cursor.y = cursorY;
     const isInput = await isInputElement(stealth, page, selector);
@@ -453,11 +453,11 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
     if (!force) {
       await checkPointerEvents(page, selector, target.x, target.y, stealth, remainingMs());
     }
-    await humanMove(raw, cursor.x, cursor.y, target.x, target.y, callCfg);
+    await humanMove(raw, cursor.x, cursor.y, target.x, target.y, callCfg, signal);
     cursor.x = target.x;
     cursor.y = target.y;
     await raw.down({ clickCount: 2 });
-    await sleep(rand(30, 60));
+    await sleep(rand(30, 60), signal);
     await raw.up({ clickCount: 2 });
   };
 
@@ -473,9 +473,9 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
 
     if (!force && !skipChecks) await ensureActionable(page, selector, CHECKS_HOVER, remainingMs(), force);
     if (callCfg.idle_between_actions) {
-      await humanIdle(raw, cursor.x, cursor.y, callCfg);
+      await humanIdle(raw, cursor.x, cursor.y, callCfg, signal);
     }
-    const { box, cursorX, cursorY, didScroll } = await scrollToElement(page, raw, selector, cursor.x, cursor.y, callCfg, remainingMs());
+    const { box, cursorX, cursorY, didScroll } = await scrollToElement(page, raw, selector, cursor.x, cursor.y, callCfg, remainingMs(), signal);
     cursor.x = cursorX;
     cursor.y = cursorY;
     let finalBox = box;
@@ -487,7 +487,7 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
     if (!force) {
       await checkPointerEvents(page, selector, target.x, target.y, stealth, remainingMs());
     }
-    await humanMove(raw, cursor.x, cursor.y, target.x, target.y, callCfg);
+    await humanMove(raw, cursor.x, cursor.y, target.x, target.y, callCfg, signal);
     cursor.x = target.x;
     cursor.y = target.y;
   };
@@ -501,12 +501,12 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
     const remainingMs = () => Math.max(0, deadline - Date.now());
 
     if (!force) await ensureActionable(page, selector, CHECKS_INPUT, remainingMs(), force);
-    await sleep(randRange(callCfg.field_switch_delay));
+    await sleep(randRange(callCfg.field_switch_delay), signal);
     await humanClickFn(selector, { _skipChecks: true, timeout: remainingMs(), force, human_config: options?.human_config } as any);
-    await sleep(rand(100, 250));
+    await sleep(rand(100, 250), signal);
     const cdp = await ensureCdp();
     const target = await selectorHumanTypeTarget(stealth, page, selector, options?.sensitive);
-    await humanType(page, rawKb, text, callCfg, cdp, target);
+    await humanType(page, rawKb, text, callCfg, cdp, target, undefined, signal);
   };
 
   // --- fill (clears existing content first) ---
@@ -518,16 +518,16 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
     const remainingMs = () => Math.max(0, deadline - Date.now());
 
     if (!force) await ensureActionable(page, selector, CHECKS_INPUT, remainingMs(), force);
-    await sleep(randRange(callCfg.field_switch_delay));
+    await sleep(randRange(callCfg.field_switch_delay), signal);
     await humanClickFn(selector, { _skipChecks: true, timeout: remainingMs(), force, human_config: options?.human_config } as any);
-    await sleep(rand(100, 250));
+    await sleep(rand(100, 250), signal);
     await originals.keyboardPress(SELECT_ALL);
-    await sleep(rand(30, 80));
+    await sleep(rand(30, 80), signal);
     await originals.keyboardPress('Backspace');
-    await sleep(rand(50, 150));
+    await sleep(rand(50, 150), signal);
     const cdp = await ensureCdp();
     const target = await selectorHumanTypeTarget(stealth, page, selector, options?.sensitive);
-    await humanType(page, rawKb, value, callCfg, cdp, target);
+    await humanType(page, rawKb, value, callCfg, cdp, target, undefined, signal);
   };
 
   // --- clear ---
@@ -541,9 +541,9 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
     if (!await isSelectorFocused(stealth, page, selector)) {
       await humanClickFn(selector, { _skipChecks: true, timeout: remainingMs(), force, human_config: options?.human_config } as any);
     }
-    await sleep(rand(50, 150));
+    await sleep(rand(50, 150), signal);
     await originals.keyboardPress(SELECT_ALL);
-    await sleep(rand(30, 80));
+    await sleep(rand(30, 80), signal);
     await originals.keyboardPress('Backspace');
   };
 
@@ -557,7 +557,7 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
 
     if (!force) await ensureActionable(page, selector, CHECKS_CHECK, remainingMs(), force);
     if (callCfg.idle_between_actions) {
-      await humanIdle(raw, cursor.x, cursor.y, callCfg);
+      await humanIdle(raw, cursor.x, cursor.y, callCfg, signal);
     }
     const checked = await originals.isChecked(selector).catch(() => false);
     if (!checked) {
@@ -575,7 +575,7 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
 
     if (!force) await ensureActionable(page, selector, CHECKS_CHECK, remainingMs(), force);
     if (callCfg.idle_between_actions) {
-      await humanIdle(raw, cursor.x, cursor.y, callCfg);
+      await humanIdle(raw, cursor.x, cursor.y, callCfg, signal);
     }
     const checked = await originals.isChecked(selector).catch(() => true);
     if (checked) {
@@ -592,7 +592,7 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
 
     if (!force) await ensureActionable(page, selector, CHECKS_FOCUS, remainingMs(), force);
     await humanHoverFn(selector, { _skipChecks: true, timeout: remainingMs(), force, human_config: options?.human_config } as any);
-    await sleep(rand(100, 300));
+    await sleep(rand(100, 300), signal);
     return originals.selectOption(selector, values, options);
   };
 
@@ -607,7 +607,7 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
     if (!await isSelectorFocused(stealth, page, selector)) {
       await humanClickFn(selector, { _skipChecks: true, timeout: remainingMs(), force, human_config: options?.human_config } as any);
     }
-    await sleep(rand(50, 150));
+    await sleep(rand(50, 150), signal);
     await originals.keyboardPress(key);
   };
 
@@ -623,10 +623,10 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
     if (!await isSelectorFocused(stealth, page, selector)) {
       await humanClickFn(selector, { _skipChecks: true, timeout: remainingMs(), force, human_config: options?.human_config } as any);
     }
-    await sleep(rand(100, 250));
+    await sleep(rand(100, 250), signal);
     const cdp = await ensureCdp();
     const target = await selectorHumanTypeTarget(stealth, page, selector, options?.sensitive);
-    await humanType(page, rawKb, text, callCfg, cdp, target);
+    await humanType(page, rawKb, text, callCfg, cdp, target, undefined, signal);
   };
 
   // --- tap ---
@@ -654,7 +654,7 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
     steps?: number;
   }) => {
     await ensureCursorInit();
-    await humanMove(raw, cursor.x, cursor.y, x, y, cfg);
+    await humanMove(raw, cursor.x, cursor.y, x, y, cfg, signal);
     cursor.x = x;
     cursor.y = y;
   };
@@ -665,16 +665,16 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
     delay?: number;
   }) => {
     await ensureCursorInit();
-    await humanMove(raw, cursor.x, cursor.y, x, y, cfg);
+    await humanMove(raw, cursor.x, cursor.y, x, y, cfg, signal);
     cursor.x = x;
     cursor.y = y;
-    await humanClick(raw, false, cfg);
+    await humanClick(raw, false, cfg, signal);
   };
 
   // --- keyboard patches ---
   page.keyboard.type = async (text: string, options?: { delay?: number }) => {
     const cdp = await ensureCdp();
-    await humanType(page, rawKb, text, cfg, cdp);
+    await humanType(page, rawKb, text, cfg, cdp, undefined, undefined, signal);
   };
 
   // Store helpers for frame patching
@@ -698,10 +698,10 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
   }).catch(() => {});
 
   // --- Patch Frame-level methods (for sub-frames) ---
-  patchFrames(page, cfg, cursor, raw, rawKb, originals, stealth);
+  patchFrames(page, cfg, cursor, raw, rawKb, originals, stealth, signal);
 
   // --- Patch ElementHandle selectors (page.$, page.$$, page.waitForSelector) ---
-  patchPageElementHandles(page, cfg, cursor, raw, rawKb, originals, stealth);
+  patchPageElementHandles(page, cfg, cursor, raw, rawKb, originals, stealth, signal);
 }
 
 
@@ -722,11 +722,12 @@ function patchFrames(
   rawKb: RawKeyboard,
   originals: any,
   stealth: StealthEval,
+  signal?: AbortSignal,
 ): void {
   for (const frame of iterFrames(page)) {
-    patchSingleFrame(frame, page, cfg, cursor, raw, rawKb, originals, stealth);
+    patchSingleFrame(frame, page, cfg, cursor, raw, rawKb, originals, stealth, signal);
     // Patch frame-level ElementHandle selectors ($, $$, waitForSelector)
-    patchFrameElementHandles(frame, page, cfg, cursor, raw, rawKb, originals, stealth);
+    patchFrameElementHandles(frame, page, cfg, cursor, raw, rawKb, originals, stealth, signal);
   }
 }
 
@@ -771,6 +772,7 @@ function patchSingleFrame(
   rawKb: RawKeyboard,
   originals: any,
   stealth: StealthEval,
+  signal?: AbortSignal,
 ): void {
   if ((frame as any)._humanPatched) return;
   const frameKeys = [
@@ -808,7 +810,7 @@ function patchSingleFrame(
   ) => {
     const callCfg = mergeConfig(cfg, options?.human_config ?? options);
     if (callCfg.idle_between_actions) {
-      await humanIdle(raw, cursor.x, cursor.y, callCfg);
+      await humanIdle(raw, cursor.x, cursor.y, callCfg, signal);
     }
 
     const locator = firstFrameLocator(frame, selector);
@@ -820,7 +822,7 @@ function patchSingleFrame(
 
     const isInput = inputBias || await isFrameInputElement(frame, selector);
     const target = clickTarget(box, isInput, callCfg);
-    await humanMove(raw, cursor.x, cursor.y, target.x, target.y, callCfg);
+    await humanMove(raw, cursor.x, cursor.y, target.x, target.y, callCfg, signal);
     cursor.x = target.x;
     cursor.y = target.y;
     return { callCfg, isInput };
@@ -832,7 +834,7 @@ function patchSingleFrame(
     const remainingMs = () => Math.max(0, deadline - Date.now());
     const moved = await moveToFrameSelector(selector, options, false, remainingMs);
     if (!moved) return origFrameClick(selector, { ...options, timeout: Math.max(1, remainingMs()) });
-    await humanClick(raw, moved.isInput, moved.callCfg);
+    await humanClick(raw, moved.isInput, moved.callCfg, signal);
   };
 
   const getFrameCdp = async () => stealth.getCdpSession().catch(() => null);
@@ -854,7 +856,7 @@ function patchSingleFrame(
     const moved = await moveToFrameSelector(selector, options, false, remainingMs);
     if (!moved) return origFrameDblclick(selector, { ...options, timeout: Math.max(1, remainingMs()) });
     await raw.down({ clickCount: 2 });
-    await sleep(rand(30, 60));
+    await sleep(rand(30, 60), signal);
     await raw.up({ clickCount: 2 });
   };
 
@@ -862,26 +864,34 @@ function patchSingleFrame(
 
   (frame as any).type = async (selector: string, text: string, options?: HumanActionOptions) => {
     const callCfg = mergeConfig(cfg, options?.human_config ?? options);
-    await sleep(randRange(callCfg.field_switch_delay));
+    await sleep(randRange(callCfg.field_switch_delay), signal);
     await frameClick(selector, options);
-    await sleep(rand(100, 250));
+    await sleep(rand(100, 250), signal);
     const cdp = await getFrameCdp();
     const target = await frameHumanTypeTarget(frame, selector, options?.sensitive);
-    await humanType(page, rawKb, text, callCfg, cdp, target).catch(() => origFrameType(selector, text, options));
+    await humanType(page, rawKb, text, callCfg, cdp, target, undefined, signal)
+      .catch(error => {
+        if (signal?.aborted) throw error;
+        return origFrameType(selector, text, options);
+      });
   };
 
   (frame as any).fill = async (selector: string, value: string, options?: HumanActionOptions) => {
     const callCfg = mergeConfig(cfg, options?.human_config ?? options);
-    await sleep(randRange(callCfg.field_switch_delay));
+    await sleep(randRange(callCfg.field_switch_delay), signal);
     await frameClick(selector, options);
-    await sleep(rand(100, 250));
+    await sleep(rand(100, 250), signal);
     await originals.keyboardPress(SELECT_ALL);
-    await sleep(rand(30, 80));
+    await sleep(rand(30, 80), signal);
     await originals.keyboardPress('Backspace');
-    await sleep(rand(50, 150));
+    await sleep(rand(50, 150), signal);
     const cdp = await getFrameCdp();
     const target = await frameHumanTypeTarget(frame, selector, options?.sensitive);
-    await humanType(page, rawKb, value, callCfg, cdp, target).catch(() => origFrameFill(selector, value, options));
+    await humanType(page, rawKb, value, callCfg, cdp, target, undefined, signal)
+      .catch(error => {
+        if (signal?.aborted) throw error;
+        return origFrameFill(selector, value, options);
+      });
   };
 
   (frame as any).check = async (selector: string, options?: HumanActionOptions) => {
@@ -900,7 +910,7 @@ function patchSingleFrame(
 
   (frame as any).selectOption = async (selector: string, values: any, options?: HumanActionOptions) => {
     await frameHover(selector, options);
-    await sleep(rand(100, 300));
+    await sleep(rand(100, 300), signal);
     return origFrameSelectOption(selector, values, options);
   };
 
@@ -908,7 +918,7 @@ function patchSingleFrame(
     if (!await isFrameSelectorFocused(frame, selector)) {
       await frameClick(selector, options);
     }
-    await sleep(rand(50, 150));
+    await sleep(rand(50, 150), signal);
     await originals.keyboardPress(key);
   };
 
@@ -917,10 +927,14 @@ function patchSingleFrame(
     if (!await isFrameSelectorFocused(frame, selector)) {
       await frameClick(selector, options);
     }
-    await sleep(rand(100, 250));
+    await sleep(rand(100, 250), signal);
     const cdp = await getFrameCdp();
     const target = await frameHumanTypeTarget(frame, selector, options?.sensitive);
-    await humanType(page, rawKb, text, callCfg, cdp, target).catch(() => origFramePressSequentially?.(selector, text, options));
+    await humanType(page, rawKb, text, callCfg, cdp, target, undefined, signal)
+      .catch(error => {
+        if (signal?.aborted) throw error;
+        return origFramePressSequentially?.(selector, text, options);
+      });
   };
 
   (frame as any).tap = async (selector: string, options?: HumanActionOptions) => {
@@ -931,9 +945,9 @@ function patchSingleFrame(
     if (!await isFrameSelectorFocused(frame, selector)) {
       await frameClick(selector, options);
     }
-    await sleep(rand(50, 150));
+    await sleep(rand(50, 150), signal);
     await originals.keyboardPress(SELECT_ALL);
-    await sleep(rand(30, 80));
+    await sleep(rand(30, 80), signal);
     await originals.keyboardPress('Backspace');
   };
 
@@ -959,11 +973,11 @@ function patchSingleFrame(
       const ty = tgtBox.y + tgtBox.height / 2;
 
       await page.mouse.move(sx, sy);
-      await sleep(rand(100, 200));
+      await sleep(rand(100, 200), signal);
       await originals.mouseDown();
-      await sleep(rand(80, 150));
+      await sleep(rand(80, 150), signal);
       await page.mouse.move(tx, ty);
-      await sleep(rand(80, 150));
+      await sleep(rand(80, 150), signal);
       await originals.mouseUp();
     } else {
       return origFrameDragAndDrop(source, target, { ...options, timeout: Math.max(1, remainingMs()) });

--- a/src/browser/humanizer/index.ts
+++ b/src/browser/humanizer/index.ts
@@ -26,7 +26,7 @@ import type { Browser, BrowserContext, Page, Frame, CDPSession } from 'playwrigh
 import type { HumanConfig, HumanActionOptions } from './config.js';
 import { resolveConfig, mergeConfig, rand, randRange, sleep } from './config.js';
 import { RawMouse, RawKeyboard, humanMove, humanClick, clickTarget, humanIdle } from './mouse.js';
-import { humanType } from './keyboard.js';
+import { humanType, type HumanTypeTarget } from './keyboard.js';
 import { scrollToElement, humanScrollIntoView } from './scroll.js';
 import { patchPageElementHandles, patchFrameElementHandles, patchSingleElementHandle } from './elementhandle.js';
 import {
@@ -234,6 +234,44 @@ async function isInputElement(
     return tag === 'input' || tag === 'textarea'
       || el.getAttribute('contenteditable') === 'true';
   }, selector).catch(() => false);
+}
+
+async function selectorHumanTypeTarget(
+  stealth: StealthEval | null,
+  page: Page,
+  selector: string,
+  sensitive?: boolean,
+): Promise<HumanTypeTarget | undefined> {
+  if (stealth) {
+    try {
+      const escaped = JSON.stringify(selector);
+      return await stealth.evaluate(`
+        (() => {
+          const el = document.querySelector(${escaped});
+          return el ? {
+            tag: el.tagName.toLowerCase(),
+            type: el.getAttribute('type'),
+            autocomplete: el.getAttribute('autocomplete'),
+            contentEditable: el.isContentEditable,
+            sensitive: ${Boolean(sensitive)},
+          } : undefined;
+        })()
+      `);
+    } catch {
+      // Fall through to page.evaluate.
+    }
+  }
+
+  return page.evaluate(({ selector, sensitive }) => {
+    const el = document.querySelector(selector);
+    return el ? {
+      tag: el.tagName.toLowerCase(),
+      type: el.getAttribute('type'),
+      autocomplete: el.getAttribute('autocomplete'),
+      contentEditable: (el as HTMLElement).isContentEditable,
+      sensitive,
+    } : undefined;
+  }, { selector, sensitive: Boolean(sensitive) }).catch(() => undefined);
 }
 
 /**
@@ -466,7 +504,8 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
     await humanClickFn(selector, { _skipChecks: true, timeout: remainingMs(), force, human_config: options?.human_config } as any);
     await sleep(rand(100, 250));
     const cdp = await ensureCdp();
-    await humanType(page, rawKb, text, callCfg, cdp);
+    const target = await selectorHumanTypeTarget(stealth, page, selector, options?.sensitive);
+    await humanType(page, rawKb, text, callCfg, cdp, target);
   };
 
   // --- fill (clears existing content first) ---
@@ -486,7 +525,8 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
     await originals.keyboardPress('Backspace');
     await sleep(rand(50, 150));
     const cdp = await ensureCdp();
-    await humanType(page, rawKb, value, callCfg, cdp);
+    const target = await selectorHumanTypeTarget(stealth, page, selector, options?.sensitive);
+    await humanType(page, rawKb, value, callCfg, cdp, target);
   };
 
   // --- clear ---
@@ -584,7 +624,8 @@ export function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): vo
     }
     await sleep(rand(100, 250));
     const cdp = await ensureCdp();
-    await humanType(page, rawKb, text, callCfg, cdp);
+    const target = await selectorHumanTypeTarget(stealth, page, selector, options?.sensitive);
+    await humanType(page, rawKb, text, callCfg, cdp, target);
   };
 
   // --- tap ---
@@ -691,6 +732,20 @@ function patchFrames(
 function firstFrameLocator(frame: Frame, selector: string): any {
   const locator = frame.locator(selector) as any;
   return typeof locator.first === 'function' ? locator.first() : locator;
+}
+
+async function frameHumanTypeTarget(
+  frame: Frame,
+  selector: string,
+  sensitive?: boolean,
+): Promise<HumanTypeTarget | undefined> {
+  return firstFrameLocator(frame, selector).evaluate((el: Element, sensitive: boolean) => ({
+    tag: el.tagName.toLowerCase(),
+    type: el.getAttribute('type'),
+    autocomplete: el.getAttribute('autocomplete'),
+    contentEditable: (el as HTMLElement).isContentEditable,
+    sensitive,
+  }), Boolean(sensitive)).catch(() => undefined);
 }
 
 async function isFrameInputElement(frame: Frame, selector: string): Promise<boolean> {
@@ -810,7 +865,8 @@ function patchSingleFrame(
     await frameClick(selector, options);
     await sleep(rand(100, 250));
     const cdp = await getFrameCdp();
-    await humanType(page, rawKb, text, callCfg, cdp).catch(() => origFrameType(selector, text, options));
+    const target = await frameHumanTypeTarget(frame, selector, options?.sensitive);
+    await humanType(page, rawKb, text, callCfg, cdp, target).catch(() => origFrameType(selector, text, options));
   };
 
   (frame as any).fill = async (selector: string, value: string, options?: HumanActionOptions) => {
@@ -823,7 +879,8 @@ function patchSingleFrame(
     await originals.keyboardPress('Backspace');
     await sleep(rand(50, 150));
     const cdp = await getFrameCdp();
-    await humanType(page, rawKb, value, callCfg, cdp).catch(() => origFrameFill(selector, value, options));
+    const target = await frameHumanTypeTarget(frame, selector, options?.sensitive);
+    await humanType(page, rawKb, value, callCfg, cdp, target).catch(() => origFrameFill(selector, value, options));
   };
 
   (frame as any).check = async (selector: string, options?: HumanActionOptions) => {
@@ -861,7 +918,8 @@ function patchSingleFrame(
     }
     await sleep(rand(100, 250));
     const cdp = await getFrameCdp();
-    await humanType(page, rawKb, text, callCfg, cdp).catch(() => origFramePressSequentially?.(selector, text, options));
+    const target = await frameHumanTypeTarget(frame, selector, options?.sensitive);
+    await humanType(page, rawKb, text, callCfg, cdp, target).catch(() => origFramePressSequentially?.(selector, text, options));
   };
 
   (frame as any).tap = async (selector: string, options?: HumanActionOptions) => {

--- a/src/browser/humanizer/index.ts
+++ b/src/browser/humanizer/index.ts
@@ -898,14 +898,20 @@ function patchSingleFrame(
     const locator = firstFrameLocator(frame, selector);
     if (typeof locator.isChecked !== 'function') return origFrameCheck(selector, options);
     const checked = await locator.isChecked();
-    if (!checked) await frameClick(selector, options).catch(() => origFrameCheck(selector, options));
+    if (!checked) await frameClick(selector, options).catch(error => {
+      if (signal?.aborted) throw error;
+      return origFrameCheck(selector, options);
+    });
   };
 
   (frame as any).uncheck = async (selector: string, options?: HumanActionOptions) => {
     const locator = firstFrameLocator(frame, selector);
     if (typeof locator.isChecked !== 'function') return origFrameUncheck(selector, options);
     const checked = await locator.isChecked();
-    if (checked) await frameClick(selector, options).catch(() => origFrameUncheck(selector, options));
+    if (checked) await frameClick(selector, options).catch(error => {
+      if (signal?.aborted) throw error;
+      return origFrameUncheck(selector, options);
+    });
   };
 
   (frame as any).selectOption = async (selector: string, values: any, options?: HumanActionOptions) => {
@@ -938,7 +944,10 @@ function patchSingleFrame(
   };
 
   (frame as any).tap = async (selector: string, options?: HumanActionOptions) => {
-    await frameClick(selector, options).catch(() => origFrameTap?.(selector, options));
+    await frameClick(selector, options).catch(error => {
+      if (signal?.aborted) throw error;
+      return origFrameTap?.(selector, options);
+    });
   };
 
   (frame as any).clear = async (selector: string, options?: HumanActionOptions) => {

--- a/src/browser/humanizer/keyboard.test.ts
+++ b/src/browser/humanizer/keyboard.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DEFAULT_CONFIG } from './config.js';
+import type { RawKeyboard } from './mouse.js';
+import { humanType, shouldAllowIntentionalMistype } from './keyboard.js';
+
+const FAST_CONFIG = {
+  ...DEFAULT_CONFIG,
+  key_hold: [0, 0] as [number, number],
+  mistype_delay_notice: [0, 0] as [number, number],
+  mistype_delay_correct: [0, 0] as [number, number],
+  typing_pause_chance: 0,
+  typing_delay: 0,
+  typing_delay_spread: 0,
+  mistype_chance: 1,
+};
+
+function rawKeyboard(): RawKeyboard {
+  return {
+    down: vi.fn().mockResolvedValue(undefined),
+    up: vi.fn().mockResolvedValue(undefined),
+    type: vi.fn().mockResolvedValue(undefined),
+    insertText: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('shouldAllowIntentionalMistype', () => {
+  it.each([
+    [{ tag: 'input', type: 'text', autocomplete: '' }, true],
+    [{ tag: 'input', type: 'password' }, false],
+    [{ tag: 'input', type: 'text', autocomplete: 'cc-number' }, false],
+    [{ tag: 'input', type: 'text', autocomplete: 'one-time-code' }, false],
+    [{ tag: 'textarea', autocomplete: 'new-password' }, false],
+    [{ tag: 'div', contentEditable: true }, false],
+    [{ tag: 'input', type: 'text', sensitive: true }, false],
+  ] as const)('classifies %o as %s', (target, expected) => {
+    expect(shouldAllowIntentionalMistype(target)).toBe(expected);
+  });
+});
+
+describe('humanType intentional mistypes', () => {
+  it('suppresses mistypes for sensitive targets', async () => {
+    const raw = rawKeyboard();
+
+    await humanType(
+      {} as any, raw, 'a', FAST_CONFIG, null, { tag: 'input', type: 'password' }, () => 0,
+    );
+
+    expect(raw.down).toHaveBeenCalledWith('a');
+    expect(raw.down).not.toHaveBeenCalledWith('Backspace');
+  });
+
+  it('makes and corrects mistypes for text inputs', async () => {
+    const raw = rawKeyboard();
+
+    await humanType(
+      {} as any, raw, 'a', FAST_CONFIG, null, { tag: 'input', type: 'text' }, () => 0,
+    );
+
+    expect(raw.down).toHaveBeenCalledWith('s');
+    expect(raw.down).toHaveBeenCalledWith('Backspace');
+    expect(raw.down).toHaveBeenCalledWith('a');
+  });
+});

--- a/src/browser/humanizer/keyboard.ts
+++ b/src/browser/humanizer/keyboard.ts
@@ -111,6 +111,7 @@ export async function humanType(
   cdpSession?: CDPSession | null,
   target?: HumanTypeTarget,
   random: () => number = Math.random,
+  signal?: AbortSignal,
 ): Promise<void> {
   const chars = [...text]; // Handle emoji surrogate pairs correctly
 
@@ -119,10 +120,10 @@ export async function humanType(
 
     // Non-ASCII characters (Cyrillic, CJK, emoji) — use insertText
     if (!isAscii(ch)) {
-      await sleep(randRange(cfg.key_hold));
+      await sleep(randRange(cfg.key_hold), signal);
       await raw.insertText(ch);
       if (i < chars.length - 1) {
-        await interCharDelay(cfg, random);
+        await interCharDelay(cfg, random, signal);
       }
       continue;
     }
@@ -132,41 +133,41 @@ export async function humanType(
       && random() < cfg.mistype_chance
       && /^[a-zA-Z0-9]$/.test(ch)) {
       const wrong = getNearbyKey(ch, random);
-      await typeNormalChar(raw, wrong, cfg);
-      await sleep(randRange(cfg.mistype_delay_notice));
+      await typeNormalChar(raw, wrong, cfg, signal);
+      await sleep(randRange(cfg.mistype_delay_notice), signal);
       await raw.down('Backspace');
-      await sleep(randRange(cfg.key_hold));
+      await sleep(randRange(cfg.key_hold), signal);
       await raw.up('Backspace');
-      await sleep(randRange(cfg.mistype_delay_correct));
+      await sleep(randRange(cfg.mistype_delay_correct), signal);
     }
 
     if (isUpperCase(ch)) {
-      await typeShiftedChar(raw, ch, cfg);
+      await typeShiftedChar(raw, ch, cfg, signal);
     } else if (SHIFT_SYMBOLS.has(ch)) {
-      await typeShiftSymbol(page, raw, ch, cfg, cdpSession);
+      await typeShiftSymbol(page, raw, ch, cfg, cdpSession, signal);
     } else {
-      await typeNormalChar(raw, ch, cfg);
+      await typeNormalChar(raw, ch, cfg, signal);
     }
 
     if (i < chars.length - 1) {
-      await interCharDelay(cfg, random);
+      await interCharDelay(cfg, random, signal);
     }
   }
 }
 
-async function typeNormalChar(raw: RawKeyboard, ch: string, cfg: HumanConfig): Promise<void> {
+async function typeNormalChar(raw: RawKeyboard, ch: string, cfg: HumanConfig, signal?: AbortSignal): Promise<void> {
   await raw.down(ch);
-  await sleep(randRange(cfg.key_hold));
+  await sleep(randRange(cfg.key_hold), signal);
   await raw.up(ch);
 }
 
-async function typeShiftedChar(raw: RawKeyboard, ch: string, cfg: HumanConfig): Promise<void> {
+async function typeShiftedChar(raw: RawKeyboard, ch: string, cfg: HumanConfig, signal?: AbortSignal): Promise<void> {
   await raw.down('Shift');
-  await sleep(randRange(cfg.shift_down_delay));
+  await sleep(randRange(cfg.shift_down_delay), signal);
   await raw.down(ch);
-  await sleep(randRange(cfg.key_hold));
+  await sleep(randRange(cfg.key_hold), signal);
   await raw.up(ch);
-  await sleep(randRange(cfg.shift_up_delay));
+  await sleep(randRange(cfg.shift_up_delay), signal);
   await raw.up('Shift');
 }
 
@@ -186,6 +187,7 @@ async function typeShiftSymbol(
   ch: string,
   cfg: HumanConfig,
   cdpSession?: CDPSession | null,
+  signal?: AbortSignal,
 ): Promise<void> {
   if (cdpSession) {
     // --- Stealth path: CDP Input.dispatchKeyEvent ---
@@ -193,7 +195,7 @@ async function typeShiftSymbol(
     const keyCode = SHIFT_SYMBOL_KEYCODES[ch] || 0;
 
     await raw.down('Shift');
-    await sleep(randRange(cfg.shift_down_delay));
+    await sleep(randRange(cfg.shift_down_delay), signal);
 
     await cdpSession.send('Input.dispatchKeyEvent', {
       type: 'keyDown',
@@ -204,7 +206,7 @@ async function typeShiftSymbol(
       text: ch,
       unmodifiedText: ch,
     });
-    await sleep(randRange(cfg.key_hold));
+    await sleep(randRange(cfg.key_hold), signal);
 
     await cdpSession.send('Input.dispatchKeyEvent', {
       type: 'keyUp',
@@ -214,12 +216,12 @@ async function typeShiftSymbol(
       windowsVirtualKeyCode: keyCode,
     });
 
-    await sleep(randRange(cfg.shift_up_delay));
+    await sleep(randRange(cfg.shift_up_delay), signal);
     await raw.up('Shift');
   } else {
     // --- Fallback path: page.evaluate (detectable) ---
     await raw.down('Shift');
-    await sleep(randRange(cfg.shift_down_delay));
+    await sleep(randRange(cfg.shift_down_delay), signal);
     await raw.insertText(ch);
     await page.evaluate((key: string) => {
       const el = document.activeElement;
@@ -228,16 +230,16 @@ async function typeShiftSymbol(
         el.dispatchEvent(new KeyboardEvent('keyup', { key, bubbles: true }));
       }
     }, ch);
-    await sleep(randRange(cfg.shift_up_delay));
+    await sleep(randRange(cfg.shift_up_delay), signal);
     await raw.up('Shift');
   }
 }
 
-async function interCharDelay(cfg: HumanConfig, random: () => number): Promise<void> {
+async function interCharDelay(cfg: HumanConfig, random: () => number, signal?: AbortSignal): Promise<void> {
   if (random() < cfg.typing_pause_chance) {
-    await sleep(randRange(cfg.typing_pause_range));
+    await sleep(randRange(cfg.typing_pause_range), signal);
   } else {
     const delay = cfg.typing_delay + (random() - 0.5) * 2 * cfg.typing_delay_spread;
-    await sleep(Math.max(10, delay));
+    await sleep(Math.max(10, delay), signal);
   }
 }

--- a/src/browser/humanizer/keyboard.ts
+++ b/src/browser/humanizer/keyboard.ts
@@ -10,6 +10,31 @@ import type { Page, CDPSession } from 'playwright-core';
 import { RawKeyboard } from './mouse.js';
 import { HumanConfig, rand, randRange, sleep } from './config.js';
 
+export interface HumanTypeTarget {
+  tag: string;
+  type?: string | null;
+  autocomplete?: string | null;
+  contentEditable?: boolean;
+  sensitive?: boolean;
+}
+
+export function shouldAllowIntentionalMistype(target?: HumanTypeTarget): boolean {
+  if (!target || target.sensitive || target.contentEditable) return false;
+
+  const tag = target.tag.toLowerCase();
+  if (tag !== 'textarea'
+    && (tag !== 'input' || !['text', 'search', 'email', 'url', 'tel'].includes((target.type ?? 'text').toLowerCase()))) {
+    return false;
+  }
+
+  return !(target.autocomplete ?? '').toLowerCase().split(/\s+/).some(token =>
+    token.includes('password')
+    || token === 'one-time-code'
+    || token === 'webauthn'
+    || token.startsWith('cc-'),
+  );
+}
+
 const SHIFT_SYMBOLS = new Set([
   '@', '#', '!', '$', '%', '^', '&', '*', '(', ')',
   '_', '+', '{', '}', '|', ':', '"', '<', '>', '?', '~',
@@ -56,11 +81,11 @@ function isAscii(ch: string): boolean {
   return code !== undefined && code < 128;
 }
 
-function getNearbyKey(ch: string): string {
+function getNearbyKey(ch: string, random: () => number): string {
   const lower = ch.toLowerCase();
   if (lower in NEARBY_KEYS) {
     const neighbors = NEARBY_KEYS[lower];
-    const wrong = neighbors[Math.floor(Math.random() * neighbors.length)];
+    const wrong = neighbors[Math.floor(random() * neighbors.length)];
     return ch === ch.toUpperCase() && ch !== ch.toLowerCase() ? wrong.toUpperCase() : wrong;
   }
   return ch;
@@ -84,6 +109,8 @@ export async function humanType(
   text: string,
   cfg: HumanConfig,
   cdpSession?: CDPSession | null,
+  target?: HumanTypeTarget,
+  random: () => number = Math.random,
 ): Promise<void> {
   const chars = [...text]; // Handle emoji surrogate pairs correctly
 
@@ -95,14 +122,16 @@ export async function humanType(
       await sleep(randRange(cfg.key_hold));
       await raw.insertText(ch);
       if (i < chars.length - 1) {
-        await interCharDelay(cfg);
+        await interCharDelay(cfg, random);
       }
       continue;
     }
 
     // Mistype chance — only for ASCII alphanumeric
-    if (Math.random() < cfg.mistype_chance && /^[a-zA-Z0-9]$/.test(ch)) {
-      const wrong = getNearbyKey(ch);
+    if (shouldAllowIntentionalMistype(target)
+      && random() < cfg.mistype_chance
+      && /^[a-zA-Z0-9]$/.test(ch)) {
+      const wrong = getNearbyKey(ch, random);
       await typeNormalChar(raw, wrong, cfg);
       await sleep(randRange(cfg.mistype_delay_notice));
       await raw.down('Backspace');
@@ -120,7 +149,7 @@ export async function humanType(
     }
 
     if (i < chars.length - 1) {
-      await interCharDelay(cfg);
+      await interCharDelay(cfg, random);
     }
   }
 }
@@ -204,11 +233,11 @@ async function typeShiftSymbol(
   }
 }
 
-async function interCharDelay(cfg: HumanConfig): Promise<void> {
-  if (Math.random() < cfg.typing_pause_chance) {
+async function interCharDelay(cfg: HumanConfig, random: () => number): Promise<void> {
+  if (random() < cfg.typing_pause_chance) {
     await sleep(randRange(cfg.typing_pause_range));
   } else {
-    const delay = cfg.typing_delay + (Math.random() - 0.5) * 2 * cfg.typing_delay_spread;
+    const delay = cfg.typing_delay + (random() - 0.5) * 2 * cfg.typing_delay_spread;
     await sleep(Math.max(10, delay));
   }
 }

--- a/src/browser/humanizer/mouse.ts
+++ b/src/browser/humanizer/mouse.ts
@@ -78,6 +78,7 @@ export async function humanMove(
   endX: number,
   endY: number,
   cfg: HumanConfig,
+  signal?: AbortSignal,
 ): Promise<void> {
   const dist = Math.hypot(endX - startX, endY - startY);
   if (dist < 1) return;
@@ -107,7 +108,7 @@ export async function humanMove(
 
     burstCounter++;
     if (burstCounter >= burstSize && i < steps) {
-      await sleep(randRange(cfg.mouse_burst_pause));
+      await sleep(randRange(cfg.mouse_burst_pause), signal);
       burstCounter = 0;
     }
   }
@@ -118,7 +119,7 @@ export async function humanMove(
     const ovX = Math.round(endX + Math.cos(angle) * overshootDist);
     const ovY = Math.round(endY + Math.sin(angle) * overshootDist);
     await raw.move(ovX, ovY);
-    await sleep(rand(30, 70));
+    await sleep(rand(30, 70), signal);
     const corrX = Math.round(endX + (Math.random() - 0.5) * 4);
     const corrY = Math.round(endY + (Math.random() - 0.5) * 4);
     await raw.move(corrX, corrY);
@@ -154,17 +155,18 @@ export async function humanClick(
   raw: RawMouse,
   isInput: boolean,
   cfg: HumanConfig,
+  signal?: AbortSignal,
 ): Promise<void> {
   const aimDelay = isInput
     ? randRange(cfg.click_aim_delay_input)
     : randRange(cfg.click_aim_delay_button);
-  await sleep(aimDelay);
+  await sleep(aimDelay, signal);
 
   const holdTime = isInput
     ? randRange(cfg.click_hold_input)
     : randRange(cfg.click_hold_button);
   await raw.down();
-  await sleep(holdTime);
+  await sleep(holdTime, signal);
   await raw.up();
 }
 
@@ -177,6 +179,7 @@ export function humanIdle(
   cx: number,
   cy: number,
   cfg: HumanConfig,
+  signal?: AbortSignal,
 ): Promise<void>;
 export function humanIdle(
   raw: RawMouse,
@@ -184,21 +187,25 @@ export function humanIdle(
   cx: number,
   cy: number,
   cfg: HumanConfig,
+  signal?: AbortSignal,
 ): Promise<void>;
 export async function humanIdle(
   raw: RawMouse,
   secondsOrCx: number,
   cxOrCy: number,
   cyOrCfg: number | HumanConfig,
-  maybeCfg?: HumanConfig,
+  maybeCfgOrSignal?: HumanConfig | AbortSignal,
+  maybeSignal?: AbortSignal,
 ): Promise<void> {
-  const hasExplicitSeconds = maybeCfg !== undefined;
+  const hasExplicitSeconds = maybeCfgOrSignal !== undefined
+    && 'idle_between_duration' in maybeCfgOrSignal;
+  const signal = hasExplicitSeconds ? maybeSignal : maybeCfgOrSignal as AbortSignal | undefined;
   const seconds = hasExplicitSeconds
     ? secondsOrCx
     : rand((cyOrCfg as HumanConfig).idle_between_duration[0], (cyOrCfg as HumanConfig).idle_between_duration[1]);
   const cx = hasExplicitSeconds ? cxOrCy : secondsOrCx;
   const cy = hasExplicitSeconds ? (cyOrCfg as number) : cxOrCy;
-  const cfg = hasExplicitSeconds ? maybeCfg! : (cyOrCfg as HumanConfig);
+  const cfg = hasExplicitSeconds ? maybeCfgOrSignal as HumanConfig : (cyOrCfg as HumanConfig);
   const endTime = Date.now() + seconds * 1000;
   let x = cx;
   let y = cy;
@@ -208,6 +215,6 @@ export async function humanIdle(
     x += dx;
     y += dy;
     await raw.move(Math.round(x), Math.round(y));
-    await sleep(randRange(cfg.idle_pause_range));
+    await sleep(randRange(cfg.idle_pause_range), signal);
   }
 }

--- a/src/browser/humanizer/page.test.ts
+++ b/src/browser/humanizer/page.test.ts
@@ -334,7 +334,7 @@ describe('humanizePage', () => {
     const interCharacterDelays = timeoutSpy.mock.calls
       .map(([, ms]) => Number(ms))
       .filter(ms => ms >= 10);
-    expect(interCharacterDelays).toEqual([10, 30]);
+    expect(interCharacterDelays).toEqual([28, 20]);
     expect(owned.page.keyboard.down.mock.calls.map(([key]) => key)).toEqual(['a', 'b', 'c']);
     expect(owned.page.keyboard.up.mock.calls.map(([key]) => key)).toEqual(['a', 'b', 'c']);
   });

--- a/src/browser/humanizer/page.test.ts
+++ b/src/browser/humanizer/page.test.ts
@@ -340,21 +340,28 @@ describe('humanizePage', () => {
 
   it('suppresses mistypes when Page type extracts a password target through CDP', async () => {
     mockRandom([0]);
-    const cdp = fakeCdpSession(expression => expression.includes('autocomplete') ? {
-      tag: 'input',
-      type: 'password',
-      autocomplete: null,
-      contentEditable: false,
-      sensitive: false,
-    } : false);
+    const selector = 'input[data-label="a\\b"]';
+    const passwordInput = {
+      tagName: 'INPUT',
+      getAttribute: vi.fn((name: string) => name === 'type' ? 'password' : null),
+      isContentEditable: false,
+    };
+    const document = { querySelector: vi.fn((receivedSelector: string) => {
+      expect(receivedSelector).toBe(selector);
+      return passwordInput;
+    }) };
+    const cdp = fakeCdpSession(expression => Function('document', `return (${expression})`)(document));
     const owned = fakePage({ cdp });
 
     humanizePage(owned.page as any, { ...FAST_HUMAN_CONFIG, mistype_chance: 1 });
-    await owned.page.type('#password', 'a', { force: true });
+    await owned.page.type(selector, 'a', { force: true });
 
     expect(cdp.send).toHaveBeenCalledWith('Runtime.evaluate', expect.objectContaining({
       expression: expect.stringContaining('autocomplete'),
     }));
+    expect(document.querySelector).toHaveBeenCalledWith(selector);
+    expect(passwordInput.getAttribute).toHaveBeenCalledWith('type');
+    expect(passwordInput.getAttribute).toHaveBeenCalledWith('autocomplete');
     expect(owned.page.keyboard.down).toHaveBeenCalledWith('a');
     expect(owned.page.keyboard.down).not.toHaveBeenCalledWith('Backspace');
   });
@@ -401,7 +408,7 @@ describe('humanizePage', () => {
     expect(owned.page.keyboard.down).toHaveBeenCalledWith('a');
   });
 
-  it('fails closed when ElementHandle fill cannot extract a target', async () => {
+  it('suppresses mistypes when ElementHandle fill extracts a password target', async () => {
     mockRandom([0]);
     const passwordInput = {
       tagName: 'INPUT',
@@ -409,9 +416,6 @@ describe('humanizePage', () => {
       isContentEditable: false,
     };
     const handle = fakeElement(undefined, passwordInput);
-    handle.evaluate
-      .mockImplementationOnce(async (fn: unknown) => (fn as (node: typeof passwordInput) => unknown)(passwordInput))
-      .mockRejectedValueOnce(new Error('detached'));
     const owned = fakePage();
     owned.page.$.mockResolvedValue(handle);
 
@@ -420,6 +424,28 @@ describe('humanizePage', () => {
     await patchedHandle.fill('a', { force: true });
 
     expect(handle.evaluate).toHaveBeenCalledTimes(2);
+    expect(passwordInput.getAttribute).toHaveBeenCalledWith('type');
+    expect(passwordInput.getAttribute).toHaveBeenCalledWith('autocomplete');
+    expect(owned.page.keyboard.down).toHaveBeenCalledWith('a');
+    expect(owned.page.keyboard.down).not.toHaveBeenCalledWith('Backspace');
+  });
+
+  it('passes caller sensitivity through ElementHandle fill for text inputs', async () => {
+    mockRandom([0]);
+    const textInput = {
+      tagName: 'INPUT',
+      getAttribute: vi.fn((name: string) => name === 'type' ? 'text' : null),
+      isContentEditable: false,
+    };
+    const handle = fakeElement(undefined, textInput);
+    const owned = fakePage();
+    owned.page.$.mockResolvedValue(handle);
+
+    humanizePage(owned.page as any, { ...FAST_HUMAN_CONFIG, mistype_chance: 1 });
+    const patchedHandle = await owned.page.$('#name');
+    await patchedHandle.fill('a', { force: true, sensitive: true });
+
+    expect(handle.evaluate).toHaveBeenLastCalledWith(expect.any(Function), true);
     expect(owned.page.keyboard.down).toHaveBeenCalledWith('a');
     expect(owned.page.keyboard.down).not.toHaveBeenCalledWith('Backspace');
   });

--- a/src/browser/humanizer/page.test.ts
+++ b/src/browser/humanizer/page.test.ts
@@ -338,6 +338,27 @@ describe('humanizePage', () => {
     expect(owned.page.keyboard.up.mock.calls.map(([key]) => key)).toEqual(['a', 'b', 'c']);
   });
 
+  it('cancels in-flight keyboard typing when the Page is disposed', async () => {
+    const owned = fakePage();
+    humanizePage(owned.page as any, {
+      ...FAST_HUMAN_CONFIG,
+      typing_delay: 10_000,
+      typing_delay_spread: 0,
+    });
+
+    const type = owned.page.keyboard.type('hello');
+    await vi.waitFor(() => expect(owned.page.keyboard.down).toHaveBeenCalledOnce());
+    await disposeHumanizedPage(owned.page as any);
+
+    await expect(Promise.race([
+      type.then(() => 'settled', () => 'settled'),
+      new Promise(resolve => setTimeout(() => resolve('timed out'), 50)),
+    ])).resolves.toBe('settled');
+    expect(owned.page.keyboard.down).toHaveBeenCalledOnce();
+    expect(owned.page.keyboard.up).toHaveBeenCalledOnce();
+    expect(owned.cdp.send).not.toHaveBeenCalledWith('Input.dispatchKeyEvent', expect.anything());
+  });
+
   it('suppresses mistypes when Page type extracts a password target through CDP', async () => {
     mockRandom([0]);
     const selector = 'input[data-label="a\\b"]';

--- a/src/browser/humanizer/page.test.ts
+++ b/src/browser/humanizer/page.test.ts
@@ -359,6 +359,25 @@ describe('humanizePage', () => {
     expect(owned.cdp.send).not.toHaveBeenCalledWith('Input.dispatchKeyEvent', expect.anything());
   });
 
+  it('does not fall back to Frame check when disposal aborts the human click', async () => {
+    const childFrame = fakeFrame();
+    const mainFrame = fakeFrame();
+    mainFrame.childFrames.mockReturnValue([childFrame]);
+    const owned = fakePage({ mainFrame });
+    const rawFrameCheck = childFrame.check;
+
+    humanizePage(owned.page as any, {
+      ...FAST_HUMAN_CONFIG,
+      click_aim_delay_button: [10_000, 10_000],
+    });
+    const check = childFrame.check('#checkbox');
+    await new Promise(resolve => setTimeout(resolve, 20));
+    await disposeHumanizedPage(owned.page as any);
+
+    await expect(check).rejects.toThrow(/abort/i);
+    expect(rawFrameCheck).not.toHaveBeenCalled();
+  });
+
   it('suppresses mistypes when Page type extracts a password target through CDP', async () => {
     mockRandom([0]);
     const selector = 'input[data-label="a\\b"]';
@@ -444,9 +463,27 @@ describe('humanizePage', () => {
     const patchedHandle = await owned.page.$('#password');
     await patchedHandle.fill('a', { force: true });
 
-    expect(handle.evaluate).toHaveBeenCalledTimes(2);
-    expect(passwordInput.getAttribute).toHaveBeenCalledWith('type');
-    expect(passwordInput.getAttribute).toHaveBeenCalledWith('autocomplete');
+    expect(handle.evaluate).toHaveBeenCalledOnce();
+    expect(owned.page.keyboard.down).toHaveBeenCalledWith('a');
+    expect(owned.page.keyboard.down).not.toHaveBeenCalledWith('Backspace');
+  });
+
+  it('does not evaluate the ElementHandle target in the main world when CDP is available', async () => {
+    mockRandom([0]);
+    const textInput = {
+      tagName: 'INPUT',
+      getAttribute: vi.fn((name: string) => name === 'type' ? 'text' : null),
+      isContentEditable: false,
+    };
+    const handle = fakeElement(undefined, textInput);
+    const owned = fakePage();
+    owned.page.$.mockResolvedValue(handle);
+
+    humanizePage(owned.page as any, { ...FAST_HUMAN_CONFIG, mistype_chance: 1 });
+    const patchedHandle = await owned.page.$('#name');
+    await patchedHandle.fill('a', { force: true });
+
+    expect(handle.evaluate).toHaveBeenCalledTimes(1);
     expect(owned.page.keyboard.down).toHaveBeenCalledWith('a');
     expect(owned.page.keyboard.down).not.toHaveBeenCalledWith('Backspace');
   });
@@ -466,7 +503,7 @@ describe('humanizePage', () => {
     const patchedHandle = await owned.page.$('#name');
     await patchedHandle.fill('a', { force: true, sensitive: true });
 
-    expect(handle.evaluate).toHaveBeenLastCalledWith(expect.any(Function), true);
+    expect(handle.evaluate).toHaveBeenCalledOnce();
     expect(owned.page.keyboard.down).toHaveBeenCalledWith('a');
     expect(owned.page.keyboard.down).not.toHaveBeenCalledWith('Backspace');
   });

--- a/src/browser/humanizer/page.test.ts
+++ b/src/browser/humanizer/page.test.ts
@@ -39,24 +39,23 @@ const FAST_HUMAN_CONFIG: Partial<HumanConfig> = {
   idle_between_actions: false,
 };
 
-function fakeCdpSession() {
+function fakeCdpSession(runtimeEvaluate?: (expression: string) => unknown) {
   return {
     detach: vi.fn().mockResolvedValue(undefined),
-    send: vi.fn(async (method: string) => {
+    send: vi.fn(async (method: string, params?: { expression?: string }) => {
       if (method === 'Page.getFrameTree') return { frameTree: { frame: { id: 'frame-1' } } };
       if (method === 'Page.createIsolatedWorld') return { executionContextId: 7 };
-      if (method === 'Runtime.evaluate') return { result: { value: false } };
+      if (method === 'Runtime.evaluate') return { result: { value: runtimeEvaluate?.(params?.expression ?? '') ?? false } };
       return {};
     }),
   };
 }
 
-function fakeLocator(boxes: Array<{ x: number; y: number; width: number; height: number }> = [{ x: 10, y: 10, width: 20, height: 10 }]) {
+function fakeLocator(
+  boxes: Array<{ x: number; y: number; width: number; height: number }> = [{ x: 10, y: 10, width: 20, height: 10 }],
+  node: any = { tagName: 'BUTTON', getAttribute: vi.fn(() => null), isContentEditable: false },
+) {
   let boxIndex = 0;
-  const node = {
-    tagName: 'BUTTON',
-    getAttribute: vi.fn(() => null),
-  };
   const locator: any = {
     first: vi.fn(() => locator),
     waitFor: vi.fn().mockResolvedValue(undefined),
@@ -66,24 +65,23 @@ function fakeLocator(boxes: Array<{ x: number; y: number; width: number; height:
     isChecked: vi.fn().mockResolvedValue(false),
     scrollIntoViewIfNeeded: vi.fn().mockResolvedValue(undefined),
     boundingBox: vi.fn(async () => boxes[Math.min(boxIndex++, boxes.length - 1)]),
-    evaluate: vi.fn(async (fn: unknown) => {
+    evaluate: vi.fn(async (fn: unknown, arg?: unknown) => {
       if (typeof fn === 'string') return { hit: true };
-      return (fn as (el: typeof node) => unknown)(node);
+      return (fn as (el: typeof node, arg?: unknown) => unknown)(node, arg);
     }),
   };
   return locator;
 }
 
-function fakeElement(box = { x: 10, y: 10, width: 20, height: 10 }) {
-  const node = {
-    tagName: 'BUTTON',
-    getAttribute: vi.fn(() => null),
-  };
+function fakeElement(
+  box = { x: 10, y: 10, width: 20, height: 10 },
+  node: any = { tagName: 'BUTTON', getAttribute: vi.fn(() => null), isContentEditable: false },
+) {
   const child = {
     boundingBox: vi.fn().mockResolvedValue(box),
-    evaluate: vi.fn(async (fn: unknown) => {
+    evaluate: vi.fn(async (fn: unknown, arg?: unknown) => {
       if (typeof fn === 'string') return { hit: true };
-      return (fn as (el: typeof node) => unknown)(node);
+      return (fn as (el: typeof node, arg?: unknown) => unknown)(node, arg);
     }),
     waitForElementState: vi.fn().mockResolvedValue(undefined),
     click: vi.fn(),
@@ -199,6 +197,7 @@ function mockRandom(values: number[]) {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe('humanizePage', () => {
@@ -337,6 +336,92 @@ describe('humanizePage', () => {
     expect(interCharacterDelays).toEqual([28, 20]);
     expect(owned.page.keyboard.down.mock.calls.map(([key]) => key)).toEqual(['a', 'b', 'c']);
     expect(owned.page.keyboard.up.mock.calls.map(([key]) => key)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('suppresses mistypes when Page type extracts a password target through CDP', async () => {
+    mockRandom([0]);
+    const cdp = fakeCdpSession(expression => expression.includes('autocomplete') ? {
+      tag: 'input',
+      type: 'password',
+      autocomplete: null,
+      contentEditable: false,
+      sensitive: false,
+    } : false);
+    const owned = fakePage({ cdp });
+
+    humanizePage(owned.page as any, { ...FAST_HUMAN_CONFIG, mistype_chance: 1 });
+    await owned.page.type('#password', 'a', { force: true });
+
+    expect(cdp.send).toHaveBeenCalledWith('Runtime.evaluate', expect.objectContaining({
+      expression: expect.stringContaining('autocomplete'),
+    }));
+    expect(owned.page.keyboard.down).toHaveBeenCalledWith('a');
+    expect(owned.page.keyboard.down).not.toHaveBeenCalledWith('Backspace');
+  });
+
+  it('uses Page evaluate to extract a text target when CDP extraction is unavailable', async () => {
+    mockRandom([0]);
+    const textInput = {
+      tagName: 'INPUT',
+      getAttribute: vi.fn((name: string) => name === 'type' ? 'text' : null),
+      isContentEditable: false,
+    };
+    const owned = fakePage();
+    vi.stubGlobal('document', { querySelector: vi.fn(() => textInput) });
+    owned.page.evaluate.mockImplementation(async (fn: (arg: unknown) => unknown, arg: unknown) => fn(arg));
+
+    humanizePage(owned.page as any, { ...FAST_HUMAN_CONFIG, mistype_chance: 1 });
+    await owned.page.fill('#name', 'a', { force: true });
+
+    expect(owned.page.evaluate).toHaveBeenCalledOnce();
+    expect(owned.page.keyboard.down).toHaveBeenCalledWith('s');
+    expect(owned.page.keyboard.down).toHaveBeenCalledWith('Backspace');
+    expect(owned.page.keyboard.down).toHaveBeenCalledWith('a');
+  });
+
+  it('makes and corrects mistypes when Frame pressSequentially extracts a text target', async () => {
+    mockRandom([0]);
+    const textInput = {
+      tagName: 'INPUT',
+      getAttribute: vi.fn((name: string) => name === 'type' ? 'text' : null),
+      isContentEditable: false,
+    };
+    const childLocator = fakeLocator(undefined, textInput);
+    const childFrame = fakeFrame(childLocator);
+    const mainFrame = fakeFrame();
+    mainFrame.childFrames.mockReturnValue([childFrame]);
+    const owned = fakePage({ mainFrame });
+
+    humanizePage(owned.page as any, { ...FAST_HUMAN_CONFIG, mistype_chance: 1 });
+    await childFrame.pressSequentially('#name', 'a');
+
+    expect(childLocator.evaluate).toHaveBeenCalledWith(expect.any(Function), false);
+    expect(owned.page.keyboard.down).toHaveBeenCalledWith('s');
+    expect(owned.page.keyboard.down).toHaveBeenCalledWith('Backspace');
+    expect(owned.page.keyboard.down).toHaveBeenCalledWith('a');
+  });
+
+  it('fails closed when ElementHandle fill cannot extract a target', async () => {
+    mockRandom([0]);
+    const passwordInput = {
+      tagName: 'INPUT',
+      getAttribute: vi.fn((name: string) => name === 'type' ? 'password' : null),
+      isContentEditable: false,
+    };
+    const handle = fakeElement(undefined, passwordInput);
+    handle.evaluate
+      .mockImplementationOnce(async (fn: unknown) => (fn as (node: typeof passwordInput) => unknown)(passwordInput))
+      .mockRejectedValueOnce(new Error('detached'));
+    const owned = fakePage();
+    owned.page.$.mockResolvedValue(handle);
+
+    humanizePage(owned.page as any, { ...FAST_HUMAN_CONFIG, mistype_chance: 1 });
+    const patchedHandle = await owned.page.$('#password');
+    await patchedHandle.fill('a', { force: true });
+
+    expect(handle.evaluate).toHaveBeenCalledTimes(2);
+    expect(owned.page.keyboard.down).toHaveBeenCalledWith('a');
+    expect(owned.page.keyboard.down).not.toHaveBeenCalledWith('Backspace');
   });
 
   it('uses CDP dispatchKeyEvent for shift symbols on the trusted-event path', async () => {

--- a/src/browser/humanizer/page.ts
+++ b/src/browser/humanizer/page.ts
@@ -8,6 +8,7 @@ import { restorePatchedElementHandles } from './elementhandle.js';
 
 const humanizedPages = new WeakSet<Page>();
 const pageSnapshots = new WeakMap<Page, {
+  abortController: AbortController;
   page: Map<PropertyKey, PropertyDescriptor | undefined>;
   mouse: Map<PropertyKey, PropertyDescriptor | undefined>;
   keyboard: Map<PropertyKey, PropertyDescriptor | undefined>;
@@ -44,7 +45,9 @@ function currentFrames(page: Page): object[] {
 export function humanizePage(page: Page, config?: Partial<HumanConfig>): Page {
   if (humanizedPages.has(page)) return page;
   disposalPromises.delete(page);
+  const abortController = new AbortController();
   pageSnapshots.set(page, {
+    abortController,
     page: new Map(PAGE_KEYS.map(key => [key, Object.getOwnPropertyDescriptor(page, key)])),
     mouse: new Map(MOUSE_KEYS.map(key => [key, Object.getOwnPropertyDescriptor(page.mouse, key)])),
     keyboard: new Map(KEYBOARD_KEYS.map(key => [key, Object.getOwnPropertyDescriptor(page.keyboard, key)])),
@@ -53,7 +56,7 @@ export function humanizePage(page: Page, config?: Partial<HumanConfig>): Page {
       descriptors: new Map(FRAME_KEYS.map(key => [key, Object.getOwnPropertyDescriptor(frame, key)])),
     })),
   });
-  patchPage(page, resolveConfig('default', config), createCursorState());
+  patchPage(page, resolveConfig('default', config), createCursorState(), abortController.signal);
   humanizedPages.add(page);
   return page;
 }
@@ -86,6 +89,7 @@ export function disposeHumanizedPage(page: Page): Promise<void> {
   const existing = disposalPromises.get(page);
   if (existing) return existing;
   const dispose = (async () => {
+    pageSnapshots.get(page)?.abortController.abort();
     const stealth = (page as unknown as { _stealth?: { dispose?: () => Promise<void> } })._stealth;
     await stealth?.dispose?.();
     restoreHumanizedPage(page);

--- a/src/browser/humanizer/scroll.ts
+++ b/src/browser/humanizer/scroll.ts
@@ -25,7 +25,7 @@ function isInViewport(
   return topEdge >= zoneTop && bottomEdge <= zoneBottom;
 }
 
-async function smoothWheel(raw: RawMouse, delta: number, cfg: HumanConfig): Promise<void> {
+async function smoothWheel(raw: RawMouse, delta: number, cfg: HumanConfig, signal?: AbortSignal): Promise<void> {
   const absD = Math.abs(delta);
   const sign = delta > 0 ? 1 : -1;
   let sent = 0;
@@ -34,7 +34,7 @@ async function smoothWheel(raw: RawMouse, delta: number, cfg: HumanConfig): Prom
     const chunk = Math.min(stepSize, absD - sent);
     await raw.wheel(0, Math.round(chunk) * sign);
     sent += chunk;
-    await sleep(rand(8, 20));
+    await sleep(rand(8, 20), signal);
   }
 }
 
@@ -52,6 +52,7 @@ export async function humanScrollIntoView(
   cursorX: number,
   cursorY: number,
   cfg: HumanConfig,
+  signal?: AbortSignal,
 ): Promise<{ box: ElementBounds; cursorX: number; cursorY: number; didScroll: boolean }> {
   // Headed launches default to no_viewport so the page tracks the real OS
   // window; page.viewportSize() is then null. Fall back to the live window
@@ -74,10 +75,10 @@ export async function humanScrollIntoView(
   // Move cursor into scroll area
   const scrollAreaX = Math.round(viewport.width * rand(0.3, 0.7));
   const scrollAreaY = Math.round(viewport.height * rand(0.3, 0.7));
-  await humanMove(raw, cursorX, cursorY, scrollAreaX, scrollAreaY, cfg);
+  await humanMove(raw, cursorX, cursorY, scrollAreaX, scrollAreaY, cfg, signal);
   cursorX = scrollAreaX;
   cursorY = scrollAreaY;
-  await sleep(randRange(cfg.scroll_pre_move_delay));
+  await sleep(randRange(cfg.scroll_pre_move_delay), signal);
 
   // Calculate scroll distance
   const targetY = viewport.height * rand(cfg.scroll_target_zone[0], cfg.scroll_target_zone[1]);
@@ -112,9 +113,9 @@ export async function humanScrollIntoView(
     delta *= 1 + (Math.random() - 0.5) * 2 * cfg.scroll_delta_variance;
     delta = Math.round(delta) * direction;
 
-    await smoothWheel(raw, delta, cfg);
+    await smoothWheel(raw, delta, cfg, signal);
     scrolled += Math.abs(delta);
-    await sleep(pause);
+    await sleep(pause, signal);
 
     // Check visibility every 3 steps
     if (i % 3 === 2 || i === totalClicks - 1) {
@@ -130,19 +131,19 @@ export async function humanScrollIntoView(
   // Optional overshoot + correction
   if (Math.random() < cfg.scroll_overshoot_chance) {
     const overshootPx = Math.round(randRange(cfg.scroll_overshoot_px)) * direction;
-    await smoothWheel(raw, overshootPx, cfg);
-    await sleep(randRange(cfg.scroll_settle_delay));
+    await smoothWheel(raw, overshootPx, cfg, signal);
+    await sleep(randRange(cfg.scroll_settle_delay), signal);
 
     const corrections = randIntRange([1, 2]);
     for (let c = 0; c < corrections; c++) {
       const corrDelta = Math.round(rand(40, 80)) * -direction;
-      await smoothWheel(raw, corrDelta, cfg);
-      await sleep(rand(100, 250));
+      await smoothWheel(raw, corrDelta, cfg, signal);
+      await sleep(rand(100, 250), signal);
     }
   }
 
   // Settle
-  await sleep(randRange(cfg.scroll_settle_delay));
+  await sleep(randRange(cfg.scroll_settle_delay), signal);
 
   box = await getBox();
   if (!box) throw new Error('Element lost after scrolling into view');
@@ -167,11 +168,12 @@ export async function scrollToElement(
   cursorY: number,
   cfg: HumanConfig,
   timeout?: number,
+  signal?: AbortSignal,
 ): Promise<{ box: ElementBounds; cursorX: number; cursorY: number; didScroll: boolean }> {
   return humanScrollIntoView(
     page, raw,
     () => getElementBox(page, selector, timeout),
-    cursorX, cursorY, cfg,
+    cursorX, cursorY, cfg, signal,
   );
 }
 

--- a/src/browser/runtime/local-slab/behavior-profile.test.ts
+++ b/src/browser/runtime/local-slab/behavior-profile.test.ts
@@ -1,9 +1,10 @@
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   BEHAVIOR_FILENAME,
+  BEHAVIOR_LOCK,
   BEHAVIOR_SCHEMA_VERSION,
   loadOrCreateBehaviorProfile,
 } from './behavior-profile.js';
@@ -62,6 +63,31 @@ describe('SLAB behavior profiles', () => {
 
     expect(second.traits).toEqual(first.traits);
   });
+
+  it('recovers from an abandoned behavior lock older than one minute', async () => {
+    const baseDir = await createBaseDir();
+    const profileDir = resolveSlabProfileDir('default', { baseDir });
+    await mkdir(profileDir, { recursive: true });
+    const lockPath = path.join(profileDir, BEHAVIOR_LOCK);
+    await writeFile(lockPath, '');
+    const stale = new Date(Date.now() - 61_000);
+    await utimes(lockPath, stale, stale);
+
+    await expect(loadOrCreateBehaviorProfile('default', { baseDir })).resolves.toMatchObject({
+      profileId: 'default',
+      schemaVersion: BEHAVIOR_SCHEMA_VERSION,
+    });
+  });
+
+  it('names the blocking lock file when initialization times out', async () => {
+    const baseDir = await createBaseDir();
+    const profileDir = resolveSlabProfileDir('default', { baseDir });
+    await mkdir(profileDir, { recursive: true });
+    await writeFile(path.join(profileDir, BEHAVIOR_LOCK), '');
+
+    await expect(loadOrCreateBehaviorProfile('default', { baseDir }))
+      .rejects.toThrow(/behavior\.lock/);
+  }, 10_000);
 
   it('retains existing trait values and samples only missing allowlisted fields', async () => {
     const baseDir = await createBaseDir();

--- a/src/browser/runtime/local-slab/behavior-profile.test.ts
+++ b/src/browser/runtime/local-slab/behavior-profile.test.ts
@@ -32,6 +32,8 @@ describe('SLAB behavior profiles', () => {
 
     expect(created.schemaVersion).toBe(BEHAVIOR_SCHEMA_VERSION);
     expect(loaded.traits).toEqual(created.traits);
+    expect(created.warning).toBeUndefined();
+    expect(loaded.warning).toBeUndefined();
     const raw = JSON.parse(await readFile(
       path.join(baseDir, 'slab', 'profiles', 'Profile 1', BEHAVIOR_FILENAME),
       'utf8',
@@ -74,6 +76,7 @@ describe('SLAB behavior profiles', () => {
     });
 
     expect(document.schemaVersion).toBe(BEHAVIOR_SCHEMA_VERSION);
+    expect(document.warning).toMatch(/regenerated.*malformed/i);
     expect(await readFile(path.join(profileDir, 'behavior.json.corrupt-123'), 'utf8'))
       .toBe('{"schemaVersion":1,"traits":');
   });

--- a/src/browser/runtime/local-slab/behavior-profile.test.ts
+++ b/src/browser/runtime/local-slab/behavior-profile.test.ts
@@ -159,6 +159,8 @@ describe('SLAB behavior profiles', () => {
     await loadOrCreateBehaviorProfile('default', { baseDir });
 
     const file = await stat(path.join(resolveSlabProfileDir('default', { baseDir }), BEHAVIOR_FILENAME));
-    expect(file.mode & 0o777).toBe(0o600);
+    if (process.platform !== 'win32') {
+      expect(file.mode & 0o777).toBe(0o600);
+    }
   });
 });

--- a/src/browser/runtime/local-slab/behavior-profile.test.ts
+++ b/src/browser/runtime/local-slab/behavior-profile.test.ts
@@ -63,6 +63,24 @@ describe('SLAB behavior profiles', () => {
     expect(second.traits).toEqual(first.traits);
   });
 
+  it('retains existing trait values and samples only missing allowlisted fields', async () => {
+    const baseDir = await createBaseDir();
+    const profileDir = resolveSlabProfileDir('default', { baseDir });
+    await mkdir(profileDir, { recursive: true });
+    const partial = {
+      schemaVersion: 1,
+      profileId: 'default',
+      traits: { typing_delay: 91, idle_between_actions: false },
+    };
+    await writeFile(path.join(profileDir, BEHAVIOR_FILENAME), JSON.stringify(partial));
+
+    const loaded = await loadOrCreateBehaviorProfile('default', { baseDir, random: () => 0.5 });
+
+    expect(loaded.traits.typing_delay).toBe(91);
+    expect(loaded.traits.typing_delay_spread).toEqual(expect.any(Number));
+    expect(loaded.warning).toBeUndefined();
+  });
+
   it('moves a malformed current document aside and regenerates it once', async () => {
     const baseDir = await createBaseDir();
     const profileDir = resolveSlabProfileDir('default', { baseDir });

--- a/src/browser/runtime/local-slab/behavior-profile.test.ts
+++ b/src/browser/runtime/local-slab/behavior-profile.test.ts
@@ -1,0 +1,117 @@
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  BEHAVIOR_FILENAME,
+  BEHAVIOR_SCHEMA_VERSION,
+  loadOrCreateBehaviorProfile,
+} from './behavior-profile.js';
+import { resolveSlabProfileDir } from './profiles.js';
+
+const temporaryDirectories: string[] = [];
+
+async function createBaseDir(): Promise<string> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'webcmd-behavior-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map(directory => rm(directory, { recursive: true, force: true })));
+});
+
+describe('SLAB behavior profiles', () => {
+  it('creates one document on first use and reloads identical traits', async () => {
+    const baseDir = await createBaseDir();
+    let i = 0;
+    const random = () => (i++ % 10) / 10;
+
+    const created = await loadOrCreateBehaviorProfile('Profile 1', { baseDir, random });
+    const loaded = await loadOrCreateBehaviorProfile('Profile 1', { baseDir, random });
+
+    expect(created.schemaVersion).toBe(BEHAVIOR_SCHEMA_VERSION);
+    expect(loaded.traits).toEqual(created.traits);
+    const raw = JSON.parse(await readFile(
+      path.join(baseDir, 'slab', 'profiles', 'Profile 1', BEHAVIOR_FILENAME),
+      'utf8',
+    ));
+    expect(raw.traits).toEqual(created.traits);
+  });
+
+  it('gives two profile ids independent documents', async () => {
+    const baseDir = await createBaseDir();
+
+    const first = await loadOrCreateBehaviorProfile('Profile 1', { baseDir, random: () => 0 });
+    const second = await loadOrCreateBehaviorProfile('Profile 2', { baseDir, random: () => 0.999 });
+
+    expect(first.profileId).toBe('Profile 1');
+    expect(second.profileId).toBe('Profile 2');
+    expect(second.traits).not.toEqual(first.traits);
+  });
+
+  it('serializes concurrent first use so callers share one personality', async () => {
+    const baseDir = await createBaseDir();
+
+    const [first, second] = await Promise.all([
+      loadOrCreateBehaviorProfile('default', { baseDir, random: () => 0 }),
+      loadOrCreateBehaviorProfile('default', { baseDir, random: () => 0.999 }),
+    ]);
+
+    expect(second.traits).toEqual(first.traits);
+  });
+
+  it('moves a malformed current document aside and regenerates it once', async () => {
+    const baseDir = await createBaseDir();
+    const profileDir = resolveSlabProfileDir('default', { baseDir });
+    await mkdir(profileDir, { recursive: true });
+    await writeFile(path.join(profileDir, BEHAVIOR_FILENAME), '{"schemaVersion":1,"traits":');
+
+    const document = await loadOrCreateBehaviorProfile('default', {
+      baseDir,
+      now: () => 123,
+      random: () => 0.5,
+    });
+
+    expect(document.schemaVersion).toBe(BEHAVIOR_SCHEMA_VERSION);
+    expect(await readFile(path.join(profileDir, 'behavior.json.corrupt-123'), 'utf8'))
+      .toBe('{"schemaVersion":1,"traits":');
+  });
+
+  it('errors on a future schema version without overwriting it', async () => {
+    const baseDir = await createBaseDir();
+    const profileDir = resolveSlabProfileDir('default', { baseDir });
+    await mkdir(profileDir, { recursive: true });
+    const futureDocument = JSON.stringify({ schemaVersion: 99, profileId: 'default', traits: {} });
+    await writeFile(path.join(profileDir, BEHAVIOR_FILENAME), futureDocument);
+
+    await expect(loadOrCreateBehaviorProfile('default', { baseDir }))
+      .rejects.toThrow(/newer schema version/i);
+    expect(await readFile(path.join(profileDir, BEHAVIOR_FILENAME), 'utf8')).toBe(futureDocument);
+  });
+
+  it('fails clearly when the behavior profile cannot be persisted', async () => {
+    const baseDir = await createBaseDir();
+    const unavailableDirectory = path.join(baseDir, 'unwritable');
+    await writeFile(unavailableDirectory, 'not a directory');
+
+    await expect(loadOrCreateBehaviorProfile('default', { baseDir: unavailableDirectory }))
+      .rejects.toThrow(/persist behavior profile/i);
+  });
+
+  it('writes only allowlisted behavior traits and disables idle actions', async () => {
+    const baseDir = await createBaseDir();
+    const document = await loadOrCreateBehaviorProfile('default', { baseDir, random: () => 0.5 });
+
+    expect(JSON.stringify(document)).not.toMatch(/cookie|history|canvas|webgl/i);
+    expect(document.traits.idle_between_actions).toBe(false);
+  });
+
+  it('keeps behavior.json owner-readable and writable only', async () => {
+    const baseDir = await createBaseDir();
+    await loadOrCreateBehaviorProfile('default', { baseDir });
+
+    const file = await stat(path.join(resolveSlabProfileDir('default', { baseDir }), BEHAVIOR_FILENAME));
+    expect(file.mode & 0o777).toBe(0o600);
+  });
+});

--- a/src/browser/runtime/local-slab/behavior-profile.ts
+++ b/src/browser/runtime/local-slab/behavior-profile.ts
@@ -16,6 +16,7 @@ export type BehaviorDocument = {
   schemaVersion: typeof BEHAVIOR_SCHEMA_VERSION;
   profileId: string;
   traits: BehaviorTraits;
+  warning?: string;
 };
 
 type Bounds = readonly [number, number];
@@ -103,6 +104,7 @@ export async function loadOrCreateBehaviorProfile(
   }
 
   try {
+    let warning: string | undefined;
     const afterLock = await tryLoad(behaviorPath);
     if (afterLock.kind === 'valid') return afterLock.document;
     if (afterLock.kind === 'future') throw futureVersionError();
@@ -112,6 +114,7 @@ export async function loadOrCreateBehaviorProfile(
       } catch (error) {
         throw persistError(profileId, error);
       }
+      warning = 'Regenerated malformed behavior profile document.';
     }
 
     const document: BehaviorDocument = {
@@ -120,7 +123,7 @@ export async function loadOrCreateBehaviorProfile(
       traits: sampleTraits(random),
     };
     await persist(behaviorPath, document, profileId);
-    return document;
+    return warning ? { ...document, warning } : document;
   } finally {
     await unlink(lockPath).catch(() => undefined);
   }

--- a/src/browser/runtime/local-slab/behavior-profile.ts
+++ b/src/browser/runtime/local-slab/behavior-profile.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, open, readFile, rename, unlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, open, readFile, rename, stat, unlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { DEFAULT_CONFIG, type HumanConfig } from '../../humanizer/config.js';
 import { resolveSlabProfileDir } from './profiles.js';
@@ -69,6 +69,7 @@ const TRAIT_BOUNDS: Record<NumericTrait, Bounds> = {
 
 const LOCK_RETRY_MS = 50;
 const LOCK_TIMEOUT_MS = 5_000;
+const STALE_LOCK_MS = 60_000;
 
 export async function loadOrCreateBehaviorProfile(
   profileId: string,
@@ -100,7 +101,7 @@ export async function loadOrCreateBehaviorProfile(
     const waited = await tryLoad(behaviorPath);
     if (waited.kind === 'valid') return waited.document;
     if (waited.kind === 'future') throw futureVersionError();
-    throw new Error(`Timed out waiting to initialize behavior profile "${profileId}"`);
+    throw new Error(`Timed out waiting for lock "${lockPath}" to initialize behavior profile "${profileId}"`);
   }
 
   try {
@@ -169,6 +170,15 @@ async function acquireLock(lockPath: string, behaviorPath: string): Promise<bool
       return true;
     } catch (error: unknown) {
       if (!isCode(error, 'EEXIST')) throw error;
+      try {
+        const lock = await stat(lockPath);
+        if (Date.now() - lock.mtimeMs > STALE_LOCK_MS) {
+          await unlink(lockPath);
+          continue;
+        }
+      } catch (staleError: unknown) {
+        if (!isCode(staleError, 'ENOENT')) throw staleError;
+      }
       if (Date.now() >= deadline) return false;
       await delay(LOCK_RETRY_MS);
       const existing = await tryLoad(behaviorPath);

--- a/src/browser/runtime/local-slab/behavior-profile.ts
+++ b/src/browser/runtime/local-slab/behavior-profile.ts
@@ -108,6 +108,11 @@ export async function loadOrCreateBehaviorProfile(
     const afterLock = await tryLoad(behaviorPath);
     if (afterLock.kind === 'valid') return afterLock.document;
     if (afterLock.kind === 'future') throw futureVersionError();
+    if (afterLock.kind === 'partial') {
+      const document = migrateBehaviorDocument(afterLock.document, random);
+      await persist(behaviorPath, document, profileId);
+      return document;
+    }
     if (afterLock.kind === 'invalid' && afterLock.raw !== undefined) {
       try {
         await rename(behaviorPath, `${behaviorPath}.corrupt-${now()}`);
@@ -133,6 +138,7 @@ type LoadResult =
   | { kind: 'missing' }
   | { kind: 'invalid'; raw?: string }
   | { kind: 'future' }
+  | { kind: 'partial'; document: unknown }
   | { kind: 'valid'; document: BehaviorDocument };
 
 async function tryLoad(behaviorPath: string): Promise<LoadResult> {
@@ -147,7 +153,8 @@ async function tryLoad(behaviorPath: string): Promise<LoadResult> {
   try {
     const document: unknown = JSON.parse(raw);
     if (hasFutureSchema(document)) return { kind: 'future' };
-    return isBehaviorDocument(document) ? { kind: 'valid', document } : { kind: 'invalid', raw };
+    if (isBehaviorDocument(document)) return { kind: 'valid', document };
+    return isMigratableBehaviorDocument(document) ? { kind: 'partial', document } : { kind: 'invalid', raw };
   } catch {
     return { kind: 'invalid', raw };
   }
@@ -194,6 +201,28 @@ function sampleTraits(random: () => number): BehaviorTraits {
   return traits as BehaviorTraits;
 }
 
+export function migrateBehaviorDocument(raw: unknown, random: () => number = Math.random): BehaviorDocument {
+  if (!isMigratableBehaviorDocument(raw)) throw new Error('Cannot migrate invalid behavior profile document');
+
+  const existingTraits = raw.traits as Record<string, unknown>;
+  const traits: Record<string, number | [number, number] | false> = {
+    idle_between_actions: false,
+  };
+  for (const key of Object.keys(TRAIT_BOUNDS) as NumericTrait[]) {
+    const existing = existingTraits[key];
+    if (existing !== undefined) {
+      traits[key] = existing as number | [number, number];
+      continue;
+    }
+    const defaultValue = DEFAULT_CONFIG[key];
+    traits[key] = Array.isArray(defaultValue)
+      ? sampleTuple(defaultValue, TRAIT_BOUNDS[key], random)
+      : sampleNumber(defaultValue, TRAIT_BOUNDS[key], random);
+  }
+
+  return { schemaVersion: BEHAVIOR_SCHEMA_VERSION, profileId: raw.profileId as string, traits: traits as BehaviorTraits };
+}
+
 function sampleTuple(value: [number, number], bounds: Bounds, random: () => number): [number, number] {
   const first = sampleNumber(value[0], bounds, random);
   const second = sampleNumber(value[1], bounds, random);
@@ -207,19 +236,29 @@ function sampleNumber(value: number, bounds: Bounds, random: () => number): numb
 }
 
 function isBehaviorDocument(value: unknown): value is BehaviorDocument {
+  return isMigratableBehaviorDocument(value)
+    && Object.keys((value as BehaviorDocument).traits).length === Object.keys(TRAIT_BOUNDS).length + 1;
+}
+
+function isMigratableBehaviorDocument(value: unknown): value is Record<string, unknown> & {
+  schemaVersion: typeof BEHAVIOR_SCHEMA_VERSION;
+  profileId: string;
+  traits: Record<string, unknown>;
+} {
   if (!value || typeof value !== 'object') return false;
   const document = value as Record<string, unknown>;
   if (document.schemaVersion !== BEHAVIOR_SCHEMA_VERSION || typeof document.profileId !== 'string') return false;
   if (!document.traits || typeof document.traits !== 'object') return false;
   const traits = document.traits as Record<string, unknown>;
-  const keys = Object.keys(traits).sort();
   const allowedKeys = [...Object.keys(TRAIT_BOUNDS), 'idle_between_actions'].sort();
-  if (keys.length !== allowedKeys.length || keys.some((key, index) => key !== allowedKeys[index])) return false;
+  if (Object.keys(traits).some(key => !allowedKeys.includes(key))) return false;
   if (traits.idle_between_actions !== false) return false;
-  return (Object.keys(TRAIT_BOUNDS) as NumericTrait[]).every(key => {
-    const bounds = TRAIT_BOUNDS[key];
+  return Object.keys(traits).every(key => {
+    if (key === 'idle_between_actions') return true;
+    const numericKey = key as NumericTrait;
+    const bounds = TRAIT_BOUNDS[numericKey];
     const trait = traits[key];
-    return Array.isArray(DEFAULT_CONFIG[key])
+    return Array.isArray(DEFAULT_CONFIG[numericKey])
       ? Array.isArray(trait)
         && trait.length === 2
         && trait.every(item => isBoundedNumber(item, bounds))

--- a/src/browser/runtime/local-slab/behavior-profile.ts
+++ b/src/browser/runtime/local-slab/behavior-profile.ts
@@ -193,12 +193,16 @@ async function persist(behaviorPath: string, document: BehaviorDocument, profile
 function sampleTraits(random: () => number): BehaviorTraits {
   const traits: Record<string, number | [number, number] | false> = { idle_between_actions: false };
   for (const key of Object.keys(TRAIT_BOUNDS) as NumericTrait[]) {
-    const defaultValue = DEFAULT_CONFIG[key];
-    traits[key] = Array.isArray(defaultValue)
-      ? sampleTuple(defaultValue, TRAIT_BOUNDS[key], random)
-      : sampleNumber(defaultValue, TRAIT_BOUNDS[key], random);
+    traits[key] = sampleTrait(key, random);
   }
   return traits as BehaviorTraits;
+}
+
+function sampleTrait(key: NumericTrait, random: () => number): number | [number, number] {
+  const defaultValue = DEFAULT_CONFIG[key];
+  return Array.isArray(defaultValue)
+    ? sampleTuple(defaultValue, TRAIT_BOUNDS[key], random)
+    : sampleNumber(defaultValue, TRAIT_BOUNDS[key], random);
 }
 
 export function migrateBehaviorDocument(raw: unknown, random: () => number = Math.random): BehaviorDocument {
@@ -214,10 +218,7 @@ export function migrateBehaviorDocument(raw: unknown, random: () => number = Mat
       traits[key] = existing as number | [number, number];
       continue;
     }
-    const defaultValue = DEFAULT_CONFIG[key];
-    traits[key] = Array.isArray(defaultValue)
-      ? sampleTuple(defaultValue, TRAIT_BOUNDS[key], random)
-      : sampleNumber(defaultValue, TRAIT_BOUNDS[key], random);
+    traits[key] = sampleTrait(key, random);
   }
 
   return { schemaVersion: BEHAVIOR_SCHEMA_VERSION, profileId: raw.profileId as string, traits: traits as BehaviorTraits };

--- a/src/browser/runtime/local-slab/behavior-profile.ts
+++ b/src/browser/runtime/local-slab/behavior-profile.ts
@@ -1,0 +1,253 @@
+import { chmod, mkdir, open, readFile, rename, unlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { DEFAULT_CONFIG, type HumanConfig } from '../../humanizer/config.js';
+import { resolveSlabProfileDir } from './profiles.js';
+
+export const BEHAVIOR_SCHEMA_VERSION = 1 as const;
+export const BEHAVIOR_FILENAME = 'behavior.json';
+export const BEHAVIOR_LOCK = 'behavior.lock';
+
+type NumericTrait = Exclude<keyof HumanConfig, 'idle_between_actions'>;
+export type BehaviorTraits = Pick<HumanConfig, NumericTrait> & {
+  idle_between_actions: false;
+};
+
+export type BehaviorDocument = {
+  schemaVersion: typeof BEHAVIOR_SCHEMA_VERSION;
+  profileId: string;
+  traits: BehaviorTraits;
+};
+
+type Bounds = readonly [number, number];
+
+// This is the complete persistence allowlist. Bounds are the hard limits for
+// sampled values; the generated value is additionally constrained to ±20% of
+// the default in humanizer/config.ts.
+const TRAIT_BOUNDS: Record<NumericTrait, Bounds> = {
+  typing_delay: [0, 10_000],
+  typing_delay_spread: [0, 10_000],
+  typing_pause_chance: [0, 1],
+  typing_pause_range: [0, 60_000],
+  shift_down_delay: [0, 10_000],
+  shift_up_delay: [0, 10_000],
+  key_hold: [0, 10_000],
+  field_switch_delay: [0, 60_000],
+  mistype_chance: [0, 1],
+  mistype_delay_notice: [0, 60_000],
+  mistype_delay_correct: [0, 60_000],
+  mouse_steps_divisor: [0, 1_000],
+  mouse_min_steps: [0, 10_000],
+  mouse_max_steps: [0, 10_000],
+  mouse_wobble_max: [0, 10_000],
+  mouse_overshoot_chance: [0, 1],
+  mouse_overshoot_px: [0, 10_000],
+  mouse_burst_size: [0, 10_000],
+  mouse_burst_pause: [0, 60_000],
+  click_aim_delay_input: [0, 60_000],
+  click_aim_delay_button: [0, 60_000],
+  click_hold_input: [0, 60_000],
+  click_hold_button: [0, 60_000],
+  click_input_x_range: [0, 1],
+  idle_drift_px: [0, 10_000],
+  idle_pause_range: [0, 60_000],
+  scroll_delta_base: [0, 100_000],
+  scroll_delta_variance: [0, 1],
+  scroll_pause_fast: [0, 60_000],
+  scroll_pause_slow: [0, 60_000],
+  scroll_accel_steps: [0, 10_000],
+  scroll_decel_steps: [0, 10_000],
+  scroll_overshoot_chance: [0, 1],
+  scroll_overshoot_px: [0, 100_000],
+  scroll_settle_delay: [0, 60_000],
+  scroll_target_zone: [0, 1],
+  scroll_pre_move_delay: [0, 60_000],
+  initial_cursor_x: [0, 100_000],
+  initial_cursor_y: [0, 100_000],
+  idle_between_duration: [0, 60_000],
+};
+
+const LOCK_RETRY_MS = 50;
+const LOCK_TIMEOUT_MS = 5_000;
+
+export async function loadOrCreateBehaviorProfile(
+  profileId: string,
+  opts: {
+    baseDir?: string;
+    random?: () => number;
+    now?: () => number;
+  } = {},
+): Promise<BehaviorDocument> {
+  const profileDir = resolveSlabProfileDir(profileId, { baseDir: opts.baseDir });
+  const behaviorPath = path.join(profileDir, BEHAVIOR_FILENAME);
+  const lockPath = path.join(profileDir, BEHAVIOR_LOCK);
+  const random = opts.random ?? Math.random;
+  const now = opts.now ?? Date.now;
+
+  try {
+    await mkdir(profileDir, { recursive: true, mode: 0o700 });
+    await chmod(profileDir, 0o700);
+  } catch (error) {
+    throw persistError(profileId, error);
+  }
+
+  const existing = await tryLoad(behaviorPath);
+  if (existing.kind === 'valid') return existing.document;
+  if (existing.kind === 'future') throw futureVersionError();
+
+  const acquired = await acquireLock(lockPath, behaviorPath);
+  if (!acquired) {
+    const waited = await tryLoad(behaviorPath);
+    if (waited.kind === 'valid') return waited.document;
+    if (waited.kind === 'future') throw futureVersionError();
+    throw new Error(`Timed out waiting to initialize behavior profile "${profileId}"`);
+  }
+
+  try {
+    const afterLock = await tryLoad(behaviorPath);
+    if (afterLock.kind === 'valid') return afterLock.document;
+    if (afterLock.kind === 'future') throw futureVersionError();
+    if (afterLock.kind === 'invalid' && afterLock.raw !== undefined) {
+      try {
+        await rename(behaviorPath, `${behaviorPath}.corrupt-${now()}`);
+      } catch (error) {
+        throw persistError(profileId, error);
+      }
+    }
+
+    const document: BehaviorDocument = {
+      schemaVersion: BEHAVIOR_SCHEMA_VERSION,
+      profileId,
+      traits: sampleTraits(random),
+    };
+    await persist(behaviorPath, document, profileId);
+    return document;
+  } finally {
+    await unlink(lockPath).catch(() => undefined);
+  }
+}
+
+type LoadResult =
+  | { kind: 'missing' }
+  | { kind: 'invalid'; raw?: string }
+  | { kind: 'future' }
+  | { kind: 'valid'; document: BehaviorDocument };
+
+async function tryLoad(behaviorPath: string): Promise<LoadResult> {
+  let raw: string;
+  try {
+    raw = await readFile(behaviorPath, 'utf8');
+  } catch (error: unknown) {
+    if (isCode(error, 'ENOENT')) return { kind: 'missing' };
+    throw error;
+  }
+
+  try {
+    const document: unknown = JSON.parse(raw);
+    if (hasFutureSchema(document)) return { kind: 'future' };
+    return isBehaviorDocument(document) ? { kind: 'valid', document } : { kind: 'invalid', raw };
+  } catch {
+    return { kind: 'invalid', raw };
+  }
+}
+
+async function acquireLock(lockPath: string, behaviorPath: string): Promise<boolean> {
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+  while (true) {
+    try {
+      const handle = await open(lockPath, 'wx', 0o600);
+      await handle.close();
+      return true;
+    } catch (error: unknown) {
+      if (!isCode(error, 'EEXIST')) throw error;
+      if (Date.now() >= deadline) return false;
+      await delay(LOCK_RETRY_MS);
+      const existing = await tryLoad(behaviorPath);
+      if (existing.kind === 'valid' || existing.kind === 'future') return false;
+    }
+  }
+}
+
+async function persist(behaviorPath: string, document: BehaviorDocument, profileId: string): Promise<void> {
+  const temporaryPath = `${behaviorPath}.tmp`;
+  try {
+    await writeFile(temporaryPath, `${JSON.stringify(document)}\n`, { encoding: 'utf8', mode: 0o600 });
+    await chmod(temporaryPath, 0o600);
+    await rename(temporaryPath, behaviorPath);
+    await chmod(behaviorPath, 0o600);
+  } catch (error) {
+    await unlink(temporaryPath).catch(() => undefined);
+    throw persistError(profileId, error);
+  }
+}
+
+function sampleTraits(random: () => number): BehaviorTraits {
+  const traits: Record<string, number | [number, number] | false> = { idle_between_actions: false };
+  for (const key of Object.keys(TRAIT_BOUNDS) as NumericTrait[]) {
+    const defaultValue = DEFAULT_CONFIG[key];
+    traits[key] = Array.isArray(defaultValue)
+      ? sampleTuple(defaultValue, TRAIT_BOUNDS[key], random)
+      : sampleNumber(defaultValue, TRAIT_BOUNDS[key], random);
+  }
+  return traits as BehaviorTraits;
+}
+
+function sampleTuple(value: [number, number], bounds: Bounds, random: () => number): [number, number] {
+  const first = sampleNumber(value[0], bounds, random);
+  const second = sampleNumber(value[1], bounds, random);
+  return first <= second ? [first, second] : [second, first];
+}
+
+function sampleNumber(value: number, bounds: Bounds, random: () => number): number {
+  const lower = Math.max(bounds[0], value * 0.8);
+  const upper = Math.min(bounds[1], value * 1.2);
+  return lower + Math.min(1, Math.max(0, random())) * (upper - lower);
+}
+
+function isBehaviorDocument(value: unknown): value is BehaviorDocument {
+  if (!value || typeof value !== 'object') return false;
+  const document = value as Record<string, unknown>;
+  if (document.schemaVersion !== BEHAVIOR_SCHEMA_VERSION || typeof document.profileId !== 'string') return false;
+  if (!document.traits || typeof document.traits !== 'object') return false;
+  const traits = document.traits as Record<string, unknown>;
+  const keys = Object.keys(traits).sort();
+  const allowedKeys = [...Object.keys(TRAIT_BOUNDS), 'idle_between_actions'].sort();
+  if (keys.length !== allowedKeys.length || keys.some((key, index) => key !== allowedKeys[index])) return false;
+  if (traits.idle_between_actions !== false) return false;
+  return (Object.keys(TRAIT_BOUNDS) as NumericTrait[]).every(key => {
+    const bounds = TRAIT_BOUNDS[key];
+    const trait = traits[key];
+    return Array.isArray(DEFAULT_CONFIG[key])
+      ? Array.isArray(trait)
+        && trait.length === 2
+        && trait.every(item => isBoundedNumber(item, bounds))
+        && trait[0] <= trait[1]
+      : isBoundedNumber(trait, bounds);
+  });
+}
+
+function hasFutureSchema(value: unknown): boolean {
+  return !!value
+    && typeof value === 'object'
+    && typeof (value as Record<string, unknown>).schemaVersion === 'number'
+    && (value as Record<string, number>).schemaVersion > BEHAVIOR_SCHEMA_VERSION;
+}
+
+function isBoundedNumber(value: unknown, bounds: Bounds): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= bounds[0] && value <= bounds[1];
+}
+
+function futureVersionError(): Error {
+  return new Error(`Behavior profile uses a newer schema version than supported (${BEHAVIOR_SCHEMA_VERSION})`);
+}
+
+function persistError(profileId: string, cause: unknown): Error {
+  return new Error(`Unable to persist behavior profile "${profileId}": ${cause instanceof Error ? cause.message : String(cause)}`);
+}
+
+function isCode(error: unknown, code: string): boolean {
+  return typeof error === 'object' && error !== null && (error as { code?: string }).code === code;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/src/browser/runtime/local-slab/session-manager.test.ts
+++ b/src/browser/runtime/local-slab/session-manager.test.ts
@@ -1,7 +1,25 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { dispatchSlabAction } from './actions.js';
 import { SlabSessionManager } from './session-manager.js';
 import { humanizePage } from '../../humanizer/page.js';
+import { loadOrCreateBehaviorProfile } from './behavior-profile.js';
+
+vi.mock('./behavior-profile.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('./behavior-profile.js')>(),
+  loadOrCreateBehaviorProfile: vi.fn(),
+}));
+
+const behaviorTraits = { typing_delay: 123 } as any;
+const behaviorDocument = {
+  schemaVersion: 1 as const,
+  profileId: 'default',
+  traits: behaviorTraits,
+};
+const loadBehaviorProfile = vi.mocked(loadOrCreateBehaviorProfile);
+afterEach(() => {
+  loadBehaviorProfile.mockReset();
+  loadBehaviorProfile.mockResolvedValue(behaviorDocument);
+});
 
 function fakeAttachedProfile() {
   const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
@@ -216,6 +234,67 @@ async function flushPageEvent(): Promise<void> {
 }
 
 describe('SlabSessionManager ownership', () => {
+  it('loads one behavior profile for owned pages and passes its traits to humanize', async () => {
+    const attached = fakeAttachedProfile();
+    const humanize = vi.fn((page: any, _config?: any) => page);
+    loadBehaviorProfile.mockResolvedValue(behaviorDocument);
+    const manager = new SlabSessionManager({
+      attachProfile: vi.fn().mockResolvedValue(attached.attachment),
+      humanize,
+    });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
+
+    await manager.getPage(input);
+    await manager.getPage({ ...input, session: 'agent-2', sessionId: 'agent-2' });
+
+    expect(loadBehaviorProfile).toHaveBeenCalledTimes(1);
+    expect(loadBehaviorProfile).toHaveBeenCalledWith('default', { baseDir: undefined });
+    expect(humanize).toHaveBeenCalled();
+    expect(humanize.mock.calls.every(([, config]) => config === behaviorTraits)).toBe(true);
+  });
+
+  it('does not load behavior while discovering pages', async () => {
+    const attached = fakeAttachedProfile();
+    const humanize = vi.fn(page => page);
+    loadBehaviorProfile.mockClear();
+    const manager = new SlabSessionManager({
+      attachProfile: vi.fn().mockResolvedValue(attached.attachment),
+      humanize,
+    });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
+
+    await manager.listPages(input);
+    await manager.discoveredWindows('default');
+
+    expect(loadBehaviorProfile).not.toHaveBeenCalled();
+    expect(humanize).not.toHaveBeenCalled();
+  });
+
+  it('keys behavior loading by native SLAB profile id', async () => {
+    const attached = fakeAttachedProfile();
+    loadBehaviorProfile.mockResolvedValue({ ...behaviorDocument, profileId: 'Profile 1' });
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
+
+    await manager.getPage({ profileId: 'Profile 1', session: 'agent', sessionId: 'agent', surface: 'browser' });
+
+    expect(loadBehaviorProfile).toHaveBeenCalledWith('Profile 1', { baseDir: undefined });
+  });
+
+  it('reports behavioral-state failures without humanizing an otherwise attached page', async () => {
+    const attached = fakeAttachedProfile();
+    const humanize = vi.fn(page => page);
+    loadBehaviorProfile.mockRejectedValue(new Error('storage unavailable'));
+    const attachProfile = vi.fn().mockResolvedValue(attached.attachment);
+    const manager = new SlabSessionManager({ attachProfile, humanize });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
+
+    await expect(manager.getPage(input)).rejects.toThrow(/behavioral state.*storage unavailable/i);
+
+    expect(attachProfile).toHaveBeenCalledOnce();
+    expect(humanize).not.toHaveBeenCalled();
+    expect(attached.attachment.release).not.toHaveBeenCalled();
+  });
+
   it('discovers unowned human tabs without creating, owning, or humanizing a page', async () => {
     const attached = fakeAttachedProfile();
     attached.moveToWindow(attached.humanBlank, attached.windowIdFor(attached.humanPage)!);

--- a/src/browser/runtime/local-slab/session-manager.test.ts
+++ b/src/browser/runtime/local-slab/session-manager.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { dispatchSlabAction } from './actions.js';
 import { SlabSessionManager } from './session-manager.js';
@@ -234,6 +236,13 @@ async function flushPageEvent(): Promise<void> {
 }
 
 describe('SlabSessionManager ownership', () => {
+  it('does not enable Playwright tracing or snapshots for agent sessions', () => {
+    const source = readFileSync(fileURLToPath(new URL('./session-manager.ts', import.meta.url)), 'utf8');
+
+    expect(source).not.toMatch(/\btracing\.start\b/);
+    expect(source).not.toMatch(/\bsnapshots\s*:\s*true\b/);
+  });
+
   it('loads one behavior profile for owned pages and passes its traits to humanize', async () => {
     const attached = fakeAttachedProfile();
     const humanize = vi.fn((page: any, _config?: any) => page);

--- a/src/browser/runtime/local-slab/session-manager.test.ts
+++ b/src/browser/runtime/local-slab/session-manager.test.ts
@@ -5,6 +5,7 @@ import { dispatchSlabAction } from './actions.js';
 import { SlabSessionManager } from './session-manager.js';
 import { humanizePage } from '../../humanizer/page.js';
 import { loadOrCreateBehaviorProfile } from './behavior-profile.js';
+import { log } from '../../../logger.js';
 
 vi.mock('./behavior-profile.js', async (importOriginal) => ({
   ...await importOriginal<typeof import('./behavior-profile.js')>(),
@@ -260,6 +261,22 @@ describe('SlabSessionManager ownership', () => {
     expect(loadBehaviorProfile).toHaveBeenCalledWith('default', { baseDir: undefined });
     expect(humanize).toHaveBeenCalled();
     expect(humanize.mock.calls.every(([, config]) => config === behaviorTraits)).toBe(true);
+  });
+
+  it('warns when a corrupt behavior profile was regenerated', async () => {
+    const attached = fakeAttachedProfile();
+    const warn = vi.spyOn(log, 'warn').mockImplementation(() => undefined);
+    loadBehaviorProfile.mockResolvedValue({
+      ...behaviorDocument,
+      warning: 'Regenerated malformed behavior profile document.',
+    });
+    const manager = new SlabSessionManager({ attachProfile: vi.fn().mockResolvedValue(attached.attachment) });
+    const input = { profileId: 'default', session: 'agent', sessionId: 'agent', surface: 'browser' as const };
+
+    await manager.getPage(input);
+
+    expect(warn).toHaveBeenCalledWith('Regenerated malformed behavior profile document.');
+    warn.mockRestore();
   });
 
   it('does not load behavior while discovering pages', async () => {

--- a/src/browser/runtime/local-slab/session-manager.ts
+++ b/src/browser/runtime/local-slab/session-manager.ts
@@ -8,6 +8,7 @@ import { isClosedContextError } from '../../run/types.js';
 import { disposeHumanizedPage, humanizePage } from '../../humanizer/page.js';
 import { attachSlabProfile, type AttachedSlabProfile } from './attachment.js';
 import type { DiscoveredBrowserWindowListRow } from '../../sessions.js';
+import { loadOrCreateBehaviorProfile, type BehaviorDocument } from './behavior-profile.js';
 
 const TARGET_PAGE_MATCH_TIMEOUT_MS = 1_000;
 export const PROFILE_IDLE_TIMEOUT_MS = 60_000;
@@ -95,6 +96,7 @@ interface ProfileRuntime {
   profileId: string;
   attachment: AttachedSlabProfile;
   context: BrowserContext;
+  behavior?: BehaviorDocument;
   cdp?: CDPSession;
   sessions: Map<string, SessionRuntime>;
   windowOwners: Map<number, string>;
@@ -165,7 +167,7 @@ export interface SlabSessionManagerOptions {
   baseDir?: string;
   attachProfile?: AttachSlabProfile;
   hasActiveHandoff?: (profileId: string) => boolean;
-  humanize?: typeof humanizePage;
+  humanize?: (page: PlaywrightPage, config?: Parameters<typeof humanizePage>[1]) => PlaywrightPage;
 }
 
 let pageCounter = 0;
@@ -206,7 +208,7 @@ export class SlabSessionManager {
 
   private readonly attachProfile: AttachSlabProfile;
   private readonly hasActiveHandoff: (profileId: string) => boolean;
-  private readonly humanize: typeof humanizePage;
+  private readonly humanize: (page: PlaywrightPage, config?: Parameters<typeof humanizePage>[1]) => PlaywrightPage;
   private readonly profiles = new Map<string, ProfileRuntime>();
   private readonly detachedSessions = new Map<string, Set<string>>();
   private readonly profileLaunches = new Map<string, Promise<ProfileRuntime>>();
@@ -679,9 +681,10 @@ export class SlabSessionManager {
     }
     const newlyHumanized: PlaywrightPage[] = [];
     try {
+      const behavior = await this.ensureBehavior(runtime);
       for (const sibling of siblings) {
         if (!(sibling as unknown as { _original?: unknown })._original) {
-          this.humanize(sibling);
+          this.humanize(sibling, behavior.traits);
           newlyHumanized.push(sibling);
         }
       }
@@ -1396,6 +1399,7 @@ export class SlabSessionManager {
       humanize?: boolean;
     },
   ): Promise<PageEntry> {
+    const behavior = input.humanize !== false ? await this.ensureBehavior(runtime) : undefined;
     const targetId = await this.targetIdForPage(runtime, page);
     this.clearPendingTargetPage(runtime, targetId, page);
     const windowId = await this.windowIdForTarget(runtime, targetId, page);
@@ -1455,7 +1459,7 @@ export class SlabSessionManager {
       entry.leaseKey = input.leaseKey ?? (entry.leaseKey.startsWith('unowned\u0000') ? `page\u0000${entry.pageId}` : entry.leaseKey);
     }
     session.pages.set(entry.leaseKey, entry);
-    if (input.humanize !== false) this.humanize(page);
+    if (behavior) this.humanize(page, behavior.traits);
     this.cancelProfileIdle(runtime);
     this.refreshIdleTimer(runtime, session, entry.leaseKey, entry);
     if (!wasOwned) for (const listener of this.sessionPageListeners.get(session) ?? []) listener(page);
@@ -1479,6 +1483,18 @@ export class SlabSessionManager {
         await disposeHumanizedPage(entry.page);
       }
       throw error;
+    }
+  }
+
+  private async ensureBehavior(runtime: ProfileRuntime): Promise<BehaviorDocument> {
+    if (runtime.behavior) return runtime.behavior;
+    try {
+      runtime.behavior = await loadOrCreateBehaviorProfile(runtime.profileId, { baseDir: this.opts.baseDir });
+      return runtime.behavior;
+    } catch (error) {
+      throw new Error(
+        `Unable to load SLAB behavioral state for profile "${runtime.profileId}": ${errorMessage(error)}`,
+      );
     }
   }
 

--- a/src/browser/runtime/local-slab/session-manager.ts
+++ b/src/browser/runtime/local-slab/session-manager.ts
@@ -1490,6 +1490,7 @@ export class SlabSessionManager {
     if (runtime.behavior) return runtime.behavior;
     try {
       runtime.behavior = await loadOrCreateBehaviorProfile(runtime.profileId, { baseDir: this.opts.baseDir });
+      if (runtime.behavior.warning) log.warn(runtime.behavior.warning);
       return runtime.behavior;
     } catch (error) {
       throw new Error(


### PR DESCRIPTION
## Description

Persist a versioned allowlisted behavior document per native SLAB Profile, load it once per daemon Profile runtime, and apply it on agent-owned pages. Suppress intentional mistypes on sensitive fields, cancel in-flight humanizer sleeps on dispose, and keep Playwright tracing snapshots off the agent path.

Related issue: SLAB daily-driver stealth (orchestrator plan `2026-09-08-slab-daily-driver-stealth-01-webcmd-behavior`)

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [ ] I included output or screenshots when useful
- [ ] If I edited `skill-src/`, I ran `make build` and committed `skills/`

### Adapter Notes

- [ ] Updated generated or lean docs when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Test plan
- [x] `npm test` in the worktree: 3537 passed, 92 skipped (after rebase onto `origin/main`)
- [ ] CI unit suite green
- [ ] Corrupt `behavior.json` regenerates once and `ensureBehavior` logs the warning
- [ ] Password / `cc-*` / `one-time-code` fields do not get intentional mistypes
- [ ] Disposing an agent page aborts in-flight `type`/`check` rather than falling back to stock Playwright clicks


Made with [Cursor](https://cursor.com)