### PR TITLE
fix(chrome): debounce sync-to-chrome export and set the exported profile's display name

### DIFF
--- a/src/browser/google-chrome.test.ts
+++ b/src/browser/google-chrome.test.ts
@@ -10,6 +10,7 @@ import {
   importChromeCookies,
   isProfileRegisteredInLocalState,
   listChromeCookieSources,
+  setProfileDisplayName,
 } from './google-chrome.js';
 
 describe('Google Chrome discovery', () => {
@@ -256,5 +257,39 @@ describe('isProfileRegisteredInLocalState', () => {
   it('reports false when Local State is missing or unreadable', () => {
     const readFileSync = () => { throw new Error('ENOENT'); };
     expect(isProfileRegisteredInLocalState(chromeRoot, 'webcmd-work', { readFileSync })).toBe(false);
+  });
+});
+
+describe('setProfileDisplayName', () => {
+  const chromeRoot = path.join('Users', 'test', 'Chrome');
+  const localStatePath = path.join(chromeRoot, 'Local State');
+
+  it('sets the name when the entry exists', () => {
+    const writeFileSync = vi.fn();
+    setProfileDisplayName(chromeRoot, 'test1', 'test1', {
+      readFileSync: (() => JSON.stringify({ profile: { info_cache: { test1: { name: 'Person 2' } } } })) as unknown as typeof import('node:fs').readFileSync,
+      writeFileSync: writeFileSync as unknown as typeof import('node:fs').writeFileSync,
+    });
+    expect(writeFileSync).toHaveBeenCalledOnce();
+    expect(writeFileSync.mock.calls[0][0]).toBe(localStatePath);
+    expect(JSON.parse(writeFileSync.mock.calls[0][1] as string).profile.info_cache.test1.name).toBe('test1');
+  });
+
+  it('leaves the file alone when the profileDirectory key is not in info_cache', () => {
+    const writeFileSync = vi.fn();
+    setProfileDisplayName(chromeRoot, 'test1', 'test1', {
+      readFileSync: (() => JSON.stringify({ profile: { info_cache: { Default: { name: 'Person 1' } } } })) as unknown as typeof import('node:fs').readFileSync,
+      writeFileSync: writeFileSync as unknown as typeof import('node:fs').writeFileSync,
+    });
+    expect(writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when Local State is missing, unreadable, or malformed JSON', () => {
+    expect(() => setProfileDisplayName(chromeRoot, 'test1', 'test1', {
+      readFileSync: (() => { throw new Error('ENOENT'); }) as unknown as typeof import('node:fs').readFileSync,
+    })).not.toThrow();
+    expect(() => setProfileDisplayName(chromeRoot, 'test1', 'test1', {
+      readFileSync: (() => '{not json') as unknown as typeof import('node:fs').readFileSync,
+    })).not.toThrow();
   });
 });

--- a/src/browser/google-chrome.ts
+++ b/src/browser/google-chrome.ts
@@ -288,3 +288,35 @@ export function isProfileRegisteredInLocalState(
     return false;
   }
 }
+
+export interface SetProfileDisplayNameOptions {
+  readFileSync?: typeof fs.readFileSync;
+  writeFileSync?: typeof fs.writeFileSync;
+}
+
+/**
+ * Sets a native Chrome profile's display name in Local State to exactly
+ * `name`. Best-effort and silent on any failure — this is cosmetic only;
+ * the profile still works correctly with Chrome's own generic name if this
+ * fails or never runs.
+ */
+export function setProfileDisplayName(
+  userDataDir: string,
+  profileDirectory: string,
+  name: string,
+  opts: SetProfileDisplayNameOptions = {},
+): void {
+  const readFileSync = opts.readFileSync ?? fs.readFileSync;
+  const writeFileSync = opts.writeFileSync ?? fs.writeFileSync;
+  try {
+    const localStatePath = path.join(userDataDir, 'Local State');
+    const raw = readFileSync(localStatePath, 'utf-8');
+    const parsed = JSON.parse(raw) as { profile?: { info_cache?: Record<string, { name?: unknown }> } };
+    const entry = parsed.profile?.info_cache?.[profileDirectory];
+    if (!entry) return;
+    entry.name = name;
+    writeFileSync(localStatePath, JSON.stringify(parsed), 'utf-8');
+  } catch {
+    // Missing/unreadable/malformed Local State: leave the generic name in place.
+  }
+}

--- a/src/browser/runtime/local-cloak/chrome-profile-export.test.ts
+++ b/src/browser/runtime/local-cloak/chrome-profile-export.test.ts
@@ -11,6 +11,7 @@ function deps(overrides: Partial<RegisterNativeChromeProfileDeps> = {}): Registe
     delay: vi.fn().mockImplementation(async (ms: number) => { now += ms; }),
     now: vi.fn(() => now),
     platform: 'darwin',
+    setDisplayName: vi.fn(),
     ...overrides,
   };
 }
@@ -74,5 +75,57 @@ describe('registerNativeChromeProfile', () => {
 
     expect(result).toEqual({ registered: true });
     expect(d.terminate).not.toHaveBeenCalled();
+  });
+
+  it('sets the Chrome display name to the alias after killing a spawned registration process', async () => {
+    const d = deps({
+      isRegistered: vi.fn().mockReturnValue(true),
+      findProcesses: vi.fn().mockResolvedValue([4242]),
+    });
+
+    await registerNativeChromeProfile(
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      '/Users/test/Chrome',
+      'test1',
+      d,
+    );
+
+    expect(d.delay).toHaveBeenCalledWith(300);
+    expect(d.setDisplayName).toHaveBeenCalledWith('/Users/test/Chrome', 'test1', 'test1');
+  });
+
+  // Known limitation: Chrome already running absorbed the request, so the name write is best-effort and may not stick.
+  it('still attempts setDisplayName when no process was spawned (absorbed into existing Chrome; best-effort, may not stick)', async () => {
+    const d = deps({
+      isRegistered: vi.fn().mockReturnValue(true),
+      findProcesses: vi.fn().mockResolvedValue([]),
+    });
+
+    await registerNativeChromeProfile(
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      '/Users/test/Chrome',
+      'test1',
+      d,
+    );
+
+    expect(d.delay).not.toHaveBeenCalledWith(300);
+    expect(d.setDisplayName).toHaveBeenCalledWith('/Users/test/Chrome', 'test1', 'test1');
+  });
+
+  it('does not set the display name when registration never succeeded', async () => {
+    const d = deps({
+      isRegistered: vi.fn().mockReturnValue(false),
+      findProcesses: vi.fn().mockResolvedValue([9]),
+    });
+
+    const result = await registerNativeChromeProfile(
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      '/Users/test/Chrome',
+      'test1',
+      d,
+    );
+
+    expect(result).toEqual({ registered: false });
+    expect(d.setDisplayName).not.toHaveBeenCalled();
   });
 });

--- a/src/browser/runtime/local-cloak/chrome-profile-export.ts
+++ b/src/browser/runtime/local-cloak/chrome-profile-export.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'node:child_process';
 import path from 'node:path';
 import { promisify } from 'node:util';
-import { isProfileRegisteredInLocalState } from '../../google-chrome.js';
+import { isProfileRegisteredInLocalState, setProfileDisplayName } from '../../google-chrome.js';
 import { findExactChromeProcesses, terminateChromeProcessTree } from './chrome-process.js';
 
 const execFileAsync = promisify(execFile);
@@ -16,6 +16,7 @@ export interface RegisterNativeChromeProfileDeps {
   delay(ms: number): Promise<void>;
   now(): number;
   platform: NodeJS.Platform;
+  setDisplayName(userDataDir: string, profileDirectory: string, name: string): void;
 }
 
 async function launchViaOpen(executablePath: string, args: string[]): Promise<void> {
@@ -33,6 +34,7 @@ const defaultDeps: RegisterNativeChromeProfileDeps = {
   delay: ms => new Promise(resolve => setTimeout(resolve, ms)),
   now: Date.now,
   platform: process.platform,
+  setDisplayName: setProfileDisplayName,
 };
 
 /**
@@ -65,8 +67,12 @@ export async function registerNativeChromeProfile(
     registered = deps.isRegistered(userDataDir, profileDirectory);
   }
 
-  for (const pid of await deps.findProcesses(identity, deps.platform)) {
-    await deps.terminate(pid, deps.platform, false);
-  }
+  const pids = await deps.findProcesses(identity, deps.platform);
+  for (const pid of pids) await deps.terminate(pid, deps.platform, false);
+  if (pids.length > 0) await deps.delay(300);
+  // Best-effort: if Chrome was already running, this write was absorbed into
+  // that process and Chrome may later flush its in-memory Local State and
+  // clobber the name. Cosmetic only — never fail the export over it.
+  if (registered) deps.setDisplayName(userDataDir, profileDirectory, profileDirectory);
   return { registered };
 }

--- a/src/browser/runtime/local-cloak/session-manager.test.ts
+++ b/src/browser/runtime/local-cloak/session-manager.test.ts
@@ -1745,6 +1745,11 @@ describe('waitUntil plumbing', () => {
 });
 
 describe('syncToChrome export on profile close', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
   function chromeManager(overrides: Partial<CloakSessionManagerOptions> = {}) {
     const launched = fakeContext();
     const launchChromePersistentContext = vi.fn().mockResolvedValue(launched.context);
@@ -1763,8 +1768,10 @@ describe('syncToChrome export on profile close', () => {
       registerNativeChromeProfile,
       ...overrides,
     });
-    return { manager, ensureNativeProfileDirectory, exportCookiesToNativeChrome, registerNativeChromeProfile };
+    return { manager, launched, ensureNativeProfileDirectory, exportCookiesToNativeChrome, registerNativeChromeProfile };
   }
+
+  const key = { profileId: 'webcmd-work', session: 's1', surface: 'browser' as const };
 
   it('exports cookies and registers the profile once its runtime fully closes', async () => {
     const { manager, ensureNativeProfileDirectory, exportCookiesToNativeChrome, registerNativeChromeProfile } = chromeManager();
@@ -1795,6 +1802,54 @@ describe('syncToChrome export on profile close', () => {
 
     await manager.getPage({ profileId: 'webcmd-work', session: 's1', surface: 'browser' });
     await manager.shutdown();
+
+    expect(exportCookiesToNativeChrome).not.toHaveBeenCalled();
+  });
+
+  it('exports cookies ~3s after a command even while a tab is still open', async () => {
+    vi.useFakeTimers();
+    const { manager, exportCookiesToNativeChrome } = chromeManager();
+
+    await manager.runWithProfileActivity('webcmd-work', () => manager.getPage(key));
+
+    expect(exportCookiesToNativeChrome).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(exportCookiesToNativeChrome).toHaveBeenCalledOnce();
+  });
+
+  it('collapses a burst of commands on the same profile into one export', async () => {
+    vi.useFakeTimers();
+    const { manager, exportCookiesToNativeChrome } = chromeManager();
+
+    await manager.runWithProfileActivity('webcmd-work', () => manager.getPage(key));
+    await vi.advanceTimersByTimeAsync(1_000);
+    await manager.runWithProfileActivity('webcmd-work', () => manager.getPage(key));
+    await vi.advanceTimersByTimeAsync(1_000);
+    await manager.runWithProfileActivity('webcmd-work', () => manager.getPage(key));
+
+    expect(exportCookiesToNativeChrome).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(exportCookiesToNativeChrome).toHaveBeenCalledOnce();
+  });
+
+  it('does not close the browser context or pages when the debounced export fires', async () => {
+    vi.useFakeTimers();
+    const { manager, launched, exportCookiesToNativeChrome } = chromeManager();
+
+    await manager.runWithProfileActivity('webcmd-work', () => manager.getPage(key));
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    expect(exportCookiesToNativeChrome).toHaveBeenCalledOnce();
+    expect(launched.context.close).not.toHaveBeenCalled();
+    expect(launched.page.close).not.toHaveBeenCalled();
+  });
+
+  it('does not export on debounce for a non-syncToChrome profile', async () => {
+    vi.useFakeTimers();
+    const { manager, exportCookiesToNativeChrome } = chromeManager({ syncToChrome: false });
+
+    await manager.runWithProfileActivity('webcmd-work', () => manager.getPage(key));
+    await vi.advanceTimersByTimeAsync(10_000);
 
     expect(exportCookiesToNativeChrome).not.toHaveBeenCalled();
   });

--- a/src/browser/runtime/local-cloak/session-manager.ts
+++ b/src/browser/runtime/local-cloak/session-manager.ts
@@ -25,6 +25,7 @@ const UNRESOLVED = Symbol('unresolved');
 const TARGET_PAGE_MATCH_TIMEOUT_MS = 1_000;
 export const PROFILE_IDLE_TIMEOUT_MS = 60_000;
 export const PROFILE_CLOSE_TIMEOUT_MS = 3_000;
+export const CHROME_SYNC_EXPORT_DEBOUNCE_MS = 3_000;
 let cachedCloakBrowserVersion: string | undefined | typeof UNRESOLVED = UNRESOLVED;
 
 /**
@@ -220,6 +221,7 @@ export class CloakSessionManager {
   private readonly exportCookiesToNativeChrome: typeof defaultExportCookies;
   private readonly registerNativeChromeProfile: typeof defaultRegisterNativeChromeProfile;
   private readonly syncExportsInFlight = new Set<string>();
+  private readonly chromeSyncExportTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly profiles = new Map<string, ProfileRuntime>();
   private readonly profileLaunches = new Map<string, Promise<ProfileRuntime>>();
   private readonly profileLifecycleQueues = new Map<string, Promise<void>>();
@@ -278,6 +280,7 @@ export class CloakSessionManager {
       if (runtime) {
         runtime.activeCommands = count;
         this.cancelProfileIdle(runtime);
+        this.cancelChromeSyncExport(profileId);
       }
     });
     try {
@@ -291,6 +294,7 @@ export class CloakSessionManager {
         if (runtime) {
           runtime.activeCommands = count;
           this.scheduleProfileIdle(profileId, runtime);
+          this.scheduleChromeSyncExport(profileId, runtime);
         }
       });
     }
@@ -718,6 +722,8 @@ export class CloakSessionManager {
 
   async shutdown(): Promise<void> {
     this.shuttingDown = true;
+    for (const timer of this.chromeSyncExportTimers.values()) clearTimeout(timer);
+    this.chromeSyncExportTimers.clear();
     while (this.profileLaunches.size > 0) {
       await Promise.allSettled([...this.profileLaunches.values()]);
     }
@@ -837,6 +843,7 @@ export class CloakSessionManager {
     if (runtime.disposed) return;
     runtime.disposed = true;
     this.cancelProfileIdle(runtime);
+    this.cancelChromeSyncExport(runtime.profileId);
     for (const entry of runtime.targetPages.values()) {
       if (entry.idleTimer) clearTimeout(entry.idleTimer);
       this.networkCapture.stop(entry.page);
@@ -964,6 +971,25 @@ export class CloakSessionManager {
       if (timeout) clearTimeout(timeout);
       this.cleanupRuntime(runtime);
       this.scheduleChromeExport(runtime.profileId, runtime);
+    }
+  }
+
+  private scheduleChromeSyncExport(profileId: string, runtime: ProfileRuntime): void {
+    if (this.opts.runtimeKind !== 'chrome' || this.opts.syncToChrome !== true) return;
+    this.cancelChromeSyncExport(profileId);
+    const timer = setTimeout(() => {
+      this.chromeSyncExportTimers.delete(profileId);
+      this.scheduleChromeExport(profileId, runtime);
+    }, CHROME_SYNC_EXPORT_DEBOUNCE_MS);
+    timer.unref?.();
+    this.chromeSyncExportTimers.set(profileId, timer);
+  }
+
+  private cancelChromeSyncExport(profileId: string): void {
+    const timer = this.chromeSyncExportTimers.get(profileId);
+    if (timer) {
+      clearTimeout(timer);
+      this.chromeSyncExportTimers.delete(profileId);
     }
   }
 


### PR DESCRIPTION
## Summary
Two follow-up fixes found while manually testing the just-shipped v0.8.3 Chrome-profile-export feature:

**1. Export was gated on the browser being fully idle-closed, which in practice almost never happens**
- `scheduleProfileIdle`'s idle timer never even gets set while any tab from the profile is still open (`hasVisiblePages` guard) — and `browser run` doesn't close its own resulting tab. Confirmed live: a profile sat "connected" for 4+ minutes with a tab open and only exported once its session was explicitly closed, which nobody would know to do.
- Fix: export is decoupled from closing the browser entirely. A new, independent per-profile debounce timer (3s, reset on every command, *not* gated on open tabs) triggers the export — copy cookies, register if new — without touching the browser or any open page. The existing close-triggered export remains as a harmless, idempotent backstop.

**2. Exported profiles show up in Chrome as "Person 2", "Person 3", etc. instead of their real webcmd alias**
- Chrome auto-registers a newly exported profile-directory but assigns it a generic name, since nothing goes through Chrome's own profile-creation UI.
- Fix: after the invisible registration-trigger process has actually exited (waiting briefly post-signal, to avoid Chrome's own shutdown flush clobbering our edit), write the profile's `Local State` display name to match the webcmd alias exactly (e.g. `test1` shows as `test1`). Best-effort and silent on failure — purely cosmetic, never blocks the export. Documented limitation: if native Chrome was already running (registration got absorbed into the existing process rather than spawning a separate one), there's nothing safe to wait on, and the name write may later get overwritten by Chrome's own state flush.

## Test plan
- [x] Full suite: 206 test files, typecheck clean (confirmed under reduced worker concurrency — full-parallelism hits the same pre-existing `runner.test.ts` browser-context flakiness under high system load documented in prior PRs; all three files this PR touches pass 106/106 in isolation)
- [x] New tests cover: export firing ~3s after a command with the tab still open, a burst of rapid commands collapsing into one export, the debounced export never closing the browser/page, no debounce for non-sync-to-chrome profiles, display name being set after a spawned registration process is confirmed killed, the best-effort case when Chrome was already running, and display name never being set when registration times out

🤖 Generated with [Claude Code](https://claude.com/claude-code)