### PR TITLE
fix: show disconnected profiles in plain output, offer sync-to-chrome interactively

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1982,6 +1982,37 @@ describe('profile list', () => {
     expect(output).not.toContain(`Webcmd ${'extension'}`);
     expect(output).not.toContain('webcmd daemon restart');
   });
+
+  it('lists disconnected saved aliases when no runtime profiles are connected', async () => {
+    fs.mkdirSync(process.env.WEBCMD_CONFIG_DIR!, { recursive: true });
+    fs.writeFileSync(path.join(process.env.WEBCMD_CONFIG_DIR!, 'browser-profiles.json'), JSON.stringify({
+      version: 1,
+      aliases: { work: 'ctx_work' },
+    }));
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        pid: 123,
+        uptime: 1,
+        daemonVersion: PKG_VERSION,
+        runtimeConnected: false,
+        runtimeName: 'Cloak',
+        profiles: [],
+        pending: 0,
+        memoryMB: 20,
+        port: 9777,
+      }),
+    } as Response);
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'webcmd', 'profile', 'list']);
+
+    const output = stdoutSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('Disconnected saved profiles:');
+    expect(output).toContain('ctx_work work — not connected');
+    expect(output).not.toContain('No Cloak runtime profiles are active');
+  });
 });
 
 describe('structured output for data-returning built-ins', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2010,7 +2010,7 @@ cli({
         console.log('Run: webcmd daemon restart');
         return;
       }
-      if (profiles.length === 0) {
+      if (profiles.length === 0 && Object.keys(config.aliases).length === 0 && !config.defaultContextId) {
         console.log(`No ${selectedProfileProviderLabel()} runtime profiles are active.`);
         console.log('Run a browser-backed command or webcmd <site> login to create one.');
         return;

--- a/src/hosted/setup.test.ts
+++ b/src/hosted/setup.test.ts
@@ -285,7 +285,7 @@ describe('webcmd setup', () => {
   it('prompts to import Chrome cookies interactively and honors a "no" answer', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-chrome-cookies-prompt-'));
     const env = { WEBCMD_CONFIG_DIR: tempDir } as NodeJS.ProcessEnv;
-    const answers = ['chrome', 'n'];
+    const answers = ['chrome', '', 'n'];
     const prompts: string[] = [];
     const importChromeCookies = vi.fn();
 
@@ -424,6 +424,124 @@ describe('webcmd setup', () => {
     })).resolves.not.toBe(0);
 
     expect(messages.join('')).toContain('--chrome-profile, --import-chrome-cookies, and --sync-to-chrome are only valid with --browser chrome');
+  });
+
+  it('prompts for sync-to-chrome interactively and persists on y', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-chrome-sync-prompt-yes-'));
+    const env = { WEBCMD_CONFIG_DIR: tempDir } as NodeJS.ProcessEnv;
+    const answers = ['chrome', 'y'];
+    const prompts: string[] = [];
+    const executablePath = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+    await expect(runHostedSetup({
+      env,
+      question: async prompt => {
+        prompts.push(prompt);
+        return answers.shift() ?? '';
+      },
+      resolveGoogleChromeExecutable: async () => executablePath,
+      listChromeCookieSources: () => [],
+      fetchDaemonStatus: async () => null,
+      write: () => undefined,
+    })).resolves.toBe(0);
+
+    expect(prompts).toContain('Export webcmd profiles to native Chrome automatically so they open directly in Chrome? [y/N] ');
+    expect(JSON.parse(await readFile(getConfigPath({ env }), 'utf8'))).toMatchObject({
+      browser: { kind: 'chrome', executablePath, syncToChrome: true },
+    });
+  });
+
+  it('omits syncToChrome when the interactive prompt is declined or left default', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-chrome-sync-prompt-no-'));
+    const env = { WEBCMD_CONFIG_DIR: tempDir } as NodeJS.ProcessEnv;
+    const answers = ['chrome', ''];
+    const prompts: string[] = [];
+    const executablePath = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+    await expect(runHostedSetup({
+      env,
+      question: async prompt => {
+        prompts.push(prompt);
+        return answers.shift() ?? '';
+      },
+      resolveGoogleChromeExecutable: async () => executablePath,
+      listChromeCookieSources: () => [],
+      fetchDaemonStatus: async () => null,
+      write: () => undefined,
+    })).resolves.toBe(0);
+
+    expect(prompts).toContain('Export webcmd profiles to native Chrome automatically so they open directly in Chrome? [y/N] ');
+    expect(JSON.parse(await readFile(getConfigPath({ env }), 'utf8')).browser).toEqual({
+      kind: 'chrome',
+      executablePath,
+    });
+  });
+
+  it('does not prompt for sync-to-chrome when --sync-to-chrome is already set', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-chrome-sync-flag-no-prompt-'));
+    const env = { WEBCMD_CONFIG_DIR: tempDir } as NodeJS.ProcessEnv;
+    const prompts: string[] = [];
+    const executablePath = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+    await expect(runHostedSetup({
+      env,
+      argv: ['--browser', 'chrome', '--sync-to-chrome', '--no-import-chrome-cookies'],
+      question: async prompt => {
+        prompts.push(prompt);
+        return '';
+      },
+      resolveGoogleChromeExecutable: async () => executablePath,
+      fetchDaemonStatus: async () => null,
+      write: () => undefined,
+    })).resolves.toBe(0);
+
+    expect(prompts).not.toContain('Export webcmd profiles to native Chrome automatically so they open directly in Chrome? [y/N] ');
+    expect(JSON.parse(await readFile(getConfigPath({ env }), 'utf8'))).toMatchObject({
+      browser: { kind: 'chrome', executablePath, syncToChrome: true },
+    });
+  });
+
+  it('does not prompt for sync-to-chrome when selecting cloak interactively', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-cloak-no-sync-prompt-'));
+    const env = { WEBCMD_CONFIG_DIR: tempDir } as NodeJS.ProcessEnv;
+    const prompts: string[] = [];
+
+    await expect(runHostedSetup({
+      env,
+      platform: 'linux',
+      question: async prompt => {
+        prompts.push(prompt);
+        return 'cloak';
+      },
+      fetchDaemonStatus: async () => null,
+      write: () => undefined,
+    })).resolves.toBe(0);
+
+    expect(prompts).not.toContain('Export webcmd profiles to native Chrome automatically so they open directly in Chrome? [y/N] ');
+  });
+
+  it('does not prompt for sync-to-chrome when selecting slab interactively', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-slab-no-sync-prompt-'));
+    const env = { WEBCMD_CONFIG_DIR: tempDir } as NodeJS.ProcessEnv;
+    const prompts: string[] = [];
+
+    await expect(runHostedSetup({
+      env,
+      platform: 'darwin',
+      homeDir: '/Users/me',
+      question: async prompt => {
+        prompts.push(prompt);
+        return 'slab';
+      },
+      existsSync: candidate => candidate === '/Applications/SLAB.app/Contents/MacOS/SLAB',
+      verifySlabApp: async () => undefined,
+      launchSlabApp: async () => undefined,
+      inspectSlabStatus: async () => 'installed-running',
+      fetchDaemonStatus: async () => null,
+      write: () => undefined,
+    })).resolves.toBe(0);
+
+    expect(prompts).not.toContain('Export webcmd profiles to native Chrome automatically so they open directly in Chrome? [y/N] ');
   });
 
   it('persists sync-to-chrome mode with --browser chrome --sync-to-chrome', async () => {

--- a/src/hosted/setup.ts
+++ b/src/hosted/setup.ts
@@ -122,9 +122,14 @@ export async function runHostedSetup(io: SetupIo = {}): Promise<number> {
       );
     }
     browser ??= { kind: 'cloak' };
+    let syncToChrome = parsed.syncToChrome;
+    if (browser.kind === 'chrome' && syncToChrome === undefined && interactive) {
+      const answer = (await ask('Export webcmd profiles to native Chrome automatically so they open directly in Chrome? [y/N] ')).trim().toLowerCase();
+      syncToChrome = answer.startsWith('y');
+    }
     const before = await (io.fetchDaemonStatus ?? fetchDaemonStatus)();
     try {
-      const selected = await validateLocalBrowser(browser, io, chromeDiscovery, parsed.syncToChrome);
+      const selected = await validateLocalBrowser(browser, io, chromeDiscovery, syncToChrome);
       if (selected.kind === 'chrome') await maybeImportChromeCookies(parsed, io, interactive, ask, write);
       (io.saveConfig ?? saveWebcmdConfig)(makeLocalConfig(io.now?.() ?? new Date(), selected), io);
       if (before) await restartConfiguredDaemon(selected, io);


### PR DESCRIPTION
## Summary
Two bugs found while manually testing the just-released v0.8.3 Chrome-export feature:

**1. `webcmd profile list` (plain-text output) hides saved-but-disconnected profiles when zero are currently connected**
- The early-return guard fired on `profiles.length === 0` alone, before ever consulting the saved alias registry — so a profile created via `profile create` but never launched was completely invisible in the default output, even though the structured (`-f json`) output already showed it correctly via `profileListRows()`.
- Fix: the guard now also checks `config.aliases` and `config.defaultContextId` before deciding there's nothing to show.

**2. `webcmd setup` never offers `--sync-to-chrome` interactively**
- Picking "chrome" at the interactive `Local browser [cloak/chrome/slab/absolute path]` prompt never mentions or asks about sync-to-chrome — unlike `--import-chrome-cookies`, which does get an interactive `[Y/n]` prompt. The only way to discover the feature was already knowing the flag name.
- Fix: added an equivalent `[y/N]` prompt (defaults to no, since it writes real files into the user's native Chrome directory — a bigger behavior change than cookie import), asked only when browser is chrome, the flag wasn't passed either way, and the session is interactive.

## Test plan
- [x] Full suite: 206/206 test files, 3652 passed, 2 skipped (confirmed under reduced worker concurrency; full-parallelism runs on this machine hit transient flakiness from unrelated `runner.test.ts` browser-context contention under high system load — every flaky file passes cleanly alone)
- [x] `npm run typecheck` — clean
- [x] New tests cover: disconnected-alias listing, the true-empty case (unchanged), the new prompt firing/persisting on yes, omitting the field on no/default, never prompting when the flag is already set, never prompting for cloak/slab

🤖 Generated with [Claude Code](https://claude.com/claude-code)