### PR TITLE
fix(cli): name the removed `setup` flags instead of a generic unknown-flag error

### DIFF
--- a/src/hosted/setup.test.ts
+++ b/src/hosted/setup.test.ts
@@ -578,6 +578,28 @@ describe('webcmd setup', () => {
     expect(messages.join('')).toContain('--chrome-profile, --import-chrome-cookies, and --sync-to-chrome are only valid with --browser chrome');
   });
 
+  it.each([
+    ['--mode local', ['--mode', 'local', '--browser', 'cloak'], '--mode'],
+    ['--mode=local', ['--mode=local'], '--mode'],
+    ['--api-key', ['--api-key', 'sk-test'], '--api-key'],
+  ])('names the removed %s flag instead of listing every valid flag', async (_label, argv, flag) => {
+    tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-removed-flag-'));
+    const messages: string[] = [];
+
+    await expect(runHostedSetup({
+      env: { WEBCMD_CONFIG_DIR: tempDir },
+      argv,
+      isTTY: false,
+      fetchDaemonStatus: async () => null,
+      write: message => { messages.push(message); },
+      stderr: new Writable({ write: (chunk, _enc, cb) => { messages.push(chunk.toString()); cb(); } }),
+    })).resolves.not.toBe(0);
+
+    const output = messages.join('');
+    expect(output).toContain(`\`setup\` no longer accepts ${flag}`);
+    expect(output).not.toContain(`unknown flag ${flag}`);
+  });
+
   it('reuses an existing SLAB app without downloading it again', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'webcmd-setup-slab-reuse-'));
     const events: string[] = [];

--- a/src/hosted/setup.ts
+++ b/src/hosted/setup.ts
@@ -79,6 +79,22 @@ const SETUP_HELP = [
   '',
 ].join('\n');
 
+/**
+ * Flags `setup` used to accept before it stopped configuring hosted mode. They
+ * still appear in older docs and in muscle memory, so name them instead of
+ * letting them fall through to the generic unknown-flag list.
+ */
+const REMOVED_SETUP_FLAGS: readonly { name: string; remediation: string }[] = [
+  {
+    name: '--mode',
+    remediation: `setup always configures local mode, so drop the flag and pick a browser with \`${CLI_COMMAND} setup --browser <cloak|chrome|slab|absolute-path>\``,
+  },
+  {
+    name: '--api-key',
+    remediation: 'setup no longer stores a Webcmd Cloud API key',
+  },
+];
+
 export async function runHostedSetup(io: SetupIo = {}): Promise<number> {
   const write = io.write
     ? async (message: string) => { await io.write!(message); }
@@ -398,6 +414,15 @@ function parseSetupArgs(argv: readonly string[]): {
       const value = token.startsWith('--browser=') ? token.slice('--browser='.length) : argv[++i];
       browser = parseLocalBrowser(value);
       continue;
+    }
+    const removed = REMOVED_SETUP_FLAGS.find(
+      flag => token === flag.name || token.startsWith(`${flag.name}=`),
+    );
+    if (removed) {
+      throw new ArgumentError(
+        `\`setup\` no longer accepts ${removed.name}; ${removed.remediation}.`,
+        `${SETUP_USAGE}\n${SETUP_EXAMPLE}`,
+      );
     }
 
     throw new ArgumentError(


### PR DESCRIPTION
## Problem

#493 removed `--mode` and `--api-key` from `webcmd setup`. Both now fall through to the generic unknown-flag branch:

```
$ webcmd setup --mode local --browser cloak
ok: false
error:
  code: ARGUMENT
  message: unknown flag --mode for `setup`
  help: >-
    valid flags for `setup`: --browser, --chrome-profile, --import-chrome-cookies,
    --no-import-chrome-cookies, --sync-to-chrome, --status, --help
  exitCode: 2
```

That message can't tell the user whether they mistyped something or the flag is gone, and it doesn't point at `--browser`, which is what replaced `--mode local`. `webcmd setup --mode local --browser ...` was the documented form until recently, so it is still in older docs, in blog posts, and in muscle memory.

## Change

`parseSetupArgs` now names removed flags before the generic branch:

```
$ webcmd setup --mode local --browser cloak
ok: false
error:
  code: ARGUMENT
  message: >-
    `setup` no longer accepts --mode; setup always configures local mode, so drop the
    flag and pick a browser with `webcmd setup --browser <cloak|chrome|slab|absolute-path>`.
  exitCode: 2

$ webcmd setup --api-key sk-...
  message: '`setup` no longer accepts --api-key; setup no longer stores a Webcmd Cloud API key.'
```

Handles the `--flag value` and `--flag=value` spellings. Genuinely unknown flags (`--bogus`) keep the existing "unknown flag" message and valid-flag list, and `SETUP_HELP` is unchanged — removed flags are named on use, not advertised.

## Tests

Added a parameterized case in `src/hosted/setup.test.ts` covering `--mode local`, `--mode=local`, and `--api-key`, asserting each is named and no longer reaches the unknown-flag branch.

`src/hosted/setup.test.ts`: 49/49 pass. `tsc --noEmit`: clean.

## Notes

I originally had docs changes alongside this — the `setup --mode local --browser ...` occurrences in `cli-reference.mdx` / `troubleshooting.mdx`. Those are already fixed on `main`, so this PR is the CLI-side half only.
